### PR TITLE
feat : desktop 클라이언트로 일정 등록 및 뷰로 확인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+/Users/myeongsung/Documents/pickd/src/main/resources/client.json
+/Users/myeongsung/Documents/pickd/src/main/resources/desktop.json
+/tokens

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	implementation("com.google.api-client:google-api-client:2.8.0")
 	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
 	implementation 'com.google.apis:google-api-services-calendar:v3-rev20250404-2.0.0'
+	// Thymeleaf Starter
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation("com.google.api-client:google-api-client:2.8.0")
+	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
+	implementation 'com.google.apis:google-api-services-calendar:v3-rev20250404-2.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/back/pickd/PickdApplication.java
+++ b/src/main/java/back/pickd/PickdApplication.java
@@ -1,7 +1,10 @@
 package back.pickd;
 
+import back.pickd.googleCalender.GoogleCalendarService;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class PickdApplication {
@@ -10,4 +13,15 @@ public class PickdApplication {
 		SpringApplication.run(PickdApplication.class, args);
 	}
 
+	@Bean
+	public CommandLineRunner testCalendar(GoogleCalendarService calendarService) {
+		return args -> {
+			try {
+				calendarService.testInsertEvent();
+			} catch (Exception e) {
+				System.err.println("❌ 테스트 실패: " + e.getMessage());
+				e.printStackTrace();
+			}
+		};
+	}
 }

--- a/src/main/java/back/pickd/config/GoogleCalenderConfig.java
+++ b/src/main/java/back/pickd/config/GoogleCalenderConfig.java
@@ -1,0 +1,78 @@
+package back.pickd.config;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.api.services.calendar.CalendarScopes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.google.api.services.calendar.Calendar;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+
+@Configuration
+public class GoogleCalenderConfig {
+    private static final String APPLICATION_NAME = "desktop";
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
+    private static final String TOKENS_DIR = "tokens";
+    private static final List<String> SCOPES = Collections.singletonList(CalendarScopes.CALENDAR);
+    private static final String CREDENTIALS_PATH = "/desktop.json";
+
+    @Bean
+    public Calendar calendarClient() throws Exception {
+        // 1) HTTP transport 생성
+        final NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+
+        // 2) 자격 증명 파일(desktop.json) 로드 및 null 체크
+        // try-with-resources를 사용하여 사용 후 스트림을 자동으로 닫습니다.
+        try (InputStream in = getClass().getResourceAsStream(CREDENTIALS_PATH)) {
+
+            if (in == null) {
+                // 파일 경로가 잘못되었거나 빌드 폴더에 파일이 없을 때 발생합니다.
+                throw new FileNotFoundException("설정된 경로에서 파일을 찾을 수 없습니다: " + CREDENTIALS_PATH
+                        + "\n[팁] src/main/resources 폴더에 파일이 있는지 확인하세요.");
+            }
+
+            GoogleClientSecrets clientSecrets;
+            try {
+                clientSecrets = GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
+            } catch (Exception e) {
+                // JSON 파일 내용이 구글 자격증명 형식과 맞지 않을 때 발생합니다.
+                throw new RuntimeException("JSON 파싱 실패! 'desktop.json' 파일의 형식이 '데스크톱 앱'용인지 확인하세요.", e);
+            }
+
+            // 3) OAuth 흐름 구성
+            GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
+                    httpTransport, JSON_FACTORY, clientSecrets, SCOPES)
+                    .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIR)))
+                    .setAccessType("offline")
+                    .build();
+
+            // 4) 로컬 서버로 인증 코드 수신 (데스크톱 앱 방식)
+            LocalServerReceiver receiver = new LocalServerReceiver.Builder()
+                    .setPort(8888)
+                    .build();
+
+            // 5) 사용자 인증 및 Credential 생성
+            // 인증을 성공하면 지정된 TOKENS_DIR에 토큰이 저장됩니다.
+            Credential credential = new AuthorizationCodeInstalledApp(flow, receiver)
+                    .authorize("user");
+
+            // 6) Calendar 클라이언트 빌드
+            return new Calendar.Builder(httpTransport, JSON_FACTORY, credential)
+                    .setApplicationName(APPLICATION_NAME)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/back/pickd/googleCalender/CalendarViewController.java
+++ b/src/main/java/back/pickd/googleCalender/CalendarViewController.java
@@ -1,0 +1,59 @@
+package back.pickd.googleCalender;
+
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.Events;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.io.IOException;
+
+@Controller
+public class CalendarViewController {
+
+    private final Calendar calendar;
+
+    public CalendarViewController(Calendar calendar) {
+        this.calendar = calendar;
+    }
+
+    @GetMapping("/my-calendar")
+    public String viewCalendar(Model model) throws IOException {
+        // 1. 한국 시간대 및 기준 시간 설정
+        java.util.TimeZone tz = java.util.TimeZone.getTimeZone("Asia/Seoul");
+        java.util.Calendar cal = java.util.Calendar.getInstance(tz);
+
+        // 현재 시간을 저장해둡니다.
+        long nowMillis = cal.getTimeInMillis();
+
+        // 2. 시작 시간 설정 (오늘로부터 14일 전, 00:00:00)
+        cal.add(java.util.Calendar.DAY_OF_YEAR, -14);
+        cal.set(java.util.Calendar.HOUR_OF_DAY, 0);
+        cal.set(java.util.Calendar.MINUTE, 0);
+        cal.set(java.util.Calendar.SECOND, 0);
+        DateTime timeMin = new DateTime(cal.getTime());
+
+        // 3. 종료 시간 설정 (시작 시간으로부터 28일 뒤 = 오늘로부터 14일 뒤, 23:59:59)
+        cal.add(java.util.Calendar.DAY_OF_YEAR, 28);
+        cal.set(java.util.Calendar.HOUR_OF_DAY, 23);
+        cal.set(java.util.Calendar.MINUTE, 59);
+        cal.set(java.util.Calendar.SECOND, 59);
+        DateTime timeMax = new DateTime(cal.getTime());
+
+        // 디버깅 로그
+        System.out.println("조회 범위: " + timeMin + " ~ " + timeMax);
+
+        // 4. API 호출
+        Events events = calendar.events().list("primary")
+                .setTimeMin(timeMin)
+                .setTimeMax(timeMax)
+                .setSingleEvents(true)
+                .setOrderBy("startTime")
+                .setMaxResults(250) // 일정이 많을 경우를 대비해 넉넉히 설정
+                .execute();
+
+        model.addAttribute("events", events.getItems());
+        return "calendar";
+    }
+}

--- a/src/main/java/back/pickd/googleCalender/GoogleCalendarService.java
+++ b/src/main/java/back/pickd/googleCalender/GoogleCalendarService.java
@@ -1,0 +1,48 @@
+package back.pickd.googleCalender;
+
+import com.google.api.client.util.DateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.EventDateTime;
+
+import java.io.IOException;
+
+@Service
+@Transactional(readOnly =true)
+@RequiredArgsConstructor
+public class GoogleCalendarService {
+
+    private final Calendar calendar;
+
+    public void testInsertEvent() throws IOException {
+        // 1. 이벤트 객체 생성
+        Event event = new Event()
+                .setSummary("Spring Boot Google API Test")
+                .setLocation("My Room")
+                .setDescription("구글 캘린더 API 연동 테스트 중입니다.");
+
+        // 2. 시작 시간 설정 (현재 시간)
+        DateTime startDateTime = new DateTime(System.currentTimeMillis());
+        EventDateTime start = new EventDateTime()
+                .setDateTime(startDateTime)
+                .setTimeZone("Asia/Seoul");
+        event.setStart(start);
+
+        // 3. 종료 시간 설정 (1시간 뒤)
+        DateTime endDateTime = new DateTime(System.currentTimeMillis() + 3600000);
+        EventDateTime end = new EventDateTime()
+                .setDateTime(endDateTime)
+                .setTimeZone("Asia/Seoul");
+        event.setEnd(end);
+
+        // 4. 캘린더에 삽입 ("primary"는 내 기본 캘린더)
+        event = calendar.events().insert("primary", event).execute();
+
+        System.out.println("✅ 일정 등록 성공!");
+        System.out.println("🔗 일정 링크: " + event.getHtmlLink());
+    }
+}
+

--- a/src/main/java/back/pickd/googleCalender/GoogleCalenderConfig.java
+++ b/src/main/java/back/pickd/googleCalender/GoogleCalenderConfig.java
@@ -1,4 +1,4 @@
-package back.pickd.config;
+package back.pickd.googleCalender;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;

--- a/src/main/resources/templates/calendar.html
+++ b/src/main/resources/templates/calendar.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>구글 캘린더뷰</title>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        #calendar { max-width: 900px; margin: 40px auto; }
+    </style>
+</head>
+<body class="container">
+<div class="mt-5">
+    <h2 class="text-center mb-4">📅 내 일정 달력</h2>
+    <div id="calendar"></div>
+</div>
+
+<script th:inline="javascript">
+    document.addEventListener('DOMContentLoaded', function() {
+        const calendarEl = document.getElementById('calendar');
+
+        // 타임리프 데이터를 JS 리스트로 변환
+        const rawEvents = /*[[${events}]]*/ [];
+        const calendarEvents = rawEvents.map(e => ({
+            title: e.summary,
+            start: e.start.dateTime ? e.start.dateTime.value : e.start.date.value,
+            end: e.end.dateTime ? e.end.dateTime.value : e.end.date.value,
+            description: e.description
+        }));
+
+        const calendar = new FullCalendar.Calendar(calendarEl, {
+            initialView: 'dayGridMonth', // 월별 보기
+            locale: 'ko',
+            headerToolbar: {
+                left: 'prev,next today',
+                center: 'title',
+                right: 'dayGridMonth,timeGridWeek,listWeek'
+            },
+            events: calendarEvents, // 데이터 바인딩
+            eventClick: function(info) {
+                alert('일정: ' + info.event.title + '\n내용: ' + (info.event.extendedProps.description || '없음'));
+            }
+        });
+        calendar.render();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
### 작업 내용 
- [x] GCP 프로젝트 생성 후 클라이언트 등록 
- [x] 구글 캘린더에 일정 등록 및 조회(현재 날짜 기준 +- 2주를 조회)
- [x] 타임리프 뷰로 동작 확인 


### 실행 화면 
| 실제 구글 캘린더 화면 | 서버에서 받아온 데이터로 구성한 뷰 |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/d3fa78c3-2512-44df-bfa8-e7c93d699f20" width="400"> | <img src="https://github.com/user-attachments/assets/de568675-7d37-4abd-92ac-24138f9e06e4" width="400"> |

### 테스트 하는 법 
<img width="266" height="240" alt="image" src="https://github.com/user-attachments/assets/263ee7ea-4557-4f62-9771-036ba0eb2405" />   

> tokens 디렉토리에 StoredCredential 발급 받기 , 서버 실행하면 GoogleCalendarConfig에서 알아서 추출해옴
> Desktop 앱으로 등록한 client secret 이름을 desktop.json 이름으로 `src/main/resources에 옮겨두기