### PR TITLE
feat: 탭2 경험 도메인 엔티티 설계 및 온보딩 코드 수정

### DIFF
--- a/src/main/java/back/pickd/user/entity/ExperienceFile.java
+++ b/src/main/java/back/pickd/user/entity/ExperienceFile.java
@@ -1,0 +1,44 @@
+package back.pickd.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "experience_files")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExperienceFile {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private UserExperience userExperience;
+
+    @Column(name = "original_filename", nullable = false)
+    private String originalFilename;
+
+    @Column(name = "file_type", nullable = false, length = 100)
+    private String fileType;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "file_path", nullable = false, columnDefinition = "TEXT")
+    private String filePath;
+
+    @Column(nullable = false, length = 50)
+    private String source;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.id == null) {
+            this.id = java.util.UUID.randomUUID().toString();
+        }
+    }
+}

--- a/src/main/java/back/pickd/user/entity/ExperienceLink.java
+++ b/src/main/java/back/pickd/user/entity/ExperienceLink.java
@@ -1,0 +1,41 @@
+package back.pickd.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "experience_links")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExperienceLink {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private UserExperience userExperience;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String url;
+
+    @Column(name = "material_type", nullable = false)
+    private String materialType;
+
+    @Column(name = "document_position")
+    private Integer documentPosition;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.id == null) {
+            this.id = java.util.UUID.randomUUID().toString();
+        }
+    }
+}

--- a/src/main/java/back/pickd/user/entity/UserExperience.java
+++ b/src/main/java/back/pickd/user/entity/UserExperience.java
@@ -1,46 +1,109 @@
 package back.pickd.user.entity;
 
+import back.pickd.user.entity.enums.ExperienceGroup;
+import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.entity.enums.Status;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Entity
-@Getter
-@NoArgsConstructor
 @Table(name = "user_experiences")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class UserExperience {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(length = 36)
+    private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
-    @Column(nullable = false)
-    private String type; // INTERN, PROJECT, ACTIVITY, AWARD
 
     @Column(nullable = false)
     private String title;
 
-    @Column
-    private String description;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_type", nullable = false, length = 50)
+    private ExperienceType experienceType;
 
-    @Column
-    private String startDate; // YYYY-MM
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_group", nullable = false, length = 20)
+    private ExperienceGroup experienceGroup;
 
-    @Column
-    private String endDate; // YYYY-MM or "진행중"
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
 
-    @Builder
-    public UserExperience(User user, String type, String title, String description, String startDate, String endDate) {
-        this.user = user;
-        this.type = type;
-        this.title = title;
-        this.description = description;
-        this.startDate = startDate;
-        this.endDate = endDate;
+    @Column(name = "document_content", columnDefinition = "TEXT")
+    private String documentContent;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "attributes", nullable = false)
+    @Builder.Default
+    private Map<String, Object> attributes = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "keywords", nullable = false)
+    @Builder.Default
+    private List<String> keywords = new ArrayList<>();
+
+    @OneToMany(mappedBy = "userExperience", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ExperienceLink> links = new ArrayList<>();
+
+    @OneToMany(mappedBy = "userExperience", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ExperienceFile> files = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.id == null) {
+            this.id = java.util.UUID.randomUUID().toString();
+        }
+        this.createdAt = OffsetDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public void updateLinks(List<ExperienceLink> newLinks) {
+        this.links.clear();
+        if (newLinks != null) {
+            newLinks.forEach(link -> {
+                link.setUserExperience(this);
+                this.links.add(link);
+            });
+        }
+    }
+
+    public void updateFiles(List<ExperienceFile> newFiles) {
+        this.files.clear();
+        if (newFiles != null) {
+            newFiles.forEach(file -> {
+                file.setUserExperience(this);
+                this.files.add(file);
+            });
+        }
     }
 }

--- a/src/main/java/back/pickd/user/entity/enums/ExperienceGroup.java
+++ b/src/main/java/back/pickd/user/entity/enums/ExperienceGroup.java
@@ -1,0 +1,5 @@
+package back.pickd.user.entity.enums;
+
+public enum ExperienceGroup {
+    NARRATIVE, SPEC;
+}

--- a/src/main/java/back/pickd/user/entity/enums/ExperienceType.java
+++ b/src/main/java/back/pickd/user/entity/enums/ExperienceType.java
@@ -1,0 +1,34 @@
+package back.pickd.user.entity.enums;
+
+public enum ExperienceType {
+    PROJECT("프로젝트"),
+    ACTIVITY("대외활동"),
+    INTERN("인턴/직무경험"),
+    CONTEST("공모전"),
+    VOLUNTEER("봉사활동"),
+    EXCHANGE("교환학생"),
+    LANGUAGE("어학"),
+    LICENSE("자격증"),
+    AWARD("수상"),
+    COURSE("수강과목"),
+    EDUCATION("교육 이수");
+
+    private final String koreanName;
+
+    ExperienceType(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+
+    public static ExperienceType fromKoreanName(String koreanName) {
+        for (ExperienceType type : values()) {
+            if (type.getKoreanName().equals(koreanName)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("지원하지 않는 경험 유형입니다: " + koreanName);
+    }
+}

--- a/src/main/java/back/pickd/user/entity/enums/Status.java
+++ b/src/main/java/back/pickd/user/entity/enums/Status.java
@@ -1,0 +1,5 @@
+package back.pickd.user.entity.enums;
+
+public enum Status {
+    IN_PROGRESS, COMPLETED;
+}

--- a/src/main/java/back/pickd/user/repository/UserExperienceRepository.java
+++ b/src/main/java/back/pickd/user/repository/UserExperienceRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserExperienceRepository extends JpaRepository<UserExperience, Long> {
+public interface UserExperienceRepository extends JpaRepository<UserExperience, String> {
     @Modifying
     @Query("delete from UserExperience e where e.user = :user")
     void deleteByUser(User user);

--- a/src/main/java/back/pickd/user/service/OnboardingService.java
+++ b/src/main/java/back/pickd/user/service/OnboardingService.java
@@ -2,7 +2,9 @@ package back.pickd.user.service;
 
 import back.pickd.user.dto.onboarding.OnboardingRequest;
 import back.pickd.user.entity.*;
-import back.pickd.user.entity.enums.OnboardingStep;
+import back.pickd.user.entity.enums.*;
+import java.util.HashMap;
+import java.util.Map;
 import back.pickd.user.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -81,15 +83,52 @@ public class OnboardingService {
     private void updateListInfos(User user, OnboardingRequest dto) {
         if (dto.getExperiences() != null) {
             experienceRepository.deleteByUser(user);
-            dto.getExperiences().forEach(e -> experienceRepository.save(
-                UserExperience.builder()
-                    .user(user)
-                    .type(e.getType())
-                    .title(e.getTitle())
-                    .startDate(e.getStartDate())
-                    .endDate(e.getEndDate())
-                    .build()
-            ));
+            dto.getExperiences().forEach(e -> {
+                ExperienceType expType = ExperienceType.PROJECT;
+                ExperienceGroup expGroup = ExperienceGroup.NARRATIVE;
+                
+                String rawType = e.getType();
+                if ("AWARD".equals(rawType)) {
+                    expType = ExperienceType.AWARD;
+                    expGroup = ExperienceGroup.SPEC;
+                } else if ("INTERN".equals(rawType)) {
+                    expType = ExperienceType.INTERN;
+                    expGroup = ExperienceGroup.NARRATIVE;
+                } else if ("ACTIVITY".equals(rawType)) {
+                    expType = ExperienceType.ACTIVITY;
+                    expGroup = ExperienceGroup.NARRATIVE;
+                } else if ("PROJECT".equals(rawType)) {
+                    expType = ExperienceType.PROJECT;
+                    expGroup = ExperienceGroup.NARRATIVE;
+                }
+
+                Map<String, Object> attributes = new HashMap<>();
+                String periodVal = (e.getStartDate() != null ? e.getStartDate() : "") 
+                        + " ~ " 
+                        + (e.getEndDate() != null ? e.getEndDate() : "");
+                
+                if (expType == ExperienceType.AWARD) {
+                    attributes.put("수상일", e.getEndDate());
+                } else if (expType == ExperienceType.INTERN) {
+                    attributes.put("근무/참여 기간", periodVal);
+                } else if (expType == ExperienceType.ACTIVITY) {
+                    attributes.put("활동 기간", periodVal);
+                } else {
+                    attributes.put("진행 기간", periodVal);
+                }
+
+                experienceRepository.save(
+                    UserExperience.builder()
+                        .user(user)
+                        .title(e.getTitle())
+                        .experienceType(expType)
+                        .experienceGroup(expGroup)
+                        .status(Status.COMPLETED)
+                        .attributes(attributes)
+                        .documentContent("")
+                        .build()
+                );
+            });
         }
         if (dto.getCertifications() != null) {
             certificationRepository.deleteByUser(user);

--- a/src/main/java/back/pickd/user/utils/PresetRegistry.java
+++ b/src/main/java/back/pickd/user/utils/PresetRegistry.java
@@ -1,0 +1,49 @@
+package back.pickd.user.utils;
+
+import back.pickd.user.entity.enums.ExperienceType;
+import org.springframework.stereotype.Component;
+import java.util.*;
+
+@Component
+public class PresetRegistry {
+
+    private static final Map<ExperienceType, List<String>> PRESET_MAP = new EnumMap<>(ExperienceType.class);
+
+    static {
+        // 상세 서술형 (Narrative) 프리셋 필드 정의
+        PRESET_MAP.put(ExperienceType.PROJECT, List.of("프로젝트명", "진행 기간", "역할", "소속/팀", "주요 성과"));
+        PRESET_MAP.put(ExperienceType.ACTIVITY, List.of("활동명", "주관기관", "활동 기간", "역할", "주요 성과"));
+        PRESET_MAP.put(ExperienceType.INTERN, List.of("회사/기관명", "직무/부서", "근무/참여 기간", "담당 업무", "주요 성과"));
+        PRESET_MAP.put(ExperienceType.CONTEST, List.of("공모전명", "주관기관", "참가 기간", "역할", "수상/결과"));
+        PRESET_MAP.put(ExperienceType.VOLUNTEER, List.of("활동명", "기관/단체", "활동 기간", "역할"));
+        PRESET_MAP.put(ExperienceType.EXCHANGE, List.of("국가/도시", "학교명", "파견 기간", "전공/수강 분야"));
+
+        // 스펙·증빙 (Spec) 프리셋 필드 정의
+        PRESET_MAP.put(ExperienceType.LANGUAGE, List.of("시험명", "점수/등급", "응시일", "유효기간", "성적표"));
+        PRESET_MAP.put(ExperienceType.LICENSE, List.of("자격증명", "발급기관", "취득일", "유효기간", "자격증 사본"));
+        PRESET_MAP.put(ExperienceType.AWARD, List.of("수상명", "수여기관", "수상일", "수상 구분", "수상 증빙"));
+        PRESET_MAP.put(ExperienceType.COURSE, List.of("과목명", "이수 학기", "학점", "성적", "관련 분야"));
+        PRESET_MAP.put(ExperienceType.EDUCATION, List.of("교육명", "운영기관", "교육 기간", "수료 여부", "수료증"));
+    }
+
+    public List<String> getPresetKeys(ExperienceType type) {
+        return PRESET_MAP.getOrDefault(type, Collections.emptyList());
+    }
+
+    /**
+     * AI가 자의적으로 바꾼 필드명(예: '역할분담', '배정부서')을 백엔드의 표준 키명으로 매핑해주는 보정 유틸리티
+     */
+    public String normalizeKey(ExperienceType type, String rawKey) {
+        if (rawKey == null) return null;
+        String cleanKey = rawKey.replace(" ", "").trim();
+        List<String> standardKeys = getPresetKeys(type);
+
+        for (String stdKey : standardKeys) {
+            String cleanStd = stdKey.replace(" ", "");
+            if (cleanStd.contains(cleanKey) || cleanKey.contains(cleanStd)) {
+                return stdKey; // 일치하는 표준 프리셋 필드가 감지되면 해당 표준 필드명 리턴
+            }
+        }
+        return rawKey; // 완전 새로운 커스텀 필드라면 그대로 유지시킴
+    }
+}


### PR DESCRIPTION
# 변경점 👍
 유저가 상세 팝업창을 열었을 때 인턴, 공모전, 자격증 등 유형별 프리셋에 맞추어 다양한 스펙 필드가 동적으로 노출되고 저장되도록, 자소서 분석을 통해 분석한 2차 상세 스펙들을 담을 엔티티 설계 (아래 그림 참고)


# 스크린샷 🖼
 
<img width="1271" height="828" alt="image" src="https://github.com/user-attachments/assets/faa6cc48-8ad7-479f-af4b-388d8b364209" />
<img width="1263" height="839" alt="image" src="https://github.com/user-attachments/assets/93ba8817-a179-4481-a3ae-1f97a858b799" />

