### PR TITLE
Back/feat/16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	implementation 'com.google.apis:google-api-services-drive:v3-rev20230822-2.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/back/pickd/auth/config/SecurityConfig.java
+++ b/src/main/java/back/pickd/auth/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
             )
 
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/login", "/error", "/css/**", "/js/**", "/h2-console/**", "/favicon.ico", "/onboarding-test.html").permitAll()
+                .requestMatchers("/", "/login", "/error", "/css/**", "/js/**", "/h2-console/**", "/favicon.ico", "/onboarding-test.html", "/api/experiences/extract/temp-token").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/back/pickd/global/infra/ai/AiClient.java
+++ b/src/main/java/back/pickd/global/infra/ai/AiClient.java
@@ -1,0 +1,98 @@
+package back.pickd.global.infra.ai;
+
+import back.pickd.global.infra.ai.dto.AiStep1Response;
+import back.pickd.global.infra.ai.dto.AiStep2Response;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class AiClient {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public AiClient(@Value("${ai-server.url:http://localhost:8000}") String aiServerUrl, ObjectMapper objectMapper) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(5000);
+        requestFactory.setReadTimeout(180000); // 180초 타임아웃 설정
+
+        this.restClient = RestClient.builder()
+                .baseUrl(aiServerUrl)
+                .requestFactory(requestFactory)
+                .build();
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * AI 1차 경험 추출 (step1)
+     */
+    public AiStep1Response extractStep1(MultipartFile file) {
+        MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder.part("file", file.getResource());
+
+        return restClient.post()
+                .uri("/api/v1/extract-experiences/step1")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(bodyBuilder.build())
+                .retrieve()
+                .body(AiStep1Response.class);
+    }
+
+    /**
+     * AI 2차 정밀 경험 추출 (step2)
+     */
+    public AiStep2Response extractStep2(MultipartFile file, List<AiStep1Response.ExperienceSummaryDto> selectedExperiences) {
+        MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder.part("file", file.getResource());
+
+        try {
+            // 선택한 1차 경험 리스트를 JSON String으로 변환하여 폼 전송
+            String jsonList = objectMapper.writeValueAsString(selectedExperiences);
+            bodyBuilder.part("selected_experiences", jsonList);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize selected experiences for AI Step2", e);
+            throw new RuntimeException("AI 분석 요청 중 직렬화 오류가 발생했습니다.", e);
+        }
+
+        return restClient.post()
+                .uri("/api/v1/extract-experiences/step2")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(bodyBuilder.build())
+                .retrieve()
+                .body(AiStep2Response.class);
+    }
+
+    /**
+     * AI 2차 정밀 경험 추출 (step2) - S3 CloudFront URL 기반 호출
+     */
+    public AiStep2Response extractStep2ByUrl(String resumeUrl, List<AiStep1Response.ExperienceSummaryDto> selectedExperiences) {
+        MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder.part("url", resumeUrl);
+
+        try {
+            String jsonList = objectMapper.writeValueAsString(selectedExperiences);
+            bodyBuilder.part("selected_experiences", jsonList);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize selected experiences for AI Step2", e);
+            throw new RuntimeException("AI 분석 요청 중 직렬화 오류가 발생했습니다.", e);
+        }
+
+        return restClient.post()
+                .uri("/api/v1/extract-experiences/step2")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(bodyBuilder.build())
+                .retrieve()
+                .body(AiStep2Response.class);
+    }
+}

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiStep1Response.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiStep1Response.java
@@ -1,0 +1,21 @@
+package back.pickd.global.infra.ai.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class AiStep1Response {
+    private List<ExperienceSummaryDto> experiences;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExperienceSummaryDto {
+        private String experience_name;
+        private String experience_group;
+        private String experience_type;
+    }
+}

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiStep2Response.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiStep2Response.java
@@ -1,0 +1,46 @@
+package back.pickd.global.infra.ai.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class AiStep2Response {
+    private List<Step2ExperienceDto> experiences;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Step2ExperienceDto {
+        private String experience_name;
+        private String experience_group;
+        private String experience_type;
+        private List<String> keywords;
+        private boolean is_important;
+        private String progress_status;
+        private boolean needs_merge;
+        private boolean unanswered;
+        private boolean has_ai_questions;
+        
+        // 11가지 소분류 유형에 따라 유동적인 필드는 Map으로 통째 파싱
+        private Map<String, Object> basic_info;
+        
+        private String experience_content;
+        private List<TaggedSentenceDto> tagged_body_text;
+        private String document_editor_content;
+        private List<String> related_links;
+        private List<String> attachments;
+        private List<String> ai_questions;
+        private List<String> ai_sentence_cards;
+        private String merge_candidate_id;
+        private String writing_status;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class TaggedSentenceDto {
+        private String tag;
+        private String sentence;
+    }
+}

--- a/src/main/java/back/pickd/global/infra/s3/FileController.java
+++ b/src/main/java/back/pickd/global/infra/s3/FileController.java
@@ -1,0 +1,50 @@
+package back.pickd.global.infra.s3;
+
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/files")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final S3Service s3Service;
+    private final UserService userService;
+
+    /**
+     * S3 파일 업로드 API
+     * (이력서, 자격증, 수료증 등을 업로드한 후 CloudFront URL을 반환받습니다)
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<Map<String, String>> uploadFile(
+            Authentication authentication,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("type") FileUploadType type) {
+        
+        if (authentication == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        // 1. 현재 로그인된 사용자 정보 조회
+        User user = userService.findByEmail(authentication.getName());
+        
+        // 2. S3Service를 호출하여 S3에 저장하고 CloudFront CDN URL 획득
+        String fileUrl = s3Service.uploadFile(file, type, user.getId());
+
+        // 3. 응답 맵 구성
+        Map<String, String> response = new HashMap<>();
+        response.put("fileUrl", fileUrl);
+        response.put("fileName", file.getOriginalFilename());
+        response.put("uploadType", type.name());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/back/pickd/global/infra/s3/FileUploadType.java
+++ b/src/main/java/back/pickd/global/infra/s3/FileUploadType.java
@@ -1,0 +1,25 @@
+package back.pickd.global.infra.s3;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileUploadType {
+    LICENSE("experience/license"),
+    EDUCATION("experience/education"),
+    LANGUAGE("experience/language"),
+    AWARD("experience/award"),
+    TEMP_RESUME("temp/resume"),
+    GENERAL("experience/general");
+
+    private final String directoryPath;
+
+    /**
+     * 유저 ID와 고유 파일명을 조합하여 S3 Key(경로)를 생성합니다.
+     * 예: experience/license/{userId}/{uuid}_{filename}
+     */
+    public String getFullPath(Long userId, String uniqueFileName) {
+        return String.format("%s/%d/%s", this.directoryPath, userId, uniqueFileName);
+    }
+}

--- a/src/main/java/back/pickd/global/infra/s3/S3Service.java
+++ b/src/main/java/back/pickd/global/infra/s3/S3Service.java
@@ -1,0 +1,75 @@
+package back.pickd.global.infra.s3;
+
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Template s3Template;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.cloudfront.domain}")
+    private String cloudFrontDomain;
+
+    /**
+     * 파일을 S3에 업로드하고 CloudFront CDN 주소를 반환합니다.
+     *
+     * @param file           업로드할 파일
+     * @param uploadType     파일 분류 타입 (LICENSE, EDUCATION 등)
+     * @param userId         사용자 ID (디렉터리 구분에 사용)
+     * @return CloudFront CDN 파일 주소
+     */
+    public String uploadFile(MultipartFile file, FileUploadType uploadType, Long userId) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 비어있습니다.");
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String extension = getFileExtension(originalFilename);
+        
+        // 파일명 중복 방지를 위한 UUID 파일명 생성
+        String uniqueFileName = UUID.randomUUID() + extension;
+        
+        // 최종 S3 적재 경로 생성
+        String s3Key = uploadType.getFullPath(userId, uniqueFileName);
+
+        try (InputStream inputStream = file.getInputStream()) {
+            s3Template.upload(bucket, s3Key, inputStream);
+            log.info("Successfully uploaded file to S3: bucket={}, key={}", bucket, s3Key);
+        } catch (IOException e) {
+            log.error("Failed to upload file to S3", e);
+            throw new RuntimeException("파일 업로드 중 오류가 발생했습니다.", e);
+        }
+
+        // S3 Direct URL 대신 CloudFront URL을 조합하여 반환
+        return combineCloudFrontUrl(s3Key);
+    }
+
+    private String getFileExtension(String filename) {
+        if (filename == null) {
+            return "";
+        }
+        int lastDotIndex = filename.lastIndexOf(".");
+        return (lastDotIndex == -1) ? "" : filename.substring(lastDotIndex);
+    }
+
+    private String combineCloudFrontUrl(String s3Key) {
+        String domain = cloudFrontDomain.endsWith("/") 
+                ? cloudFrontDomain.substring(0, cloudFrontDomain.length() - 1) 
+                : cloudFrontDomain;
+        return domain + "/" + s3Key;
+    }
+}

--- a/src/main/java/back/pickd/global/infra/s3/S3Service.java
+++ b/src/main/java/back/pickd/global/infra/s3/S3Service.java
@@ -54,6 +54,11 @@ public class S3Service {
             throw new RuntimeException("파일 업로드 중 오류가 발생했습니다.", e);
         }
 
+        // TEMP_RESUME 타입의 경우 AI 서버 접근용으로 60분짜리 Presigned URL 발급
+        if (uploadType == FileUploadType.TEMP_RESUME) {
+            return s3Template.createSignedGetURL(bucket, s3Key, java.time.Duration.ofMinutes(60)).toString();
+        }
+
         // S3 Direct URL 대신 CloudFront URL을 조합하여 반환
         return combineCloudFrontUrl(s3Key);
     }

--- a/src/main/java/back/pickd/user/controller/ExperienceExtractionController.java
+++ b/src/main/java/back/pickd/user/controller/ExperienceExtractionController.java
@@ -1,0 +1,70 @@
+package back.pickd.user.controller;
+
+import back.pickd.user.dto.ExperienceTempResponse;
+import back.pickd.user.dto.UserExperienceResponse;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.ExperienceExtractionService;
+import back.pickd.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/experiences/extract")
+@RequiredArgsConstructor
+public class ExperienceExtractionController {
+
+    private final ExperienceExtractionService extractionService;
+    private final UserService userService;
+    private final back.pickd.auth.jwt.JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 1차 경험 후보 추출 API (자소서 업로드 ➔ 후보 반환)
+     */
+    @PostMapping("/step1")
+    public ResponseEntity<List<ExperienceTempResponse>> extractStep1(
+            Authentication authentication,
+            @RequestParam("file") MultipartFile file) {
+
+        User user = userService.findByEmail(authentication.getName());
+        List<ExperienceTempResponse> result = extractionService.extractStep1(user, file)
+                .stream()
+                .map(ExperienceTempResponse::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 2차 정밀 추출 및 DB 최종 저장 API (선택 확정 ➔ 영구 저장)
+     */
+    @PostMapping("/step2")
+    public ResponseEntity<List<UserExperienceResponse>> extractStep2(
+            Authentication authentication,
+            @RequestBody Map<String, List<Long>> request) {
+
+        User user = userService.findByEmail(authentication.getName());
+        List<Long> selectedTempIds = request.get("selectedTempIds");
+        List<UserExperienceResponse> result = extractionService.extractStep2(user, selectedTempIds)
+                .stream()
+                .map(UserExperienceResponse::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 로컬 테스트용 임시 토큰 발급 API
+     */
+    @GetMapping("/temp-token")
+    public ResponseEntity<Map<String, String>> getTempToken() {
+        userService.saveOrUpdate("test@gmail.com", "테스트유저", "https://example.com/test.jpg");
+        String token = jwtTokenProvider.createToken("test@gmail.com",
+                List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_USER")));
+        return ResponseEntity.ok(Map.of("token", token));
+    }
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceTempResponse.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceTempResponse.java
@@ -1,0 +1,26 @@
+package back.pickd.user.dto;
+
+import back.pickd.user.entity.ExperienceTemp;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ExperienceTempResponse {
+
+    private final Long id;
+    private final Long userId;
+    private final String experienceName;
+    private final String experienceGroup;
+    private final String experienceType;
+    private final LocalDateTime createdAt;
+
+    public ExperienceTempResponse(ExperienceTemp temp) {
+        this.id = temp.getId();
+        this.userId = temp.getUser().getId();
+        this.experienceName = temp.getExperienceName();
+        this.experienceGroup = temp.getExperienceGroup();
+        this.experienceType = temp.getExperienceType();
+        this.createdAt = temp.getCreatedAt();
+    }
+}

--- a/src/main/java/back/pickd/user/dto/UserExperienceResponse.java
+++ b/src/main/java/back/pickd/user/dto/UserExperienceResponse.java
@@ -1,0 +1,79 @@
+package back.pickd.user.dto;
+
+import back.pickd.user.entity.ExperienceFile;
+import back.pickd.user.entity.ExperienceLink;
+import back.pickd.user.entity.UserExperience;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+public class UserExperienceResponse {
+
+    private final String id;
+    private final Long userId;
+    private final String title;
+    private final String experienceType;
+    private final String experienceGroup;
+    private final String status;
+    private final String documentContent;
+    private final Map<String, Object> attributes;
+    private final List<String> keywords;
+    private final List<FileInfo> files;
+    private final List<LinkInfo> links;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+
+    public UserExperienceResponse(UserExperience exp) {
+        this.id = exp.getId();
+        this.userId = exp.getUser().getId();
+        this.title = exp.getTitle();
+        this.experienceType = exp.getExperienceType() != null ? exp.getExperienceType().name() : null;
+        this.experienceGroup = exp.getExperienceGroup() != null ? exp.getExperienceGroup().name() : null;
+        this.status = exp.getStatus() != null ? exp.getStatus().name() : null;
+        this.documentContent = exp.getDocumentContent();
+        this.attributes = exp.getAttributes();
+        this.keywords = exp.getKeywords();
+        this.files = exp.getFiles().stream().map(FileInfo::new).collect(Collectors.toList());
+        this.links = exp.getLinks().stream().map(LinkInfo::new).collect(Collectors.toList());
+        this.createdAt = exp.getCreatedAt();
+        this.updatedAt = exp.getUpdatedAt();
+    }
+
+    @Getter
+    public static class FileInfo {
+        private final String id;
+        private final String originalFilename;
+        private final String fileType;
+        private final Long fileSize;
+        private final String filePath;
+        private final String source;
+
+        public FileInfo(ExperienceFile file) {
+            this.id = file.getId();
+            this.originalFilename = file.getOriginalFilename();
+            this.fileType = file.getFileType();
+            this.fileSize = file.getFileSize();
+            this.filePath = file.getFilePath();
+            this.source = file.getSource();
+        }
+    }
+
+    @Getter
+    public static class LinkInfo {
+        private final String id;
+        private final String title;
+        private final String url;
+        private final String materialType;
+
+        public LinkInfo(ExperienceLink link) {
+            this.id = link.getId();
+            this.title = link.getTitle();
+            this.url = link.getUrl();
+            this.materialType = link.getMaterialType();
+        }
+    }
+}

--- a/src/main/java/back/pickd/user/entity/ExperienceFile.java
+++ b/src/main/java/back/pickd/user/entity/ExperienceFile.java
@@ -1,0 +1,44 @@
+package back.pickd.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "experience_files")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExperienceFile {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private UserExperience userExperience;
+
+    @Column(name = "original_filename", nullable = false)
+    private String originalFilename;
+
+    @Column(name = "file_type", nullable = false, length = 100)
+    private String fileType;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "file_path", nullable = false, columnDefinition = "TEXT")
+    private String filePath;
+
+    @Column(nullable = false, length = 50)
+    private String source;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.id == null) {
+            this.id = java.util.UUID.randomUUID().toString();
+        }
+    }
+}

--- a/src/main/java/back/pickd/user/entity/ExperienceFile.java
+++ b/src/main/java/back/pickd/user/entity/ExperienceFile.java
@@ -16,6 +16,7 @@ public class ExperienceFile {
     @Column(length = 36)
     private String id;
 
+    @com.fasterxml.jackson.annotation.JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "experience_id", nullable = false)
     private UserExperience userExperience;

--- a/src/main/java/back/pickd/user/entity/ExperienceLink.java
+++ b/src/main/java/back/pickd/user/entity/ExperienceLink.java
@@ -1,0 +1,41 @@
+package back.pickd.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "experience_links")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExperienceLink {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private UserExperience userExperience;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String url;
+
+    @Column(name = "material_type", nullable = false)
+    private String materialType;
+
+    @Column(name = "document_position")
+    private Integer documentPosition;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.id == null) {
+            this.id = java.util.UUID.randomUUID().toString();
+        }
+    }
+}

--- a/src/main/java/back/pickd/user/entity/ExperienceLink.java
+++ b/src/main/java/back/pickd/user/entity/ExperienceLink.java
@@ -1,5 +1,6 @@
 package back.pickd.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -16,6 +17,7 @@ public class ExperienceLink {
     @Column(length = 36)
     private String id;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "experience_id", nullable = false)
     private UserExperience userExperience;

--- a/src/main/java/back/pickd/user/entity/ExperienceTemp.java
+++ b/src/main/java/back/pickd/user/entity/ExperienceTemp.java
@@ -1,0 +1,47 @@
+package back.pickd.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "experience_temps")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceTemp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String experienceName;
+
+    @Column(nullable = false)
+    private String experienceGroup; // 예: "상세 서술형", "스펙·증빙형"
+
+    @Column(nullable = false)
+    private String experienceType;  // 예: "프로젝트", "어학", "인턴"
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String resumeUrl; // 1차 업로드 시 S3에 임시 저장된 자소서 원본 CloudFront URL
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ExperienceTemp(User user, String experienceName, String experienceGroup, String experienceType, String resumeUrl) {
+        this.user = user;
+        this.experienceName = experienceName;
+        this.experienceGroup = experienceGroup;
+        this.experienceType = experienceType;
+        this.resumeUrl = resumeUrl;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/back/pickd/user/entity/UserExperience.java
+++ b/src/main/java/back/pickd/user/entity/UserExperience.java
@@ -1,46 +1,109 @@
 package back.pickd.user.entity;
 
+import back.pickd.user.entity.enums.ExperienceGroup;
+import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.entity.enums.Status;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Entity
-@Getter
-@NoArgsConstructor
 @Table(name = "user_experiences")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class UserExperience {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(length = 36)
+    private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
-    @Column(nullable = false)
-    private String type; // INTERN, PROJECT, ACTIVITY, AWARD
 
     @Column(nullable = false)
     private String title;
 
-    @Column
-    private String description;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_type", nullable = false, length = 50)
+    private ExperienceType experienceType;
 
-    @Column
-    private String startDate; // YYYY-MM
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_group", nullable = false, length = 20)
+    private ExperienceGroup experienceGroup;
 
-    @Column
-    private String endDate; // YYYY-MM or "진행중"
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
 
-    @Builder
-    public UserExperience(User user, String type, String title, String description, String startDate, String endDate) {
-        this.user = user;
-        this.type = type;
-        this.title = title;
-        this.description = description;
-        this.startDate = startDate;
-        this.endDate = endDate;
+    @Column(name = "document_content", columnDefinition = "TEXT")
+    private String documentContent;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "attributes", nullable = false)
+    @Builder.Default
+    private Map<String, Object> attributes = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "keywords", nullable = false)
+    @Builder.Default
+    private List<String> keywords = new ArrayList<>();
+
+    @OneToMany(mappedBy = "userExperience", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ExperienceLink> links = new ArrayList<>();
+
+    @OneToMany(mappedBy = "userExperience", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ExperienceFile> files = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.id == null) {
+            this.id = java.util.UUID.randomUUID().toString();
+        }
+        this.createdAt = OffsetDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public void updateLinks(List<ExperienceLink> newLinks) {
+        this.links.clear();
+        if (newLinks != null) {
+            newLinks.forEach(link -> {
+                link.setUserExperience(this);
+                this.links.add(link);
+            });
+        }
+    }
+
+    public void updateFiles(List<ExperienceFile> newFiles) {
+        this.files.clear();
+        if (newFiles != null) {
+            newFiles.forEach(file -> {
+                file.setUserExperience(this);
+                this.files.add(file);
+            });
+        }
     }
 }

--- a/src/main/java/back/pickd/user/entity/enums/ExperienceGroup.java
+++ b/src/main/java/back/pickd/user/entity/enums/ExperienceGroup.java
@@ -1,0 +1,5 @@
+package back.pickd.user.entity.enums;
+
+public enum ExperienceGroup {
+    NARRATIVE, SPEC;
+}

--- a/src/main/java/back/pickd/user/entity/enums/ExperienceType.java
+++ b/src/main/java/back/pickd/user/entity/enums/ExperienceType.java
@@ -1,0 +1,34 @@
+package back.pickd.user.entity.enums;
+
+public enum ExperienceType {
+    PROJECT("프로젝트"),
+    ACTIVITY("대외활동"),
+    INTERN("인턴/직무경험"),
+    CONTEST("공모전"),
+    VOLUNTEER("봉사활동"),
+    EXCHANGE("교환학생"),
+    LANGUAGE("어학"),
+    LICENSE("자격증"),
+    AWARD("수상"),
+    COURSE("수강과목"),
+    EDUCATION("교육 이수");
+
+    private final String koreanName;
+
+    ExperienceType(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+
+    public static ExperienceType fromKoreanName(String koreanName) {
+        for (ExperienceType type : values()) {
+            if (type.getKoreanName().equals(koreanName)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("지원하지 않는 경험 유형입니다: " + koreanName);
+    }
+}

--- a/src/main/java/back/pickd/user/entity/enums/ExperienceType.java
+++ b/src/main/java/back/pickd/user/entity/enums/ExperienceType.java
@@ -11,7 +11,9 @@ public enum ExperienceType {
     LICENSE("자격증"),
     AWARD("수상"),
     COURSE("수강과목"),
-    EDUCATION("교육 이수");
+    EDUCATION("교육 이수"),
+    ALBA("알바"),
+    RESEARCH("학부연구생");
 
     private final String koreanName;
 

--- a/src/main/java/back/pickd/user/entity/enums/Status.java
+++ b/src/main/java/back/pickd/user/entity/enums/Status.java
@@ -1,0 +1,5 @@
+package back.pickd.user.entity.enums;
+
+public enum Status {
+    IN_PROGRESS, COMPLETED;
+}

--- a/src/main/java/back/pickd/user/repository/ExperienceTempRepository.java
+++ b/src/main/java/back/pickd/user/repository/ExperienceTempRepository.java
@@ -1,0 +1,19 @@
+package back.pickd.user.repository;
+
+import back.pickd.user.entity.ExperienceTemp;
+import back.pickd.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ExperienceTempRepository extends JpaRepository<ExperienceTemp, Long> {
+    
+    List<ExperienceTemp> findByUser(User user);
+
+    @Modifying
+    @Query("delete from ExperienceTemp et where et.user = :user")
+    void deleteByUser(@Param("user") User user);
+}

--- a/src/main/java/back/pickd/user/repository/UserExperienceRepository.java
+++ b/src/main/java/back/pickd/user/repository/UserExperienceRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserExperienceRepository extends JpaRepository<UserExperience, Long> {
+public interface UserExperienceRepository extends JpaRepository<UserExperience, String> {
     @Modifying
     @Query("delete from UserExperience e where e.user = :user")
     void deleteByUser(User user);

--- a/src/main/java/back/pickd/user/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/user/service/ExperienceExtractionService.java
@@ -1,0 +1,152 @@
+package back.pickd.user.service;
+
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiStep1Response;
+import back.pickd.global.infra.ai.dto.AiStep2Response;
+import back.pickd.global.infra.s3.FileUploadType;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.entity.*;
+import back.pickd.user.entity.enums.ExperienceGroup;
+import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.entity.enums.Status;
+import back.pickd.user.repository.ExperienceTempRepository;
+import back.pickd.user.repository.UserExperienceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExperienceExtractionService {
+
+    private final AiClient aiClient;
+    private final S3Service s3Service;
+    private final ExperienceTempRepository tempRepository;
+    private final UserExperienceRepository experienceRepository;
+
+    /**
+     * 1차 경험 후보 추출 및 임시 캐싱
+     */
+    @Transactional
+    public List<ExperienceTemp> extractStep1(User user, MultipartFile file) {
+        // 1. 자소서 원본을 S3 temp/resume 디렉터리에 임시 저장 (CloudFront URL 획득)
+        String resumeUrl = s3Service.uploadFile(file, FileUploadType.TEMP_RESUME, user.getId());
+
+        // 2. AI 서버 1차 분석 호출 (FastAPI step1)
+        AiStep1Response aiResponse = aiClient.extractStep1(file);
+
+        // 3. 기존에 쌓여있던 임시 데이터는 초기화
+        tempRepository.deleteByUser(user);
+
+        // 4. 새로운 1차 분석 결과를 임시 테이블에 캐싱
+        List<ExperienceTemp> temps = new ArrayList<>();
+        if (aiResponse.getExperiences() != null) {
+            for (AiStep1Response.ExperienceSummaryDto summary : aiResponse.getExperiences()) {
+                ExperienceTemp temp = ExperienceTemp.builder()
+                        .user(user)
+                        .experienceName(summary.getExperience_name())
+                        .experienceGroup(summary.getExperience_group())
+                        .experienceType(summary.getExperience_type())
+                        .resumeUrl(resumeUrl)
+                        .build();
+                temps.add(tempRepository.save(temp));
+            }
+        }
+
+        return temps;
+    }
+
+    /**
+     * 2차 선택형 정밀 분석 및 UserExperience 최종 영구 저장
+     */
+    @Transactional
+    public List<UserExperience> extractStep2(User user, List<Long> selectedTempIds) {
+        if (selectedTempIds == null || selectedTempIds.isEmpty()) {
+            throw new IllegalArgumentException("선택된 임시 경험 ID가 없습니다.");
+        }
+
+        // 1. 선택한 임시 경험 데이터들을 DB에서 로드
+        List<ExperienceTemp> temps = tempRepository.findAllById(selectedTempIds);
+        if (temps.isEmpty()) {
+            throw new IllegalArgumentException("요청한 임시 경험 데이터를 찾을 수 없습니다.");
+        }
+
+        // 자소서 URL 추출 (모두 같은 파일이므로 첫 번째 아이템에서 획득)
+        String resumeUrl = temps.get(0).getResumeUrl();
+
+        // 2. AI step2 송신용 DTO 리스트 변환 (개행 오류 차단을 위해 객체 생성)
+        List<AiStep1Response.ExperienceSummaryDto> selectedSummaries = temps.stream()
+                .map(t -> new AiStep1Response.ExperienceSummaryDto(
+                        t.getExperienceName(),
+                        t.getExperienceGroup(),
+                        t.getExperienceType()
+                ))
+                .collect(Collectors.toList());
+
+        // 3. AI 2차 분석 호출 (S3 CloudFront URL을 던져 2차 정밀 분석 수행)
+        AiStep2Response aiResponse = aiClient.extractStep2ByUrl(resumeUrl, selectedSummaries);
+
+        // 4. 2차 상세 분석 결과 영구 저장 및 파일 연동
+        List<UserExperience> savedExperiences = new ArrayList<>();
+        if (aiResponse.getExperiences() != null) {
+            for (AiStep2Response.Step2ExperienceDto dto : aiResponse.getExperiences()) {
+                ExperienceGroup group = convertGroup(dto.getExperience_group());
+                ExperienceType type = convertType(dto.getExperience_type());
+
+                // UserExperience 빌드 및 attributes JSONB 통짜 적재
+                UserExperience userExperience = UserExperience.builder()
+                        .user(user)
+                        .title(dto.getExperience_name())
+                        .experienceGroup(group)
+                        .experienceType(type)
+                        .status(Status.COMPLETED)
+                        .documentContent(dto.getExperience_content())
+                        .attributes(dto.getBasic_info() != null ? dto.getBasic_info() : new HashMap<>())
+                        .keywords(dto.getKeywords() != null ? dto.getKeywords() : new ArrayList<>())
+                        .build();
+
+                // 첨부 파일 등록 (자소서 원본 출처 명시)
+                ExperienceFile resumeFile = ExperienceFile.builder()
+                        .userExperience(userExperience)
+                        .originalFilename("자기소개서 원본.pdf")
+                        .fileType("application/pdf")
+                        .fileSize(0L)
+                        .filePath(resumeUrl)
+                        .source("RESUME_ORIGINAL")
+                        .build();
+                userExperience.updateFiles(List.of(resumeFile));
+
+                savedExperiences.add(experienceRepository.save(userExperience));
+            }
+        }
+
+        // 5. 사용 완료된 임시 캐시 데이터 일괄 삭제
+        tempRepository.deleteByUser(user);
+
+        return savedExperiences;
+    }
+
+    private ExperienceGroup convertGroup(String koreanGroup) {
+        if ("상세 서술형".equals(koreanGroup)) {
+            return ExperienceGroup.NARRATIVE;
+        }
+        return ExperienceGroup.SPEC;
+    }
+
+    private ExperienceType convertType(String koreanType) {
+        try {
+            return ExperienceType.fromKoreanName(koreanType);
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown experience type '{}', fallback to PROJECT", koreanType);
+            return ExperienceType.PROJECT;
+        }
+    }
+}

--- a/src/main/java/back/pickd/user/service/OnboardingService.java
+++ b/src/main/java/back/pickd/user/service/OnboardingService.java
@@ -2,7 +2,9 @@ package back.pickd.user.service;
 
 import back.pickd.user.dto.onboarding.OnboardingRequest;
 import back.pickd.user.entity.*;
-import back.pickd.user.entity.enums.OnboardingStep;
+import back.pickd.user.entity.enums.*;
+import java.util.HashMap;
+import java.util.Map;
 import back.pickd.user.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -81,15 +83,52 @@ public class OnboardingService {
     private void updateListInfos(User user, OnboardingRequest dto) {
         if (dto.getExperiences() != null) {
             experienceRepository.deleteByUser(user);
-            dto.getExperiences().forEach(e -> experienceRepository.save(
-                UserExperience.builder()
-                    .user(user)
-                    .type(e.getType())
-                    .title(e.getTitle())
-                    .startDate(e.getStartDate())
-                    .endDate(e.getEndDate())
-                    .build()
-            ));
+            dto.getExperiences().forEach(e -> {
+                ExperienceType expType = ExperienceType.PROJECT;
+                ExperienceGroup expGroup = ExperienceGroup.NARRATIVE;
+                
+                String rawType = e.getType();
+                if ("AWARD".equals(rawType)) {
+                    expType = ExperienceType.AWARD;
+                    expGroup = ExperienceGroup.SPEC;
+                } else if ("INTERN".equals(rawType)) {
+                    expType = ExperienceType.INTERN;
+                    expGroup = ExperienceGroup.NARRATIVE;
+                } else if ("ACTIVITY".equals(rawType)) {
+                    expType = ExperienceType.ACTIVITY;
+                    expGroup = ExperienceGroup.NARRATIVE;
+                } else if ("PROJECT".equals(rawType)) {
+                    expType = ExperienceType.PROJECT;
+                    expGroup = ExperienceGroup.NARRATIVE;
+                }
+
+                Map<String, Object> attributes = new HashMap<>();
+                String periodVal = (e.getStartDate() != null ? e.getStartDate() : "") 
+                        + " ~ " 
+                        + (e.getEndDate() != null ? e.getEndDate() : "");
+                
+                if (expType == ExperienceType.AWARD) {
+                    attributes.put("수상일", e.getEndDate());
+                } else if (expType == ExperienceType.INTERN) {
+                    attributes.put("근무/참여 기간", periodVal);
+                } else if (expType == ExperienceType.ACTIVITY) {
+                    attributes.put("활동 기간", periodVal);
+                } else {
+                    attributes.put("진행 기간", periodVal);
+                }
+
+                experienceRepository.save(
+                    UserExperience.builder()
+                        .user(user)
+                        .title(e.getTitle())
+                        .experienceType(expType)
+                        .experienceGroup(expGroup)
+                        .status(Status.COMPLETED)
+                        .attributes(attributes)
+                        .documentContent("")
+                        .build()
+                );
+            });
         }
         if (dto.getCertifications() != null) {
             certificationRepository.deleteByUser(user);

--- a/src/main/java/back/pickd/user/utils/PresetRegistry.java
+++ b/src/main/java/back/pickd/user/utils/PresetRegistry.java
@@ -1,0 +1,49 @@
+package back.pickd.user.utils;
+
+import back.pickd.user.entity.enums.ExperienceType;
+import org.springframework.stereotype.Component;
+import java.util.*;
+
+@Component
+public class PresetRegistry {
+
+    private static final Map<ExperienceType, List<String>> PRESET_MAP = new EnumMap<>(ExperienceType.class);
+
+    static {
+        // 상세 서술형 (Narrative) 프리셋 필드 정의
+        PRESET_MAP.put(ExperienceType.PROJECT, List.of("프로젝트명", "진행 기간", "역할", "소속/팀", "주요 성과"));
+        PRESET_MAP.put(ExperienceType.ACTIVITY, List.of("활동명", "주관기관", "활동 기간", "역할", "주요 성과"));
+        PRESET_MAP.put(ExperienceType.INTERN, List.of("회사/기관명", "직무/부서", "근무/참여 기간", "담당 업무", "주요 성과"));
+        PRESET_MAP.put(ExperienceType.CONTEST, List.of("공모전명", "주관기관", "참가 기간", "역할", "수상/결과"));
+        PRESET_MAP.put(ExperienceType.VOLUNTEER, List.of("활동명", "기관/단체", "활동 기간", "역할"));
+        PRESET_MAP.put(ExperienceType.EXCHANGE, List.of("국가/도시", "학교명", "파견 기간", "전공/수강 분야"));
+
+        // 스펙·증빙 (Spec) 프리셋 필드 정의
+        PRESET_MAP.put(ExperienceType.LANGUAGE, List.of("시험명", "점수/등급", "응시일", "유효기간", "성적표"));
+        PRESET_MAP.put(ExperienceType.LICENSE, List.of("자격증명", "발급기관", "취득일", "유효기간", "자격증 사본"));
+        PRESET_MAP.put(ExperienceType.AWARD, List.of("수상명", "수여기관", "수상일", "수상 구분", "수상 증빙"));
+        PRESET_MAP.put(ExperienceType.COURSE, List.of("과목명", "이수 학기", "학점", "성적", "관련 분야"));
+        PRESET_MAP.put(ExperienceType.EDUCATION, List.of("교육명", "운영기관", "교육 기간", "수료 여부", "수료증"));
+    }
+
+    public List<String> getPresetKeys(ExperienceType type) {
+        return PRESET_MAP.getOrDefault(type, Collections.emptyList());
+    }
+
+    /**
+     * AI가 자의적으로 바꾼 필드명(예: '역할분담', '배정부서')을 백엔드의 표준 키명으로 매핑해주는 보정 유틸리티
+     */
+    public String normalizeKey(ExperienceType type, String rawKey) {
+        if (rawKey == null) return null;
+        String cleanKey = rawKey.replace(" ", "").trim();
+        List<String> standardKeys = getPresetKeys(type);
+
+        for (String stdKey : standardKeys) {
+            String cleanStd = stdKey.replace(" ", "");
+            if (cleanStd.contains(cleanKey) || cleanKey.contains(cleanStd)) {
+                return stdKey; // 일치하는 표준 프리셋 필드가 감지되면 해당 표준 필드명 리턴
+            }
+        }
+        return rawKey; // 완전 새로운 커스텀 필드라면 그대로 유지시킴
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,17 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
+  # AWS 및 S3 설정
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID:dummy-access-key}
+        secret-key: ${AWS_SECRET_ACCESS_KEY:dummy-secret-key}
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: ${AWS_S3_BUCKET:pickd-file-bucket}
+
 server:
   port: 8080
 
@@ -54,3 +65,13 @@ gemini:
   api:
     key: ${gemini.api.key}
     url: https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent
+
+ai-server:
+  url: http://localhost:8000
+
+# CloudFront CDN 도메인 설정 (유저 다운로드 초고속용)
+aws:
+  cloudfront:
+    domain: ${AWS_CLOUDFRONT_DOMAIN:https://cdn.pickd.co.kr}
+
+


### PR DESCRIPTION
📖 [API 명세서]
──────
### 1️⃣ Step 1: 경험 후보 목록 1차 추출 및 임시 저장
사용자가 자소서 PDF 파일을 업로드하면, AI가 경험 후보 목록을 1차 분류 및 명칭화하여 임시 저장한 뒤 반환합니다.

• HTTP Method & Path: POST /api/experiences/extract/step1 
• Content-Type: multipart/form-data 
• Request Headers:
    • Cookie : accessToken={JWT_TOKEN}  (구글 OAuth 로그인 후 획득한 쿠키)
• Request Parameter:
필드명                                      | 타입                                      |                 필수 여부                  | 설명
---------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------
 file                                        | MultipartFile                              |                    필수                    | 분석할 자소서/이력서 원본 PDF 파일
• Response Body (HTTP 200 OK - JSON Array):
필드명                                                 | 타입                                                 | 설명
 id                                                   | Long                                                 | 임시 경험 고유 ID (Step 2 요청 시 사용)
 userId                                               | Long                                                 | 유저 식별 ID
 experienceName                                       | String                                               | AI가 네이밍한 경험 이름
 experienceGroup                                      | String                                               | 경험 대분류 ( 상세 서술형  또는  스펙·증빙형 )
 experienceType                                       | String                                               | 경험 소분류 (프로젝트, 대외활동, 인턴/직무경험, 수강과목, 자격증 등)
 createdAt                                            | ISO DateTime                                         | 임시 저장된 시간

──────
### 2️⃣ Step 2: 선택형 정밀 분석 및 최종 영구 저장

1차로 임시 저장된 경험 후보 ID 중, 사용자가 최종 저장하기 위해 체크한 항목들의 세부 필드를 AI를 통해 채워서 DB의 JSONB 스키마로 영구 적재합니다.

• HTTP Method & Path: POST /api/experiences/extract/step2 
• Content-Type: application/json 
• Request Headers:
    • Cookie : accessToken={JWT_TOKEN} 
• Request Body:
필드명                                  | 타입                                  |               필수 여부                | 설명
-----------------------------------------|----------------------------------------|----------------------------------------|--------------------------------------------------------
 selectedTempIds                         | List<Long>                             |                  필수                  | Step 1 응답에서 확인한 저장할 대상 임시 경험 ID 리스트

    • Body JSON 예시:
      {
        "selectedTempIds": [1, 4, 6]
      }

• Response Body (HTTP 200 OK - JSON Array):
필드명                                       | 타입                                       | 설명
---------------------------------------------|--------------------------------------------|-----------------------------------------------------------------------------------------
 id                                          | String (UUID)                              | 최종 영구 저장된 경험의 고유 PK
 userId                                      | Long                                       | 유저 식별 ID
 title                                       | String                                     | 최종 경험 이름
 experienceType                              | String                                     | DB 내부 매핑 소분류 Enum (예: ACTIVITY , PROJECT , INTERN  등)
 experienceGroup                             | String                                     | DB 내부 매핑 대분류 Enum ( NARRATIVE  또는  SPEC )
 status                                      | String                                     | 작성 완료 여부 ( COMPLETED  등)
 documentContent                             | String                                     | AI가 자소서에서 복원한 핵심 본문 텍스트
 attributes                                  | JSON/JSONB Map                             | 소분류별 맞춤 세부 필드 (11개 유형별 스키마가 다이나믹하게 적재됨)
 keywords                                    | List<String>                               | AI가 내용에서 추출해 매핑한 주요 핵심 역량 태그 리스트
 files                                       | JSON Array                                 | 출처 연동된 자소서 파일 리스트 (S3 파일의 Presigned URL 및 출처 RESUME_ORIGINAL  포함)
 links                                       | JSON Array                                 | 연결된 참조 링크 목록
 createdAt                                   | ISO DateTime                               | 영구 저장 완료된 시간
 updatedAt                                   | ISO DateTime                               | 수정 시간
