### PR TITLE
feat : 병합 후보 추출 로직 강화 및 Step3 추가 

### DIFF
--- a/src/main/java/back/pickd/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/back/pickd/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package back.pickd.global.error;
 
+import back.pickd.user.dto.ExperienceMergeConflictResponse;
+import back.pickd.user.exception.ExperienceMergeConflictException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -29,6 +31,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleGoogleApiException(Exception e, HttpServletRequest request) {
         log.error("Google API Exception: {}", e.getMessage(), e);
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "구글 API 연동 중 오류가 발생했습니다.", request);
+    }
+
+    @ExceptionHandler(ExperienceMergeConflictException.class)
+    public ResponseEntity<ExperienceMergeConflictResponse> handleExperienceMergeConflict(ExperienceMergeConflictException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getResponse());
     }
 
     @ExceptionHandler({OAuth2AuthenticationException.class, RuntimeException.class})

--- a/src/main/java/back/pickd/global/infra/ai/AiClient.java
+++ b/src/main/java/back/pickd/global/infra/ai/AiClient.java
@@ -1,5 +1,7 @@
 package back.pickd.global.infra.ai;
 
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckResponse;
 import back.pickd.global.infra.ai.dto.AiStep1Response;
 import back.pickd.global.infra.ai.dto.AiStep2Response;
 import back.pickd.global.infra.ai.dto.AiJobPostingResponse;
@@ -78,12 +80,27 @@ public class AiClient {
      * AI 2차 정밀 경험 추출 (step2) - S3 CloudFront URL 기반 호출
      */
     public AiStep2Response extractStep2ByUrl(String resumeUrl, List<AiStep1Response.ExperienceSummaryDto> selectedExperiences) {
+        return extractStep2ByUrl(resumeUrl, selectedExperiences, List.of());
+    }
+
+    /**
+     * AI 2차 정밀 경험 추출 (step2) - 기존 경험 기반 병합 후보 검사 포함
+     */
+    public AiStep2Response extractStep2ByUrl(
+            String resumeUrl,
+            List<AiStep1Response.ExperienceSummaryDto> selectedExperiences,
+            List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences
+    ) {
         MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
         bodyBuilder.part("url", resumeUrl);
 
         try {
             String jsonList = objectMapper.writeValueAsString(selectedExperiences);
             bodyBuilder.part("selected_experiences", jsonList);
+            if (existingExperiences != null && !existingExperiences.isEmpty()) {
+                String existingExperienceJson = objectMapper.writeValueAsString(existingExperiences);
+                bodyBuilder.part("existing_experiences", existingExperienceJson);
+            }
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize selected experiences for AI Step2", e);
             throw new RuntimeException("AI 분석 요청 중 직렬화 오류가 발생했습니다.", e);
@@ -95,6 +112,15 @@ public class AiClient {
                 .body(bodyBuilder.build())
                 .retrieve()
                 .body(AiStep2Response.class);
+    }
+
+    public AiExperienceMergeCheckResponse checkExperienceMerge(AiExperienceMergeCheckRequest request) {
+        return restClient.post()
+                .uri("/api/v1/experiences/merge-check")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(AiExperienceMergeCheckResponse.class);
     }
 
     public AiJobPostingResponse analyzeNoticeUrl(String url) {

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiExperienceMergeCheckRequest.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiExperienceMergeCheckRequest.java
@@ -1,0 +1,67 @@
+package back.pickd.global.infra.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiExperienceMergeCheckRequest {
+
+    @Builder.Default
+    private List<ExperiencePayload> targets = new ArrayList<>();
+
+    @JsonProperty("existing_experiences")
+    @Builder.Default
+    private List<ExperiencePayload> existingExperiences = new ArrayList<>();
+
+    private Double threshold;
+
+    @JsonProperty("top_k")
+    @Builder.Default
+    private int topK = 1;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExperiencePayload {
+        private String id;
+
+        private String title;
+
+        @JsonProperty("experience_name")
+        private String experienceName;
+
+        @JsonProperty("experience_group")
+        private String experienceGroup;
+
+        @JsonProperty("experience_type")
+        private String experienceType;
+
+        @Builder.Default
+        private List<String> keywords = new ArrayList<>();
+
+        @Builder.Default
+        private Map<String, Object> attributes = new HashMap<>();
+
+        @JsonProperty("basic_info")
+        @Builder.Default
+        private Map<String, Object> basicInfo = new HashMap<>();
+
+        @JsonProperty("document_content")
+        private String documentContent;
+
+        @JsonProperty("experience_content")
+        private String experienceContent;
+    }
+}

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiExperienceMergeCheckResponse.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiExperienceMergeCheckResponse.java
@@ -1,0 +1,48 @@
+package back.pickd.global.infra.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class AiExperienceMergeCheckResponse {
+    private List<MergeCheckResult> results;
+
+    @Getter
+    @NoArgsConstructor
+    public static class MergeCheckResult {
+        @JsonProperty("target_index")
+        private int targetIndex;
+
+        @JsonProperty("target_id")
+        private String targetId;
+
+        @JsonProperty("needs_merge")
+        private boolean needsMerge;
+
+        @JsonProperty("merge_candidate_id")
+        private String mergeCandidateId;
+
+        private Double similarity;
+
+        private MergeCandidate candidate;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class MergeCandidate {
+        private String id;
+        private String title;
+
+        @JsonProperty("experience_group")
+        private String experienceGroup;
+
+        @JsonProperty("experience_type")
+        private String experienceType;
+
+        private Double similarity;
+    }
+}

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiStep2Response.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiStep2Response.java
@@ -34,6 +34,7 @@ public class AiStep2Response {
         private List<String> ai_questions;
         private List<String> ai_sentence_cards;
         private String merge_candidate_id;
+        private Double merge_similarity;
         private String writing_status;
     }
 

--- a/src/main/java/back/pickd/user/controller/ExperienceExtractionController.java
+++ b/src/main/java/back/pickd/user/controller/ExperienceExtractionController.java
@@ -1,9 +1,12 @@
 package back.pickd.user.controller;
 
 import back.pickd.user.dto.ExperienceTempResponse;
+import back.pickd.user.dto.ExperienceStep3Request;
+import back.pickd.user.dto.ExperienceStep3Response;
 import back.pickd.user.dto.ExperienceStep2Response;
 import back.pickd.user.dto.ExperienceStep2SaveResult;
 import back.pickd.user.dto.UserExperienceResponse;
+import jakarta.validation.Valid;
 import back.pickd.user.service.ExperienceExtractionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +50,14 @@ public class ExperienceExtractionController {
                 .map(UserExperienceResponse::new)
                 .collect(Collectors.toList());
         return ResponseEntity.ok(new ExperienceStep2Response(savedExperiences, result.getMergeCandidates()));
+    }
+
+    @PostMapping("/step3")
+    public ResponseEntity<ExperienceStep3Response> confirmStep3(
+            Authentication authentication,
+            @RequestBody @Valid ExperienceStep3Request request) {
+
+        return ResponseEntity.ok(extractionService.confirmStep3(authentication.getName(), request));
     }
 
 }

--- a/src/main/java/back/pickd/user/controller/ExperienceExtractionController.java
+++ b/src/main/java/back/pickd/user/controller/ExperienceExtractionController.java
@@ -1,6 +1,8 @@
 package back.pickd.user.controller;
 
 import back.pickd.user.dto.ExperienceTempResponse;
+import back.pickd.user.dto.ExperienceStep2Response;
+import back.pickd.user.dto.ExperienceStep2SaveResult;
 import back.pickd.user.dto.UserExperienceResponse;
 import back.pickd.user.service.ExperienceExtractionService;
 import lombok.RequiredArgsConstructor;
@@ -34,16 +36,17 @@ public class ExperienceExtractionController {
 
 
     @PostMapping("/step2")
-    public ResponseEntity<List<UserExperienceResponse>> extractStep2(
+    public ResponseEntity<ExperienceStep2Response> extractStep2(
             Authentication authentication,
             @RequestBody Map<String, List<Long>> request) {
 
         List<Long> selectedTempIds = request.get("selectedTempIds");
-        List<UserExperienceResponse> result = extractionService.extractStep2(authentication.getName(), selectedTempIds)
+        ExperienceStep2SaveResult result = extractionService.extractStep2(authentication.getName(), selectedTempIds);
+        List<UserExperienceResponse> savedExperiences = result.getSavedExperiences()
                 .stream()
                 .map(UserExperienceResponse::new)
                 .collect(Collectors.toList());
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(new ExperienceStep2Response(savedExperiences, result.getMergeCandidates()));
     }
 
 }

--- a/src/main/java/back/pickd/user/dto/ExperienceCreateRequestDto.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceCreateRequestDto.java
@@ -38,6 +38,8 @@ public class ExperienceCreateRequestDto {
 
     private List<LinkRequest> links = new ArrayList<>();
 
+    private boolean forceCreate = false;
+
     @Getter
     @NoArgsConstructor
     public static class LinkRequest {

--- a/src/main/java/back/pickd/user/dto/ExperienceDraftRequest.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceDraftRequest.java
@@ -1,0 +1,36 @@
+package back.pickd.user.dto;
+
+import back.pickd.user.entity.enums.ExperienceGroup;
+import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.entity.enums.Status;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class ExperienceDraftRequest {
+
+    @NotBlank(message = "경험 제목은 필수입니다.")
+    private String title;
+
+    @NotNull(message = "경험 유형은 필수입니다.")
+    private ExperienceType experienceType;
+
+    @NotNull(message = "경험 그룹은 필수입니다.")
+    private ExperienceGroup experienceGroup;
+
+    private Status status = Status.COMPLETED;
+
+    private String documentContent;
+
+    private Map<String, Object> attributes = new HashMap<>();
+
+    private List<String> keywords = new ArrayList<>();
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceDraftResponse.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceDraftResponse.java
@@ -1,0 +1,54 @@
+package back.pickd.user.dto;
+
+import back.pickd.global.infra.ai.dto.AiStep2Response;
+import back.pickd.user.entity.enums.ExperienceGroup;
+import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.entity.enums.Status;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class ExperienceDraftResponse {
+    private final String title;
+    private final String experienceType;
+    private final String experienceGroup;
+    private final String status;
+    private final String documentContent;
+    private final Map<String, Object> attributes;
+    private final List<String> keywords;
+
+    public static ExperienceDraftResponse fromCreateRequest(ExperienceCreateRequestDto request) {
+        return new ExperienceDraftResponse(
+                request.getTitle(),
+                request.getExperienceType() != null ? request.getExperienceType().name() : null,
+                request.getExperienceGroup() != null ? request.getExperienceGroup().name() : null,
+                request.getStatus() != null ? request.getStatus().name() : null,
+                request.getDocumentContent(),
+                request.getAttributes() != null ? request.getAttributes() : new HashMap<>(),
+                request.getKeywords() != null ? request.getKeywords() : new ArrayList<>()
+        );
+    }
+
+    public static ExperienceDraftResponse fromStep2(
+            AiStep2Response.Step2ExperienceDto dto,
+            ExperienceType type,
+            ExperienceGroup group,
+            Status status
+    ) {
+        return new ExperienceDraftResponse(
+                dto.getExperience_name(),
+                type != null ? type.name() : null,
+                group != null ? group.name() : null,
+                status != null ? status.name() : null,
+                dto.getExperience_content(),
+                dto.getBasic_info() != null ? dto.getBasic_info() : new HashMap<>(),
+                dto.getKeywords() != null ? dto.getKeywords() : new ArrayList<>()
+        );
+    }
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceMergeCandidateResponse.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceMergeCandidateResponse.java
@@ -1,0 +1,25 @@
+package back.pickd.user.dto;
+
+import back.pickd.user.entity.UserExperience;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExperienceMergeCandidateResponse {
+    private final String id;
+    private final String title;
+    private final String experienceType;
+    private final String experienceGroup;
+    private final Double similarity;
+
+    public static ExperienceMergeCandidateResponse from(UserExperience experience, Double similarity) {
+        return new ExperienceMergeCandidateResponse(
+                experience.getId(),
+                experience.getTitle(),
+                experience.getExperienceType() != null ? experience.getExperienceType().name() : null,
+                experience.getExperienceGroup() != null ? experience.getExperienceGroup().name() : null,
+                similarity
+        );
+    }
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceMergeConflictResponse.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceMergeConflictResponse.java
@@ -1,0 +1,13 @@
+package back.pickd.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExperienceMergeConflictResponse {
+    private final boolean needsMerge;
+    private final ExperienceMergeCandidateResponse candidate;
+    private final Double similarity;
+    private final ExperienceDraftResponse draft;
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceStep2Response.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceStep2Response.java
@@ -1,0 +1,13 @@
+package back.pickd.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ExperienceStep2Response {
+    private final List<UserExperienceResponse> savedExperiences;
+    private final List<ExperienceMergeConflictResponse> mergeCandidates;
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceStep2SaveResult.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceStep2SaveResult.java
@@ -1,0 +1,14 @@
+package back.pickd.user.dto;
+
+import back.pickd.user.entity.UserExperience;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ExperienceStep2SaveResult {
+    private final List<UserExperience> savedExperiences;
+    private final List<ExperienceMergeConflictResponse> mergeCandidates;
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceStep3Action.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceStep3Action.java
@@ -1,0 +1,6 @@
+package back.pickd.user.dto;
+
+public enum ExperienceStep3Action {
+    CREATE_NEW,
+    SKIP
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceStep3Request.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceStep3Request.java
@@ -1,0 +1,29 @@
+package back.pickd.user.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ExperienceStep3Request {
+
+    @NotEmpty(message = "처리할 중복 후보 결정 목록은 필수입니다.")
+    private List<Decision> decisions = new ArrayList<>();
+
+    @Getter
+    @NoArgsConstructor
+    public static class Decision {
+        @NotNull(message = "처리 action은 필수입니다.")
+        private ExperienceStep3Action action;
+
+        @Valid
+        @NotNull(message = "저장 후보 draft는 필수입니다.")
+        private ExperienceDraftRequest draft;
+    }
+}

--- a/src/main/java/back/pickd/user/dto/ExperienceStep3Response.java
+++ b/src/main/java/back/pickd/user/dto/ExperienceStep3Response.java
@@ -1,0 +1,13 @@
+package back.pickd.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ExperienceStep3Response {
+    private final List<UserExperienceResponse> savedExperiences;
+    private final int skippedCount;
+}

--- a/src/main/java/back/pickd/user/exception/ExperienceMergeConflictException.java
+++ b/src/main/java/back/pickd/user/exception/ExperienceMergeConflictException.java
@@ -1,0 +1,14 @@
+package back.pickd.user.exception;
+
+import back.pickd.user.dto.ExperienceMergeConflictResponse;
+import lombok.Getter;
+
+@Getter
+public class ExperienceMergeConflictException extends RuntimeException {
+    private final ExperienceMergeConflictResponse response;
+
+    public ExperienceMergeConflictException(ExperienceMergeConflictResponse response) {
+        super("유사한 기존 경험이 있어 병합 확인이 필요합니다.");
+        this.response = response;
+    }
+}

--- a/src/main/java/back/pickd/user/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/user/service/ExperienceExtractionService.java
@@ -7,7 +7,11 @@ import back.pickd.global.infra.ai.dto.AiStep2Response;
 import back.pickd.global.infra.s3.FileUploadType;
 import back.pickd.global.infra.s3.S3Service;
 import back.pickd.user.dto.ExperienceMergeConflictResponse;
+import back.pickd.user.dto.ExperienceStep3Action;
+import back.pickd.user.dto.ExperienceStep3Request;
 import back.pickd.user.dto.ExperienceStep2SaveResult;
+import back.pickd.user.dto.ExperienceStep3Response;
+import back.pickd.user.dto.UserExperienceResponse;
 import back.pickd.user.entity.*;
 import back.pickd.user.entity.enums.ExperienceGroup;
 import back.pickd.user.entity.enums.ExperienceType;
@@ -149,6 +153,39 @@ public class ExperienceExtractionService {
         tempRepository.deleteByUser(user);
 
         return new ExperienceStep2SaveResult(savedExperiences, mergeCandidates);
+    }
+
+    /**
+     * 2차 추출에서 중복 후보로 보류된 draft 경험을 사용자 결정에 따라 후처리합니다.
+     */
+    @Transactional
+    public ExperienceStep3Response confirmStep3(String email, ExperienceStep3Request request) {
+        User user = userService.findByEmail(email);
+
+        List<UserExperienceResponse> savedExperiences = new ArrayList<>();
+        int skippedCount = 0;
+
+        for (ExperienceStep3Request.Decision decision : request.getDecisions()) {
+            if (decision.getAction() == ExperienceStep3Action.SKIP) {
+                skippedCount++;
+                continue;
+            }
+
+            UserExperience experience = UserExperience.builder()
+                    .user(user)
+                    .title(decision.getDraft().getTitle())
+                    .experienceGroup(decision.getDraft().getExperienceGroup())
+                    .experienceType(decision.getDraft().getExperienceType())
+                    .status(decision.getDraft().getStatus() != null ? decision.getDraft().getStatus() : Status.COMPLETED)
+                    .documentContent(decision.getDraft().getDocumentContent())
+                    .attributes(decision.getDraft().getAttributes() != null ? decision.getDraft().getAttributes() : new HashMap<>())
+                    .keywords(decision.getDraft().getKeywords() != null ? decision.getDraft().getKeywords() : new ArrayList<>())
+                    .build();
+
+            savedExperiences.add(new UserExperienceResponse(experienceRepository.save(experience)));
+        }
+
+        return new ExperienceStep3Response(savedExperiences, skippedCount);
     }
 
     private ExperienceGroup convertGroup(String koreanGroup) {

--- a/src/main/java/back/pickd/user/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/user/service/ExperienceExtractionService.java
@@ -1,10 +1,13 @@
 package back.pickd.user.service;
 
 import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
 import back.pickd.global.infra.ai.dto.AiStep1Response;
 import back.pickd.global.infra.ai.dto.AiStep2Response;
 import back.pickd.global.infra.s3.FileUploadType;
 import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.dto.ExperienceMergeConflictResponse;
+import back.pickd.user.dto.ExperienceStep2SaveResult;
 import back.pickd.user.entity.*;
 import back.pickd.user.entity.enums.ExperienceGroup;
 import back.pickd.user.entity.enums.ExperienceType;
@@ -32,6 +35,7 @@ public class ExperienceExtractionService {
     private final ExperienceTempRepository tempRepository;
     private final UserExperienceRepository experienceRepository;
     private final UserService userService;
+    private final ExperienceMergeService experienceMergeService;
 
     /**
      * 1차 경험 후보 추출 및 임시 캐싱
@@ -70,7 +74,7 @@ public class ExperienceExtractionService {
      * 2차 선택형 정밀 분석 및 UserExperience 최종 영구 저장
      */
     @Transactional
-    public List<UserExperience> extractStep2(String email, List<Long> selectedTempIds) {
+    public ExperienceStep2SaveResult extractStep2(String email, List<Long> selectedTempIds) {
         if (selectedTempIds == null || selectedTempIds.isEmpty()) {
             throw new IllegalArgumentException("선택된 임시 경험 ID가 없습니다.");
         }
@@ -94,15 +98,25 @@ public class ExperienceExtractionService {
                 ))
                 .collect(Collectors.toList());
 
+        List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences =
+                experienceMergeService.buildExistingExperiencePayloads(user);
+
         // 3. AI 2차 분석 호출 (S3 CloudFront URL을 던져 2차 정밀 분석 수행)
-        AiStep2Response aiResponse = aiClient.extractStep2ByUrl(resumeUrl, selectedSummaries);
+        AiStep2Response aiResponse = aiClient.extractStep2ByUrl(resumeUrl, selectedSummaries, existingExperiences);
 
         // 4. 2차 상세 분석 결과 영구 저장 및 파일 연동
         List<UserExperience> savedExperiences = new ArrayList<>();
+        List<ExperienceMergeConflictResponse> mergeCandidates = new ArrayList<>();
         if (aiResponse.getExperiences() != null) {
             for (AiStep2Response.Step2ExperienceDto dto : aiResponse.getExperiences()) {
                 ExperienceGroup group = convertGroup(dto.getExperience_group());
                 ExperienceType type = convertType(dto.getExperience_type());
+
+                experienceMergeService.buildStep2MergeCandidate(user, dto, type, group)
+                        .ifPresent(mergeCandidates::add);
+                if (dto.isNeeds_merge()) {
+                    continue;
+                }
 
                 // UserExperience 빌드 및 attributes JSONB 통짜 적재
                 UserExperience userExperience = UserExperience.builder()
@@ -134,7 +148,7 @@ public class ExperienceExtractionService {
         // 5. 사용 완료된 임시 캐시 데이터 일괄 삭제
         tempRepository.deleteByUser(user);
 
-        return savedExperiences;
+        return new ExperienceStep2SaveResult(savedExperiences, mergeCandidates);
     }
 
     private ExperienceGroup convertGroup(String koreanGroup) {

--- a/src/main/java/back/pickd/user/service/ExperienceMergeService.java
+++ b/src/main/java/back/pickd/user/service/ExperienceMergeService.java
@@ -1,0 +1,167 @@
+package back.pickd.user.service;
+
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckResponse;
+import back.pickd.global.infra.ai.dto.AiStep2Response;
+import back.pickd.user.dto.ExperienceCreateRequestDto;
+import back.pickd.user.dto.ExperienceDraftResponse;
+import back.pickd.user.dto.ExperienceMergeCandidateResponse;
+import back.pickd.user.dto.ExperienceMergeConflictResponse;
+import back.pickd.user.entity.User;
+import back.pickd.user.entity.UserExperience;
+import back.pickd.user.entity.enums.ExperienceGroup;
+import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.entity.enums.Status;
+import back.pickd.user.repository.UserExperienceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExperienceMergeService {
+
+    private final AiClient aiClient;
+    private final UserExperienceRepository userExperienceRepository;
+
+    public List<AiExperienceMergeCheckRequest.ExperiencePayload> buildExistingExperiencePayloads(User user) {
+        return userExperienceRepository.findByUserOrderByCreatedAtDesc(user)
+                .stream()
+                .map(this::toPayload)
+                .toList();
+    }
+
+    public Optional<ExperienceMergeConflictResponse> findCreateMergeCandidate(
+            User user,
+            ExperienceCreateRequestDto request
+    ) {
+        List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences = buildExistingExperiencePayloads(user);
+        if (existingExperiences.isEmpty()) {
+            return Optional.empty();
+        }
+
+        AiExperienceMergeCheckResponse.MergeCheckResult result = checkSingleTarget(
+                toPayload(request),
+                existingExperiences
+        );
+
+        if (result == null || !result.isNeedsMerge()) {
+            return Optional.empty();
+        }
+
+        Optional<ExperienceMergeConflictResponse> conflict = buildConflictResponse(
+                user,
+                result.getMergeCandidateId(),
+                result.getSimilarity(),
+                ExperienceDraftResponse.fromCreateRequest(request)
+        );
+        if (conflict.isEmpty()) {
+            throw new RuntimeException("AI 병합 후보를 사용자 경험에서 찾을 수 없습니다.");
+        }
+        return conflict;
+    }
+
+    public Optional<ExperienceMergeConflictResponse> buildStep2MergeCandidate(
+            User user,
+            AiStep2Response.Step2ExperienceDto dto,
+            ExperienceType type,
+            ExperienceGroup group
+    ) {
+        if (!dto.isNeeds_merge() || dto.getMerge_candidate_id() == null) {
+            return Optional.empty();
+        }
+
+        Optional<ExperienceMergeConflictResponse> conflict = buildConflictResponse(
+                user,
+                dto.getMerge_candidate_id(),
+                dto.getMerge_similarity(),
+                ExperienceDraftResponse.fromStep2(dto, type, group, Status.COMPLETED)
+        );
+        if (conflict.isEmpty()) {
+            throw new RuntimeException("AI 병합 후보를 사용자 경험에서 찾을 수 없습니다.");
+        }
+        return conflict;
+    }
+
+    private AiExperienceMergeCheckResponse.MergeCheckResult checkSingleTarget(
+            AiExperienceMergeCheckRequest.ExperiencePayload target,
+            List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences
+    ) {
+        AiExperienceMergeCheckRequest request = AiExperienceMergeCheckRequest.builder()
+                .targets(List.of(target))
+                .existingExperiences(existingExperiences)
+                .topK(1)
+                .build();
+        AiExperienceMergeCheckResponse response = aiClient.checkExperienceMerge(request);
+        if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
+            throw new RuntimeException("AI 병합 검사 응답이 없습니다.");
+        }
+        return response.getResults().get(0);
+    }
+
+    private Optional<ExperienceMergeConflictResponse> buildConflictResponse(
+            User user,
+            String mergeCandidateId,
+            Double similarity,
+            ExperienceDraftResponse draft
+    ) {
+        if (mergeCandidateId == null) {
+            return Optional.empty();
+        }
+
+        return userExperienceRepository.findByIdAndUser(mergeCandidateId, user)
+                .map(candidate -> {
+                    ExperienceMergeCandidateResponse candidateResponse =
+                            ExperienceMergeCandidateResponse.from(candidate, similarity);
+                    return new ExperienceMergeConflictResponse(
+                            true,
+                            candidateResponse,
+                            similarity,
+                            draft
+                    );
+                });
+    }
+
+    private AiExperienceMergeCheckRequest.ExperiencePayload toPayload(UserExperience experience) {
+        return AiExperienceMergeCheckRequest.ExperiencePayload.builder()
+                .id(experience.getId())
+                .title(experience.getTitle())
+                .experienceName(experience.getTitle())
+                .experienceGroup(toKoreanGroup(experience.getExperienceGroup()))
+                .experienceType(toKoreanType(experience.getExperienceType()))
+                .keywords(experience.getKeywords() != null ? experience.getKeywords() : new ArrayList<>())
+                .attributes(experience.getAttributes() != null ? experience.getAttributes() : new HashMap<>())
+                .documentContent(experience.getDocumentContent())
+                .build();
+    }
+
+    private AiExperienceMergeCheckRequest.ExperiencePayload toPayload(ExperienceCreateRequestDto request) {
+        return AiExperienceMergeCheckRequest.ExperiencePayload.builder()
+                .title(request.getTitle())
+                .experienceName(request.getTitle())
+                .experienceGroup(toKoreanGroup(request.getExperienceGroup()))
+                .experienceType(toKoreanType(request.getExperienceType()))
+                .keywords(request.getKeywords() != null ? request.getKeywords() : new ArrayList<>())
+                .attributes(request.getAttributes() != null ? request.getAttributes() : new HashMap<>())
+                .documentContent(request.getDocumentContent())
+                .build();
+    }
+
+    private String toKoreanGroup(ExperienceGroup group) {
+        if (group == null) {
+            return null;
+        }
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
+    }
+
+    private String toKoreanType(ExperienceType type) {
+        return type != null ? type.getKoreanName() : null;
+    }
+}

--- a/src/main/java/back/pickd/user/service/UserExperienceService.java
+++ b/src/main/java/back/pickd/user/service/UserExperienceService.java
@@ -6,6 +6,7 @@ import back.pickd.user.dto.UserExperienceResponse;
 import back.pickd.user.entity.ExperienceLink;
 import back.pickd.user.entity.User;
 import back.pickd.user.entity.UserExperience;
+import back.pickd.user.exception.ExperienceMergeConflictException;
 import back.pickd.user.repository.UserExperienceRepository;
 import back.pickd.user.repository.UserRepository;
 import back.pickd.user.entity.enums.ExperienceGroup;
@@ -25,12 +26,20 @@ public class UserExperienceService {
 
     private final UserExperienceRepository userExperienceRepository;
     private final UserRepository userRepository;
+    private final ExperienceMergeService experienceMergeService;
 
     // 경험 수기 생성
     @Transactional
     public ExperienceCreateResponseDto createExperience(String email, ExperienceCreateRequestDto request) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (!request.isForceCreate()) {
+            experienceMergeService.findCreateMergeCandidate(user, request)
+                    .ifPresent(conflict -> {
+                        throw new ExperienceMergeConflictException(conflict);
+                    });
+        }
 
         UserExperience experience = UserExperience.builder()
                 .user(user)

--- a/src/test/java/back/pickd/user/service/ExperienceExtractionServiceTest.java
+++ b/src/test/java/back/pickd/user/service/ExperienceExtractionServiceTest.java
@@ -1,0 +1,117 @@
+package back.pickd.user.service;
+
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.dto.ExperienceStep3Request;
+import back.pickd.user.dto.ExperienceStep3Response;
+import back.pickd.user.entity.User;
+import back.pickd.user.entity.UserExperience;
+import back.pickd.user.entity.enums.ExperienceGroup;
+import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.entity.enums.Status;
+import back.pickd.user.repository.ExperienceTempRepository;
+import back.pickd.user.repository.UserExperienceRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExperienceExtractionServiceTest {
+
+    @Mock
+    private AiClient aiClient;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private ExperienceTempRepository tempRepository;
+
+    @Mock
+    private UserExperienceRepository experienceRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ExperienceMergeService experienceMergeService;
+
+    @InjectMocks
+    private ExperienceExtractionService experienceExtractionService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void confirmStep3CreatesSelectedDraftAndSkipsIgnoredDraft() throws Exception {
+        User user = User.builder()
+                .email("user@example.com")
+                .name("테스트")
+                .build();
+        String requestJson = """
+                {
+                  "decisions": [
+                    {
+                      "action": "CREATE_NEW",
+                      "draft": {
+                        "title": "FIn-agent",
+                        "experienceType": "PROJECT",
+                        "experienceGroup": "NARRATIVE",
+                        "status": "COMPLETED",
+                        "documentContent": "미래에셋 AI Agent 프로젝트에서 데이터 전처리와 툴 개발을 담당했습니다.",
+                        "attributes": {
+                          "project_name": "FIn-agent",
+                          "organization": "미래에셋",
+                          "period": "2025.06.31 ~07.31"
+                        },
+                        "keywords": ["문제 해결", "분석력", "실행력"]
+                      }
+                    },
+                    {
+                      "action": "SKIP",
+                      "draft": {
+                        "title": "중복으로 저장하지 않을 경험",
+                        "experienceType": "PROJECT",
+                        "experienceGroup": "NARRATIVE",
+                        "status": "COMPLETED",
+                        "documentContent": "저장하지 않는 후보입니다.",
+                        "attributes": {},
+                        "keywords": []
+                      }
+                    }
+                  ]
+                }
+                """;
+        ExperienceStep3Request request = objectMapper.readValue(requestJson, ExperienceStep3Request.class);
+
+        when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(experienceRepository.save(any(UserExperience.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ExperienceStep3Response response = experienceExtractionService.confirmStep3("user@example.com", request);
+
+        assertEquals(1, response.getSavedExperiences().size());
+        assertEquals(1, response.getSkippedCount());
+
+        ArgumentCaptor<UserExperience> captor = ArgumentCaptor.forClass(UserExperience.class);
+        verify(experienceRepository, times(1)).save(captor.capture());
+
+        UserExperience saved = captor.getValue();
+        assertEquals("FIn-agent", saved.getTitle());
+        assertEquals(ExperienceType.PROJECT, saved.getExperienceType());
+        assertEquals(ExperienceGroup.NARRATIVE, saved.getExperienceGroup());
+        assertEquals(Status.COMPLETED, saved.getStatus());
+        assertEquals("미래에셋", saved.getAttributes().get("organization"));
+        assertEquals(List.of("문제 해결", "분석력", "실행력"), saved.getKeywords());
+    }
+}

--- a/src/test/java/back/pickd/user/service/ExperienceMergeServiceTest.java
+++ b/src/test/java/back/pickd/user/service/ExperienceMergeServiceTest.java
@@ -1,0 +1,67 @@
+package back.pickd.user.service;
+
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
+import back.pickd.user.entity.User;
+import back.pickd.user.entity.UserExperience;
+import back.pickd.user.entity.enums.ExperienceGroup;
+import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.entity.enums.Status;
+import back.pickd.user.repository.UserExperienceRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExperienceMergeServiceTest {
+
+    @Mock
+    private AiClient aiClient;
+
+    @Mock
+    private UserExperienceRepository userExperienceRepository;
+
+    @InjectMocks
+    private ExperienceMergeService experienceMergeService;
+
+    @Test
+    void buildExistingExperiencePayloadsConvertsUserExperiencesForAiServer() {
+        User user = User.builder()
+                .email("user@example.com")
+                .name("테스트")
+                .build();
+        UserExperience experience = UserExperience.builder()
+                .id("exp-1")
+                .user(user)
+                .title("캡스톤 AI 프로젝트")
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .experienceType(ExperienceType.PROJECT)
+                .status(Status.COMPLETED)
+                .documentContent("추천 모델을 개선했습니다.")
+                .attributes(Map.of("role", "backend"))
+                .keywords(List.of("문제 해결"))
+                .build();
+        when(userExperienceRepository.findByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(experience));
+
+        List<AiExperienceMergeCheckRequest.ExperiencePayload> payloads =
+                experienceMergeService.buildExistingExperiencePayloads(user);
+
+        assertEquals(1, payloads.size());
+        AiExperienceMergeCheckRequest.ExperiencePayload payload = payloads.get(0);
+        assertEquals("exp-1", payload.getId());
+        assertEquals("캡스톤 AI 프로젝트", payload.getTitle());
+        assertEquals("상세 서술형", payload.getExperienceGroup());
+        assertEquals("프로젝트", payload.getExperienceType());
+        assertEquals("추천 모델을 개선했습니다.", payload.getDocumentContent());
+        assertEquals(List.of("문제 해결"), payload.getKeywords());
+        assertEquals("backend", payload.getAttributes().get("role"));
+    }
+}


### PR DESCRIPTION
# 변경점 👍
- 수기 경험 저장 전 유사 경험 검사
- Step2 추출 결과 병합 후보 분리
- AI 서버 병합 검사 요청/응답 DTO 추가
- Step3 API로 중복 후보 저장 또는 스킵 처리
- 중복 후보 draft 기반 새 경험 저장 로직 추가
- Step3 저장 및 스킵 단위 테스트 추가
