### PR TITLE
feat : 프리셋 로직 단위 테스트 실행 

### DIFF
--- a/src/main/java/back/pickd/user/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/user/service/ExperienceExtractionService.java
@@ -18,6 +18,7 @@ import back.pickd.user.entity.enums.ExperienceType;
 import back.pickd.user.entity.enums.Status;
 import back.pickd.user.repository.ExperienceTempRepository;
 import back.pickd.user.repository.UserExperienceRepository;
+import back.pickd.user.utils.PresetRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,6 +40,7 @@ public class ExperienceExtractionService {
     private final UserExperienceRepository experienceRepository;
     private final UserService userService;
     private final ExperienceMergeService experienceMergeService;
+    private final PresetRegistry presetRegistry;
 
     /**
      * 1차 경험 후보 추출 및 임시 캐싱
@@ -130,7 +131,7 @@ public class ExperienceExtractionService {
                         .experienceType(type)
                         .status(Status.COMPLETED)
                         .documentContent(dto.getExperience_content())
-                        .attributes(dto.getBasic_info() != null ? dto.getBasic_info() : new HashMap<>())
+                        .attributes(presetRegistry.normalizeAttributes(type, dto.getBasic_info()))
                         .keywords(dto.getKeywords() != null ? dto.getKeywords() : new ArrayList<>())
                         .build();
 
@@ -178,7 +179,10 @@ public class ExperienceExtractionService {
                     .experienceType(decision.getDraft().getExperienceType())
                     .status(decision.getDraft().getStatus() != null ? decision.getDraft().getStatus() : Status.COMPLETED)
                     .documentContent(decision.getDraft().getDocumentContent())
-                    .attributes(decision.getDraft().getAttributes() != null ? decision.getDraft().getAttributes() : new HashMap<>())
+                    .attributes(presetRegistry.normalizeAttributes(
+                            decision.getDraft().getExperienceType(),
+                            decision.getDraft().getAttributes()
+                    ))
                     .keywords(decision.getDraft().getKeywords() != null ? decision.getDraft().getKeywords() : new ArrayList<>())
                     .build();
 

--- a/src/main/java/back/pickd/user/service/OnboardingService.java
+++ b/src/main/java/back/pickd/user/service/OnboardingService.java
@@ -108,13 +108,13 @@ public class OnboardingService {
                         + (e.getEndDate() != null ? e.getEndDate() : "");
                 
                 if (expType == ExperienceType.AWARD) {
-                    attributes.put("수상일", e.getEndDate());
+                    attributes.put("award_date", e.getEndDate());
                 } else if (expType == ExperienceType.INTERN) {
-                    attributes.put("근무/참여 기간", periodVal);
+                    attributes.put("period", periodVal);
                 } else if (expType == ExperienceType.ACTIVITY) {
-                    attributes.put("활동 기간", periodVal);
+                    attributes.put("period", periodVal);
                 } else {
-                    attributes.put("진행 기간", periodVal);
+                    attributes.put("period", periodVal);
                 }
 
                 experienceRepository.save(

--- a/src/main/java/back/pickd/user/service/UserExperienceService.java
+++ b/src/main/java/back/pickd/user/service/UserExperienceService.java
@@ -11,6 +11,7 @@ import back.pickd.user.repository.UserExperienceRepository;
 import back.pickd.user.repository.UserRepository;
 import back.pickd.user.entity.enums.ExperienceGroup;
 import back.pickd.user.entity.enums.ExperienceType;
+import back.pickd.user.utils.PresetRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,7 @@ public class UserExperienceService {
     private final UserExperienceRepository userExperienceRepository;
     private final UserRepository userRepository;
     private final ExperienceMergeService experienceMergeService;
+    private final PresetRegistry presetRegistry;
 
     // 경험 수기 생성
     @Transactional
@@ -48,7 +50,10 @@ public class UserExperienceService {
                 .experienceGroup(request.getExperienceGroup())
                 .status(request.getStatus())
                 .documentContent(request.getDocumentContent())
-                .attributes(request.getAttributes())
+                .attributes(presetRegistry.normalizeAttributes(
+                        request.getExperienceType(),
+                        request.getAttributes()
+                ))
                 .keywords(request.getKeywords())
                 .build();
 

--- a/src/main/java/back/pickd/user/utils/PresetRegistry.java
+++ b/src/main/java/back/pickd/user/utils/PresetRegistry.java
@@ -2,31 +2,115 @@ package back.pickd.user.utils;
 
 import back.pickd.user.entity.enums.ExperienceType;
 import org.springframework.stereotype.Component;
+
 import java.util.*;
 
 @Component
 public class PresetRegistry {
 
-    private static final Map<ExperienceType, List<String>> PRESET_MAP = new EnumMap<>(ExperienceType.class);
+    public record PresetField(String key, String label) {
+    }
+
+    private static final Map<ExperienceType, List<PresetField>> PRESET_MAP =
+            new EnumMap<>(ExperienceType.class);
 
     static {
         // 상세 서술형 (Narrative) 프리셋 필드 정의
-        PRESET_MAP.put(ExperienceType.PROJECT, List.of("프로젝트명", "진행 기간", "역할", "소속/팀", "주요 성과"));
-        PRESET_MAP.put(ExperienceType.ACTIVITY, List.of("활동명", "주관기관", "활동 기간", "역할", "주요 성과"));
-        PRESET_MAP.put(ExperienceType.INTERN, List.of("회사/기관명", "직무/부서", "근무/참여 기간", "담당 업무", "주요 성과"));
-        PRESET_MAP.put(ExperienceType.CONTEST, List.of("공모전명", "주관기관", "참가 기간", "역할", "수상/결과"));
-        PRESET_MAP.put(ExperienceType.VOLUNTEER, List.of("활동명", "기관/단체", "활동 기간", "역할"));
-        PRESET_MAP.put(ExperienceType.EXCHANGE, List.of("국가/도시", "학교명", "파견 기간", "전공/수강 분야"));
+        PRESET_MAP.put(ExperienceType.PROJECT, List.of(
+                new PresetField("project_name", "프로젝트명"),
+                new PresetField("period", "진행 기간"),
+                new PresetField("role", "역할"),
+                new PresetField("organization", "소속/팀"),
+                new PresetField("achievements", "주요 성과")
+        ));
+        PRESET_MAP.put(ExperienceType.ACTIVITY, List.of(
+                new PresetField("activity_name", "활동명"),
+                new PresetField("organization", "주관기관"),
+                new PresetField("period", "활동 기간"),
+                new PresetField("role", "역할"),
+                new PresetField("achievements", "주요 성과")
+        ));
+        PRESET_MAP.put(ExperienceType.INTERN, List.of(
+                new PresetField("organization", "회사/기관명"),
+                new PresetField("department", "직무/부서"),
+                new PresetField("period", "근무/참여 기간"),
+                new PresetField("task", "담당 업무"),
+                new PresetField("achievements", "주요 성과")
+        ));
+        PRESET_MAP.put(ExperienceType.CONTEST, List.of(
+                new PresetField("competition_name", "공모전명"),
+                new PresetField("organization", "주관기관"),
+                new PresetField("period", "참가 기간"),
+                new PresetField("role", "역할"),
+                new PresetField("achievements", "수상/결과")
+        ));
+        PRESET_MAP.put(ExperienceType.VOLUNTEER, List.of(
+                new PresetField("activity_name", "활동명"),
+                new PresetField("organization", "기관/단체"),
+                new PresetField("period", "활동 기간"),
+                new PresetField("role", "역할")
+        ));
+        PRESET_MAP.put(ExperienceType.EXCHANGE, List.of(
+                new PresetField("location", "국가/도시"),
+                new PresetField("organization", "학교명"),
+                new PresetField("period", "파견 기간"),
+                new PresetField("major", "전공/수강 분야")
+        ));
+        PRESET_MAP.put(ExperienceType.ALBA, List.of(
+                new PresetField("workplace_name", "근무처명"),
+                new PresetField("period", "근무 기간"),
+                new PresetField("work_type", "업무 유형"),
+                new PresetField("task", "담당 업무"),
+                new PresetField("key_experience", "주요 경험")
+        ));
+        PRESET_MAP.put(ExperienceType.RESEARCH, List.of(
+                new PresetField("lab_name", "연구실명"),
+                new PresetField("organization", "소속 기관"),
+                new PresetField("period", "참여 기간"),
+                new PresetField("research_topic", "연구 주제"),
+                new PresetField("role", "담당 역할"),
+                new PresetField("deliverables", "주요 결과물")
+        ));
 
         // 스펙·증빙 (Spec) 프리셋 필드 정의
-        PRESET_MAP.put(ExperienceType.LANGUAGE, List.of("시험명", "점수/등급", "응시일", "유효기간", "성적표"));
-        PRESET_MAP.put(ExperienceType.LICENSE, List.of("자격증명", "발급기관", "취득일", "유효기간", "자격증 사본"));
-        PRESET_MAP.put(ExperienceType.AWARD, List.of("수상명", "수여기관", "수상일", "수상 구분", "수상 증빙"));
-        PRESET_MAP.put(ExperienceType.COURSE, List.of("과목명", "이수 학기", "학점", "성적", "관련 분야"));
-        PRESET_MAP.put(ExperienceType.EDUCATION, List.of("교육명", "운영기관", "교육 기간", "수료 여부", "수료증"));
+        PRESET_MAP.put(ExperienceType.LANGUAGE, List.of(
+                new PresetField("exam_name", "시험명"),
+                new PresetField("score", "점수/등급"),
+                new PresetField("exam_date", "응시일"),
+                new PresetField("expiration_date", "유효기간"),
+                new PresetField("score_report", "성적표")
+        ));
+        PRESET_MAP.put(ExperienceType.LICENSE, List.of(
+                new PresetField("certificate_name", "자격증명"),
+                new PresetField("organization", "발급기관"),
+                new PresetField("acquisition_date", "취득일"),
+                new PresetField("expiration_date", "유효기간"),
+                new PresetField("certificate_copy", "자격증 사본")
+        ));
+        PRESET_MAP.put(ExperienceType.AWARD, List.of(
+                new PresetField("award_name", "수상명"),
+                new PresetField("organization", "수여기관"),
+                new PresetField("award_date", "수상일"),
+                new PresetField("award_grade", "수상 구분"),
+                new PresetField("award_proof", "수상 증빙")
+        ));
+        PRESET_MAP.put(ExperienceType.COURSE, List.of(
+                new PresetField("course_name", "과목명"),
+                new PresetField("semester", "이수 학기"),
+                new PresetField("credit", "학점"),
+                new PresetField("grade", "성적"),
+                new PresetField("major", "관련 분야")
+        ));
+        PRESET_MAP.put(ExperienceType.EDUCATION, List.of(
+                new PresetField("education_name", "교육명"),
+                new PresetField("organization", "운영기관"),
+                new PresetField("period", "교육 기간"),
+                new PresetField("completion_status", "수료 여부"),
+                new PresetField("completion_certificate", "수료증")
+        ));
     }
 
-    public List<String> getPresetKeys(ExperienceType type) {
+    public List<PresetField> getPresetFields(ExperienceType type) {
         return PRESET_MAP.getOrDefault(type, Collections.emptyList());
     }
 
@@ -35,15 +119,37 @@ public class PresetRegistry {
      */
     public String normalizeKey(ExperienceType type, String rawKey) {
         if (rawKey == null) return null;
-        String cleanKey = rawKey.replace(" ", "").trim();
-        List<String> standardKeys = getPresetKeys(type);
+        String cleanKey = clean(rawKey);
 
-        for (String stdKey : standardKeys) {
-            String cleanStd = stdKey.replace(" ", "");
-            if (cleanStd.contains(cleanKey) || cleanKey.contains(cleanStd)) {
-                return stdKey; // 일치하는 표준 프리셋 필드가 감지되면 해당 표준 필드명 리턴
+        for (PresetField field : getPresetFields(type)) {
+            String cleanFieldKey = clean(field.key());
+            String cleanFieldLabel = clean(field.label());
+            if (cleanFieldKey.equals(cleanKey) || cleanFieldLabel.equals(cleanKey)) {
+                return field.key();
             }
         }
-        return rawKey; // 완전 새로운 커스텀 필드라면 그대로 유지시킴
+        return rawKey;
+    }
+
+    public Map<String, Object> normalizeAttributes(
+            ExperienceType type,
+            Map<String, Object> attributes
+    ) {
+        if (attributes == null || attributes.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+
+        Map<String, Object> normalizedAttributes = new LinkedHashMap<>();
+        attributes.forEach((key, value) ->
+                normalizedAttributes.put(normalizeKey(type, key), value)
+        );
+        return normalizedAttributes;
+    }
+
+    private String clean(String value) {
+        return value.replace(" ", "")
+                .replace("_", "")
+                .trim()
+                .toLowerCase(Locale.ROOT);
     }
 }

--- a/src/test/java/back/pickd/user/service/ExperienceExtractionServiceTest.java
+++ b/src/test/java/back/pickd/user/service/ExperienceExtractionServiceTest.java
@@ -11,6 +11,7 @@ import back.pickd.user.entity.enums.ExperienceType;
 import back.pickd.user.entity.enums.Status;
 import back.pickd.user.repository.ExperienceTempRepository;
 import back.pickd.user.repository.UserExperienceRepository;
+import back.pickd.user.utils.PresetRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +48,9 @@ class ExperienceExtractionServiceTest {
 
     @Mock
     private ExperienceMergeService experienceMergeService;
+
+    @Mock
+    private PresetRegistry presetRegistry;
 
     @InjectMocks
     private ExperienceExtractionService experienceExtractionService;
@@ -96,6 +100,7 @@ class ExperienceExtractionServiceTest {
         ExperienceStep3Request request = objectMapper.readValue(requestJson, ExperienceStep3Request.class);
 
         when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(presetRegistry.normalizeAttributes(any(ExperienceType.class), any())).thenAnswer(invocation -> invocation.getArgument(1));
         when(experienceRepository.save(any(UserExperience.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         ExperienceStep3Response response = experienceExtractionService.confirmStep3("user@example.com", request);

--- a/src/test/java/back/pickd/user/utils/PresetRegistryTest.java
+++ b/src/test/java/back/pickd/user/utils/PresetRegistryTest.java
@@ -1,0 +1,71 @@
+package back.pickd.user.utils;
+
+import back.pickd.user.entity.enums.ExperienceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PresetRegistryTest {
+
+    private PresetRegistry presetRegistry;
+
+    @BeforeEach
+    void setUp() {
+        presetRegistry = new PresetRegistry();
+    }
+
+    @Test
+    @DisplayName("영문 키가 그대로 들어오면 정상적으로 매칭된다")
+    void normalizeKey_withEnglishKey() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "project_name");
+        assertEquals("project_name", result);
+    }
+
+    @Test
+    @DisplayName("대소문자 및 언더스코어가 혼합된 키도 정상적으로 정규화된다")
+    void normalizeKey_withMixedCaseAndUnderscore() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "Project_Name");
+        assertEquals("project_name", result);
+    }
+
+    @Test
+    @DisplayName("한글 라벨이 들어오면 매칭되는 영문 키로 변환된다")
+    void normalizeKey_withKoreanLabel() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "프로젝트명");
+        assertEquals("project_name", result);
+    }
+
+    @Test
+    @DisplayName("공백이 포함된 한글 라벨도 정상적으로 영문 키로 변환된다")
+    void normalizeKey_withSpacedKoreanLabel() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "프로젝트 명");
+        assertEquals("project_name", result);
+    }
+
+    @Test
+    @DisplayName("매칭되는 키나 라벨이 없는 커스텀 필드는 원본 키를 그대로 반환한다")
+    void normalizeKey_withCustomField() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "사용자 정의 필드");
+        assertEquals("사용자 정의 필드", result);
+    }
+
+    @Test
+    @DisplayName("normalizeAttributes는 Map 내의 모든 키를 정규화하여 반환한다")
+    void normalizeAttributes() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("프로젝트 명", "픽드 백엔드");
+        input.put("Period", "2023.01 ~ 2023.12");
+        input.put("알 수 없는 필드", "커스텀 값");
+
+        Map<String, Object> result = presetRegistry.normalizeAttributes(ExperienceType.PROJECT, input);
+
+        assertEquals("픽드 백엔드", result.get("project_name"));
+        assertEquals("2023.01 ~ 2023.12", result.get("period"));
+        assertEquals("커스텀 값", result.get("알 수 없는 필드"));
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용

PresetRegistry의 키 정규화 기능에 대한 단위 테스트를 추가했습니다.

### 주요 검증 항목

- 영문 키 입력 시 정상 매핑 여부 검증
- 대소문자 및 언더스코어가 혼합된 키 정규화 검증
- 한글 라벨 → 영문 키 변환 검증
- 공백이 포함된 한글 라벨 변환 검증
- 매칭되지 않는 사용자 정의 필드 처리 검증
- `normalizeAttributes()`를 통한 Map 전체 키 정규화 검증

---

## 🧪 테스트 내용

### normalizeKey()

| 입력값 | 기대 결과 |
|---------|------------|
| `project_name` | `project_name` |
| `Project_Name` | `project_name` |
| `프로젝트명` | `project_name` |
| `프로젝트 명` | `project_name` |
| `사용자 정의 필드` | `사용자 정의 필드` |

### normalizeAttributes()

입력 Map 내의 모든 키를 순회하며 정규화된 키로 변환되는지 검증

예시

- `프로젝트 명` → `project_name`
- `Period` → `period`
- `알 수 없는 필드` → 원본 유지

---

## 🎯 추가 배경

프론트엔드, AI 서버, 사용자 입력 등 다양한 경로에서 동일한 의미의 필드가 서로 다른 형식(한글/영문, 대소문자, 공백 포함)으로 전달될 수 있습니다.

PresetRegistry의 정규화 로직이 이러한 입력을 일관된 내부 키로 변환하는지 검증하기 위해 테스트를 추가했습니다.

---

## ✅ 기대 효과

- 다양한 입력 형태에 대한 안정적인 키 매핑 보장
- 필드명 형식 차이로 인한 데이터 매핑 오류 방지
- PresetRegistry 리팩토링 시 회귀(regression) 테스트 역할 수행

---

## ✔️ 테스트 결과

- 전체 테스트 통과
- 기존 기능 영향 없음
- 메서드 커버리지 100

<img width="612" height="169" alt="image" src="https://github.com/user-attachments/assets/64da8002-bc5f-4d99-bf83-096d9e9d1b37" />
