### PR TITLE
feat : 프리셋 로직 단위 테스트 실행

### DIFF
--- a/src/test/java/back/pickd/user/service/ExperienceExtractionServiceTest.java
+++ b/src/test/java/back/pickd/user/service/ExperienceExtractionServiceTest.java
@@ -11,6 +11,7 @@ import back.pickd.user.entity.enums.ExperienceType;
 import back.pickd.user.entity.enums.Status;
 import back.pickd.user.repository.ExperienceTempRepository;
 import back.pickd.user.repository.UserExperienceRepository;
+import back.pickd.user.utils.PresetRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +48,9 @@ class ExperienceExtractionServiceTest {
 
     @Mock
     private ExperienceMergeService experienceMergeService;
+
+    @Mock
+    private PresetRegistry presetRegistry;
 
     @InjectMocks
     private ExperienceExtractionService experienceExtractionService;
@@ -96,6 +100,7 @@ class ExperienceExtractionServiceTest {
         ExperienceStep3Request request = objectMapper.readValue(requestJson, ExperienceStep3Request.class);
 
         when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(presetRegistry.normalizeAttributes(any(ExperienceType.class), any())).thenAnswer(invocation -> invocation.getArgument(1));
         when(experienceRepository.save(any(UserExperience.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         ExperienceStep3Response response = experienceExtractionService.confirmStep3("user@example.com", request);

--- a/src/test/java/back/pickd/user/utils/PresetRegistryTest.java
+++ b/src/test/java/back/pickd/user/utils/PresetRegistryTest.java
@@ -1,0 +1,71 @@
+package back.pickd.user.utils;
+
+import back.pickd.user.entity.enums.ExperienceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PresetRegistryTest {
+
+    private PresetRegistry presetRegistry;
+
+    @BeforeEach
+    void setUp() {
+        presetRegistry = new PresetRegistry();
+    }
+
+    @Test
+    @DisplayName("영문 키가 그대로 들어오면 정상적으로 매칭된다")
+    void normalizeKey_withEnglishKey() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "project_name");
+        assertEquals("project_name", result);
+    }
+
+    @Test
+    @DisplayName("대소문자 및 언더스코어가 혼합된 키도 정상적으로 정규화된다")
+    void normalizeKey_withMixedCaseAndUnderscore() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "Project_Name");
+        assertEquals("project_name", result);
+    }
+
+    @Test
+    @DisplayName("한글 라벨이 들어오면 매칭되는 영문 키로 변환된다")
+    void normalizeKey_withKoreanLabel() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "프로젝트명");
+        assertEquals("project_name", result);
+    }
+
+    @Test
+    @DisplayName("공백이 포함된 한글 라벨도 정상적으로 영문 키로 변환된다")
+    void normalizeKey_withSpacedKoreanLabel() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "프로젝트 명");
+        assertEquals("project_name", result);
+    }
+
+    @Test
+    @DisplayName("매칭되는 키나 라벨이 없는 커스텀 필드는 원본 키를 그대로 반환한다")
+    void normalizeKey_withCustomField() {
+        String result = presetRegistry.normalizeKey(ExperienceType.PROJECT, "사용자 정의 필드");
+        assertEquals("사용자 정의 필드", result);
+    }
+
+    @Test
+    @DisplayName("normalizeAttributes는 Map 내의 모든 키를 정규화하여 반환한다")
+    void normalizeAttributes() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("프로젝트 명", "픽드 백엔드");
+        input.put("Period", "2023.01 ~ 2023.12");
+        input.put("알 수 없는 필드", "커스텀 값");
+
+        Map<String, Object> result = presetRegistry.normalizeAttributes(ExperienceType.PROJECT, input);
+
+        assertEquals("픽드 백엔드", result.get("project_name"));
+        assertEquals("2023.01 ~ 2023.12", result.get("period"));
+        assertEquals("커스텀 값", result.get("알 수 없는 필드"));
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용

PresetRegistry의 키 정규화 기능에 대한 단위 테스트를 추가했습니다.

### 주요 검증 항목

- 영문 키 입력 시 정상 매핑 여부 검증
- 대소문자 및 언더스코어가 혼합된 키 정규화 검증
- 한글 라벨 → 영문 키 변환 검증
- 공백이 포함된 한글 라벨 변환 검증
- 매칭되지 않는 사용자 정의 필드 처리 검증
- `normalizeAttributes()`를 통한 Map 전체 키 정규화 검증

---

## 🧪 테스트 내용

### normalizeKey()

| 입력값 | 기대 결과 |
|---------|------------|
| `project_name` | `project_name` |
| `Project_Name` | `project_name` |
| `프로젝트명` | `project_name` |
| `프로젝트 명` | `project_name` |
| `사용자 정의 필드` | `사용자 정의 필드` |

### normalizeAttributes()

입력 Map 내의 모든 키를 순회하며 정규화된 키로 변환되는지 검증

예시

- `프로젝트 명` → `project_name`
- `Period` → `period`
- `알 수 없는 필드` → 원본 유지

---

## 🎯 추가 배경

프론트엔드, AI 서버, 사용자 입력 등 다양한 경로에서 동일한 의미의 필드가 서로 다른 형식(한글/영문, 대소문자, 공백 포함)으로 전달될 수 있습니다.

PresetRegistry의 정규화 로직이 이러한 입력을 일관된 내부 키로 변환하는지 검증하기 위해 테스트를 추가했습니다.

---

## ✅ 기대 효과

- 다양한 입력 형태에 대한 안정적인 키 매핑 보장
- 필드명 형식 차이로 인한 데이터 매핑 오류 방지
- PresetRegistry 리팩토링 시 회귀(regression) 테스트 역할 수행

---

## ✔️ 테스트 결과

- 전체 테스트 통과
- 기존 기능 영향 없음
- 메서드 커버리지 100

<img width="612" height="169" alt="image" src="https://github.com/user-attachments/assets/64da8002-bc5f-4d99-bf83-096d9e9d1b37" />
