### PR TITLE
feat : 사용자 기본 정보 조회 응답 보강

### DIFF
--- a/src/main/java/back/pickd/user/controller/UserController.java
+++ b/src/main/java/back/pickd/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package back.pickd.user.controller;
 
-import back.pickd.user.dto.UserResponseDto;
+import back.pickd.user.dto.UserProfileDto;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -15,14 +15,9 @@ public class UserController {
 
     private final UserService userService;
 
-@GetMapping
-public ResponseEntity<UserResponseDto> getUser(Authentication authentication) {
-    User user = userService.findByEmail(authentication.getName());
-
-    return ResponseEntity.ok(
-            UserResponseDto.builder()
-                    .nickname(user.getNickname())
-                    .build()
-    );
-}
+    @GetMapping
+    public ResponseEntity<UserProfileDto> getUser(Authentication authentication) {
+        User user = userService.findByEmail(authentication.getName());
+        return ResponseEntity.ok(UserProfileDto.from(user));
+    }
 }

--- a/src/main/java/back/pickd/user/dto/UserProfileDto.java
+++ b/src/main/java/back/pickd/user/dto/UserProfileDto.java
@@ -1,0 +1,100 @@
+package back.pickd.user.dto;
+
+import back.pickd.user.entity.User;
+import back.pickd.user.entity.UserEducation;
+import back.pickd.user.entity.UserInterest;
+import back.pickd.user.entity.UserLocation;
+import back.pickd.user.entity.UserPrepStatus;
+import back.pickd.user.entity.enums.DegreeType;
+import back.pickd.user.entity.enums.EnrollmentStatus;
+import back.pickd.user.entity.enums.OnboardingStep;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserProfileDto {
+
+    private String email;
+    private String name;
+    private String nickname;
+    private String picture;
+    private String phone;
+    private String birthDate;
+    private String intro;
+    private OnboardingStep onboardingStep;
+
+    private String currentResidence;
+    private List<String> desiredLocations;
+    private String detailedAddress;
+
+    private String schoolName;
+    private String department;
+    private String doubleMajor;
+    private String minor;
+    private DegreeType degreeType;
+    private EnrollmentStatus enrollmentStatus;
+    private String graduationDate;
+    private Double gpa;
+    private String campus;
+
+    private List<String> industries;
+    private List<String> jobGroups;
+    private String employmentType;
+    private List<String> companyTypes;
+    private List<String> keywords;
+    private String targetCompany;
+    private String salaryRange;
+
+    private String targetPeriod;
+    private String currentStage;
+    private List<String> focusItems;
+    private Boolean hasResume;
+    private Boolean hasBaseEssay;
+    private Boolean hasPortfolio;
+
+    public static UserProfileDto from(User user) {
+        UserLocation location = user.getLocation();
+        UserEducation education = user.getEducation();
+        UserInterest interest = user.getInterest();
+        UserPrepStatus prepStatus = user.getPrepStatus();
+
+        return UserProfileDto.builder()
+                .email(user.getEmail())
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .picture(user.getPicture())
+                .phone(user.getPhone())
+                .birthDate(user.getBirthDate())
+                .intro(user.getIntro())
+                .onboardingStep(user.getOnboardingStep())
+                .currentResidence(location != null ? location.getCurrentResidence() : null)
+                .desiredLocations(location != null ? location.getDesiredLocations() : null)
+                .detailedAddress(location != null ? location.getDetailedAddress() : null)
+                .schoolName(education != null ? education.getSchoolName() : null)
+                .department(education != null ? education.getDepartment() : null)
+                .doubleMajor(education != null ? education.getDoubleMajor() : null)
+                .minor(education != null ? education.getMinor() : null)
+                .degreeType(education != null ? education.getDegreeType() : null)
+                .enrollmentStatus(education != null ? education.getEnrollmentStatus() : null)
+                .graduationDate(education != null ? education.getGraduationDate() : null)
+                .gpa(education != null ? education.getGpa() : null)
+                .campus(education != null ? education.getCampus() : null)
+                .industries(interest != null ? interest.getIndustries() : null)
+                .jobGroups(interest != null ? interest.getJobGroups() : null)
+                .employmentType(interest != null ? interest.getEmploymentType() : null)
+                .companyTypes(interest != null ? interest.getCompanyTypes() : null)
+                .keywords(interest != null ? interest.getKeywords() : null)
+                .targetCompany(interest != null ? interest.getTargetCompany() : null)
+                .salaryRange(interest != null ? interest.getSalaryRange() : null)
+                .targetPeriod(prepStatus != null ? prepStatus.getTargetPeriod() : null)
+                .currentStage(prepStatus != null ? prepStatus.getCurrentStage() : null)
+                .focusItems(prepStatus != null ? prepStatus.getFocusItems() : null)
+                .hasResume(prepStatus != null ? prepStatus.isHasResume() : null)
+                .hasBaseEssay(prepStatus != null ? prepStatus.isHasBaseEssay() : null)
+                .hasPortfolio(prepStatus != null ? prepStatus.isHasPortfolio() : null)
+                .build();
+    }
+}

--- a/src/test/java/back/pickd/user/dto/UserProfileDtoTest.java
+++ b/src/test/java/back/pickd/user/dto/UserProfileDtoTest.java
@@ -1,0 +1,81 @@
+package back.pickd.user.dto;
+
+import back.pickd.user.entity.User;
+import back.pickd.user.entity.UserEducation;
+import back.pickd.user.entity.UserInterest;
+import back.pickd.user.entity.UserLocation;
+import back.pickd.user.entity.UserPrepStatus;
+import back.pickd.user.entity.enums.DegreeType;
+import back.pickd.user.entity.enums.EnrollmentStatus;
+import back.pickd.user.entity.enums.OnboardingStep;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserProfileDtoTest {
+
+    @Test
+    void fromMapsOnboardingProfileFields() {
+        User user = User.builder()
+                .email("user@example.com")
+                .name("기존 이름")
+                .nickname("픽디")
+                .picture("https://example.com/profile.png")
+                .onboardingStep(OnboardingStep.COMPLETED)
+                .build();
+        user.verify("홍길동", "20010315", "010-0000-0000");
+        user.updateIntro("백엔드 개발자를 준비하고 있습니다.");
+        user.setLocation(UserLocation.builder()
+                .user(user)
+                .currentResidence("부산광역시")
+                .desiredLocations(List.of("서울", "부산"))
+                .detailedAddress("센텀로 17")
+                .build());
+        user.setEducation(UserEducation.builder()
+                .user(user)
+                .schoolName("부산대학교")
+                .department("경영학과")
+                .degreeType(DegreeType.BACHELOR)
+                .enrollmentStatus(EnrollmentStatus.ENROLLED)
+                .graduationDate("2026-02")
+                .gpa(4.1)
+                .campus("부산")
+                .build());
+        user.setInterest(UserInterest.builder()
+                .user(user)
+                .industries(List.of("IT"))
+                .jobGroups(List.of("백엔드"))
+                .employmentType("FULL_TIME")
+                .companyTypes(List.of("스타트업"))
+                .keywords(List.of("Spring"))
+                .targetCompany("카카오")
+                .salaryRange("3000~4000")
+                .build());
+        user.setPrepStatus(UserPrepStatus.builder()
+                .user(user)
+                .targetPeriod("2026 상반기")
+                .currentStage("서류 준비")
+                .focusItems(List.of("이력서", "자소서"))
+                .hasResume(true)
+                .hasBaseEssay(false)
+                .hasPortfolio(true)
+                .build());
+
+        UserProfileDto response = UserProfileDto.from(user);
+
+        assertEquals("user@example.com", response.getEmail());
+        assertEquals("홍길동", response.getName());
+        assertEquals("010-0000-0000", response.getPhone());
+        assertEquals("부산광역시", response.getCurrentResidence());
+        assertEquals(List.of("서울", "부산"), response.getDesiredLocations());
+        assertEquals("부산대학교", response.getSchoolName());
+        assertEquals("경영학과", response.getDepartment());
+        assertEquals(List.of("백엔드"), response.getJobGroups());
+        assertEquals("2026 상반기", response.getTargetPeriod());
+        assertTrue(response.getHasResume());
+        assertTrue(response.getHasPortfolio());
+    }
+}


### PR DESCRIPTION
# 변경점 👍
 - 사용자 기본 정보 조회 응답 DTO 추가 (UserProfileDto)
 - Dto 매핑 테스트 추가 (UserProfileDtoTest)


# 응답 주요 정보
- 기본 정보: `email`, `name`, `nickname`, `picture`, `phone`, `birthDate`, `intro`, `onboardingStep`
- 위치 정보: `currentResidence`, `desiredLocations`, `detailedAddress`
- 학력 정보: `schoolName`, `department`, `doubleMajor`, `minor`, `degreeType`, `enrollmentStatus`, `graduationDate`, `gpa`, `campus`
- 관심 정보: `industries`, `jobGroups`, `employmentType`, `companyTypes`, `keywords`, `targetCompany`, `salaryRange`
- 준비 상태: `targetPeriod`, `currentStage`, `focusItems`, `hasResume`, `hasBaseEssay`, `hasPortfolio`