### PR TITLE
feat : 기본 프로필 사진 업로드 및 조회 API 구현

### DIFF
--- a/src/main/java/back/pickd/global/infra/s3/FileUploadType.java
+++ b/src/main/java/back/pickd/global/infra/s3/FileUploadType.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum FileUploadType {
+    PROFILE("user/profile"),
     LICENSE("experience/license"),
     EDUCATION("experience/education"),
     LANGUAGE("experience/language"),

--- a/src/main/java/back/pickd/user/controller/UserController.java
+++ b/src/main/java/back/pickd/user/controller/UserController.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/user")
@@ -15,14 +18,22 @@ public class UserController {
 
     private final UserService userService;
 
-@GetMapping
-public ResponseEntity<UserResponseDto> getUser(Authentication authentication) {
-    User user = userService.findByEmail(authentication.getName());
+    @GetMapping
+    public ResponseEntity<UserResponseDto> getUser(Authentication authentication) {
+        User user = userService.findByEmail(authentication.getName());
 
-    return ResponseEntity.ok(
-            UserResponseDto.builder()
-                    .nickname(user.getNickname())
-                    .build()
-    );
-}
+        return ResponseEntity.ok(
+                UserResponseDto.builder()
+                        .nickname(user.getNickname())
+                        .build()
+        );
+    }
+
+    @PostMapping("/profile-image")
+    public ResponseEntity<Map<String, String>> uploadProfileImage(
+            Authentication authentication,
+            @RequestParam("file") MultipartFile file) {
+        String profileImageUrl = userService.updateProfileImage(authentication.getName(), file);
+        return ResponseEntity.ok(Map.of("profileImageUrl", profileImageUrl));
+    }
 }

--- a/src/main/java/back/pickd/user/controller/UserController.java
+++ b/src/main/java/back/pickd/user/controller/UserController.java
@@ -36,4 +36,10 @@ public class UserController {
         String profileImageUrl = userService.updateProfileImage(authentication.getName(), file);
         return ResponseEntity.ok(Map.of("profileImageUrl", profileImageUrl));
     }
+
+    @GetMapping("/profile-image")
+    public ResponseEntity<Map<String, String>> getProfileImage(Authentication authentication) {
+        String profileImageUrl = userService.getProfileImage(authentication.getName());
+        return ResponseEntity.ok(Map.of("profileImageUrl", profileImageUrl));
+    }
 }

--- a/src/main/java/back/pickd/user/entity/User.java
+++ b/src/main/java/back/pickd/user/entity/User.java
@@ -123,6 +123,10 @@ public class User {
         return this;
     }
 
+    public void updatePicture(String picture) {
+        this.picture = picture;
+    }
+
     public void updateTerms(boolean serviceAgreed, boolean privacyAgreed, boolean marketingAgreed, boolean pushAgreed) {
         this.serviceAgreed = serviceAgreed;
         this.privacyAgreed = privacyAgreed;

--- a/src/main/java/back/pickd/user/service/UserService.java
+++ b/src/main/java/back/pickd/user/service/UserService.java
@@ -3,6 +3,7 @@ package back.pickd.user.service;
 import back.pickd.global.infra.s3.FileUploadType;
 import back.pickd.global.infra.s3.S3Service;
 import back.pickd.user.entity.User;
+import back.pickd.user.entity.enums.OnboardingStep;
 import back.pickd.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,7 @@ public class UserService {
                         .email(email)
                         .name(name)
                         .picture(picture)
-                        .onboardingStep(back.pickd.user.entity.enums.OnboardingStep.NONE)
+                        .onboardingStep(OnboardingStep.NONE)
                         .build());
 
         return userRepository.save(user);

--- a/src/main/java/back/pickd/user/service/UserService.java
+++ b/src/main/java/back/pickd/user/service/UserService.java
@@ -46,4 +46,9 @@ public class UserService {
         user.updatePicture(profileImageUrl);
         return profileImageUrl;
     }
+
+    @Transactional(readOnly = true)
+    public String getProfileImage(String email) {
+        return findByEmail(email).getPicture();
+    }
 }

--- a/src/main/java/back/pickd/user/service/UserService.java
+++ b/src/main/java/back/pickd/user/service/UserService.java
@@ -1,38 +1,49 @@
 package back.pickd.user.service;
 
+import back.pickd.global.infra.s3.FileUploadType;
+import back.pickd.global.infra.s3.S3Service;
 import back.pickd.user.entity.User;
 import back.pickd.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     /**
      * Save or Update user info from Google OAuth2 attributes
      */
-        @Transactional
-        public User saveOrUpdate(String email, String name, String picture) {
-            User user = userRepository.findByEmail(email)
-                    .map(entity -> entity.update(name, picture))
-                    .orElse(User.builder()
-                            .email(email)
-                            .name(name)
-                            .picture(picture)
-                            .onboardingStep(back.pickd.user.entity.enums.OnboardingStep.NONE)
-                            .build());
-    
-            return userRepository.save(user);
-        }
-    
-        @Transactional(readOnly = true)
-        public User findByEmail(String email) {
-            return userRepository.findByEmail(email)
-                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. email: " + email));
-        }
+    @Transactional
+    public User saveOrUpdate(String email, String name, String picture) {
+        User user = userRepository.findByEmail(email)
+                .map(entity -> entity.update(name, picture))
+                .orElse(User.builder()
+                        .email(email)
+                        .name(name)
+                        .picture(picture)
+                        .onboardingStep(back.pickd.user.entity.enums.OnboardingStep.NONE)
+                        .build());
+
+        return userRepository.save(user);
     }
-    
+
+    @Transactional(readOnly = true)
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. email: " + email));
+    }
+
+    @Transactional
+    public String updateProfileImage(String email, MultipartFile file) {
+        User user = findByEmail(email);
+        String profileImageUrl = s3Service.uploadFile(file, FileUploadType.PROFILE, user.getId());
+        user.updatePicture(profileImageUrl);
+        return profileImageUrl;
+    }
+}

--- a/src/test/java/back/pickd/user/service/UserServiceTest.java
+++ b/src/test/java/back/pickd/user/service/UserServiceTest.java
@@ -1,0 +1,56 @@
+package back.pickd.user.service;
+
+import back.pickd.global.infra.s3.FileUploadType;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.entity.User;
+import back.pickd.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void updateProfileImageUploadsFileAndUpdatesPicture() {
+        User user = User.builder()
+                .email("user@example.com")
+                .name("테스트")
+                .build();
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.png",
+                "image/png",
+                "image".getBytes()
+        );
+        String imageUrl = "https://cdn.example.com/user/profile/1/profile.png";
+
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+        when(s3Service.uploadFile(file, FileUploadType.PROFILE, user.getId()))
+                .thenReturn(imageUrl);
+
+        String result = userService.updateProfileImage("user@example.com", file);
+
+        assertEquals(imageUrl, result);
+        assertEquals(imageUrl, user.getPicture());
+        verify(s3Service).uploadFile(file, FileUploadType.PROFILE, user.getId());
+    }
+}

--- a/src/test/java/back/pickd/user/service/UserServiceTest.java
+++ b/src/test/java/back/pickd/user/service/UserServiceTest.java
@@ -53,4 +53,19 @@ class UserServiceTest {
         assertEquals(imageUrl, user.getPicture());
         verify(s3Service).uploadFile(file, FileUploadType.PROFILE, user.getId());
     }
+
+    @Test
+    void getProfileImageReturnsUserPicture() {
+        User user = User.builder()
+                .email("user@example.com")
+                .name("테스트")
+                .picture("https://cdn.example.com/user/profile/1/profile.png")
+                .build();
+
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        String result = userService.getProfileImage("user@example.com");
+
+        assertEquals("https://cdn.example.com/user/profile/1/profile.png", result);
+    }
 }


### PR DESCRIPTION
# 변경점 👍
- 기본 프로필 사진 업로드 API 구현
- 대표 프로필 사진 조회 API 구현

## 테스트

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew test --tests UserServiceTest
