### PR TITLE
feat : 프로필 사진 목록 관리 API 구현

### DIFF
--- a/src/main/java/back/pickd/user/photo/UserPhoto.java
+++ b/src/main/java/back/pickd/user/photo/UserPhoto.java
@@ -1,0 +1,46 @@
+package back.pickd.user.photo;
+
+import back.pickd.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    private String originalFilename;
+
+    @Column(nullable = false)
+    private boolean isPublic;
+
+    @Column(nullable = false)
+    private boolean isRepresentative;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateRepresentative(boolean representative) {
+        this.isRepresentative = representative;
+    }
+}

--- a/src/main/java/back/pickd/user/photo/UserPhotoController.java
+++ b/src/main/java/back/pickd/user/photo/UserPhotoController.java
@@ -1,0 +1,42 @@
+package back.pickd.user.photo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/user/photos")
+@RequiredArgsConstructor
+public class UserPhotoController {
+
+    private final UserPhotoService userPhotoService;
+
+    @PostMapping
+    public ResponseEntity<UserPhotoResponse> uploadPhoto(
+            Authentication authentication,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(defaultValue = "false") boolean isPublic,
+            @RequestParam(defaultValue = "false") boolean isRepresentative) {
+        return ResponseEntity.ok(
+                userPhotoService.uploadPhoto(authentication.getName(), file, isPublic, isRepresentative)
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<List<UserPhotoResponse>> getPhotos(Authentication authentication) {
+        return ResponseEntity.ok(userPhotoService.getPhotos(authentication.getName()));
+    }
+
+    @PutMapping("/{photoId}/representative")
+    public ResponseEntity<UserPhotoResponse> updateRepresentative(
+            Authentication authentication,
+            @PathVariable Long photoId) {
+        return ResponseEntity.ok(
+                userPhotoService.updateRepresentative(authentication.getName(), photoId)
+        );
+    }
+}

--- a/src/main/java/back/pickd/user/photo/UserPhotoRepository.java
+++ b/src/main/java/back/pickd/user/photo/UserPhotoRepository.java
@@ -1,0 +1,15 @@
+package back.pickd.user.photo;
+
+import back.pickd.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserPhotoRepository extends JpaRepository<UserPhoto, Long> {
+    List<UserPhoto> findByUserOrderByCreatedAtDesc(User user);
+
+    Optional<UserPhoto> findByIdAndUser(Long id, User user);
+
+    Optional<UserPhoto> findByUserAndIsRepresentativeTrue(User user);
+}

--- a/src/main/java/back/pickd/user/photo/UserPhotoResponse.java
+++ b/src/main/java/back/pickd/user/photo/UserPhotoResponse.java
@@ -1,0 +1,11 @@
+package back.pickd.user.photo;
+
+import java.time.LocalDateTime;
+
+public record UserPhotoResponse(Long id, String imageUrl, String originalFilename,
+                                boolean isPublic, boolean isRepresentative, LocalDateTime createdAt) {
+    public UserPhotoResponse(UserPhoto photo) {
+        this(photo.getId(), photo.getImageUrl(), photo.getOriginalFilename(),
+                photo.isPublic(), photo.isRepresentative(), photo.getCreatedAt());
+    }
+}

--- a/src/main/java/back/pickd/user/photo/UserPhotoService.java
+++ b/src/main/java/back/pickd/user/photo/UserPhotoService.java
@@ -1,0 +1,74 @@
+package back.pickd.user.photo;
+
+import back.pickd.global.infra.s3.FileUploadType;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserPhotoService {
+
+    private final UserService userService;
+    private final UserPhotoRepository userPhotoRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public UserPhotoResponse uploadPhoto(
+            String email,
+            MultipartFile file,
+            boolean isPublic,
+            boolean isRepresentative
+    ) {
+        User user = userService.findByEmail(email);
+        String imageUrl = s3Service.uploadFile(file, FileUploadType.PROFILE, user.getId());
+
+        if (isRepresentative) {
+            clearRepresentative(user);
+            user.updatePicture(imageUrl);
+        }
+
+        UserPhoto photo = UserPhoto.builder()
+                .user(user)
+                .imageUrl(imageUrl)
+                .originalFilename(file.getOriginalFilename())
+                .isPublic(isPublic)
+                .isRepresentative(isRepresentative)
+                .build();
+
+        return new UserPhotoResponse(userPhotoRepository.save(photo));
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserPhotoResponse> getPhotos(String email) {
+        User user = userService.findByEmail(email);
+        return userPhotoRepository.findByUserOrderByCreatedAtDesc(user)
+                .stream()
+                .map(UserPhotoResponse::new)
+                .toList();
+    }
+
+    @Transactional
+    public UserPhotoResponse updateRepresentative(String email, Long photoId) {
+        User user = userService.findByEmail(email);
+        UserPhoto photo = userPhotoRepository.findByIdAndUser(photoId, user)
+                .orElseThrow(() -> new IllegalArgumentException("사진을 찾을 수 없습니다."));
+
+        clearRepresentative(user);
+        photo.updateRepresentative(true);
+        user.updatePicture(photo.getImageUrl());
+
+        return new UserPhotoResponse(photo);
+    }
+
+    private void clearRepresentative(User user) {
+        userPhotoRepository.findByUserAndIsRepresentativeTrue(user)
+                .ifPresent(photo -> photo.updateRepresentative(false));
+    }
+}

--- a/src/test/java/back/pickd/user/photo/UserPhotoServiceTest.java
+++ b/src/test/java/back/pickd/user/photo/UserPhotoServiceTest.java
@@ -1,0 +1,109 @@
+package back.pickd.user.photo;
+
+import back.pickd.global.infra.s3.FileUploadType;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserPhotoServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UserPhotoRepository userPhotoRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private UserPhotoService userPhotoService;
+
+    @Test
+    void uploadPhotoSavesPhotoAndUpdatesRepresentative() {
+        User user = createUser();
+        MockMultipartFile file = createFile();
+        UserPhoto currentRepresentative = createPhoto(user, 1L, "old-url", true);
+        String imageUrl = "https://cdn.example.com/user/profile/1/new.png";
+        when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(s3Service.uploadFile(file, FileUploadType.PROFILE, user.getId())).thenReturn(imageUrl);
+        when(userPhotoRepository.findByUserAndIsRepresentativeTrue(user))
+                .thenReturn(Optional.of(currentRepresentative));
+        when(userPhotoRepository.save(any(UserPhoto.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserPhotoResponse response =
+                userPhotoService.uploadPhoto("user@example.com", file, true, true);
+
+        assertEquals(imageUrl, response.imageUrl());
+        assertEquals("profile.png", response.originalFilename());
+        assertTrue(response.isPublic());
+        assertTrue(response.isRepresentative());
+        assertFalse(currentRepresentative.isRepresentative());
+        assertEquals(imageUrl, user.getPicture());
+        verify(userPhotoRepository).save(any(UserPhoto.class));
+    }
+
+    @Test
+    void getPhotosReturnsUserPhotos() {
+        User user = createUser();
+        UserPhoto photo = createPhoto(user, 1L, "image-url", false);
+        when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(userPhotoRepository.findByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(photo));
+
+        List<UserPhotoResponse> responses = userPhotoService.getPhotos("user@example.com");
+
+        assertEquals(1, responses.size());
+        assertEquals("image-url", responses.get(0).imageUrl());
+    }
+
+    @Test
+    void updateRepresentativeChangesRepresentativeAndUserPicture() {
+        User user = createUser();
+        UserPhoto currentRepresentative = createPhoto(user, 1L, "old-url", true);
+        UserPhoto targetPhoto = createPhoto(user, 2L, "new-url", false);
+        when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(userPhotoRepository.findByIdAndUser(2L, user)).thenReturn(Optional.of(targetPhoto));
+        when(userPhotoRepository.findByUserAndIsRepresentativeTrue(user))
+                .thenReturn(Optional.of(currentRepresentative));
+
+        UserPhotoResponse response =
+                userPhotoService.updateRepresentative("user@example.com", 2L);
+
+        assertFalse(currentRepresentative.isRepresentative());
+        assertTrue(targetPhoto.isRepresentative());
+        assertEquals("new-url", user.getPicture());
+        assertEquals("new-url", response.imageUrl());
+    }
+
+    private User createUser() {
+        return User.builder().email("user@example.com").name("테스트").build();
+    }
+
+    private MockMultipartFile createFile() {
+        return new MockMultipartFile("file", "profile.png", "image/png", "image".getBytes());
+    }
+
+    private UserPhoto createPhoto(User user, Long id, String imageUrl, boolean isRepresentative) {
+        return UserPhoto.builder()
+                .id(id)
+                .user(user)
+                .imageUrl(imageUrl)
+                .originalFilename("profile.png")
+                .isPublic(false)
+                .isRepresentative(isRepresentative)
+                .build();
+    }
+}


### PR DESCRIPTION
# 변경점 👍
- 프로필 사진 목록 관리를 위한 UserPhoto엔티티를 추가
- 프로필 사진 업로드 시 사진 정보를 DB에 저장
- 사용자의 프로필 사진 목록 조회, 여러 사진 중 대표사진 지정/변경 API 구현

## 프로필 사진 목록 조회
[
  {
    "id": 1,
    "imageUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/user/profile/1/example.png",
    "originalFilename": "example.png",
    "isPublic": true,
    "isRepresentative": true,
    "createdAt": "2026-06-21T15:30:00"
  }
]

## 대표사진 변경
{
  "id": 2,
  "imageUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/user/profile/1/another.png",
  "originalFilename": "another.png",
  "isPublic": false,
  "isRepresentative": true,
  "createdAt": "2026-06-21T15:40:00"
}

#테스트 
-프로필 사진 업로드 시 S3 업로드 결과 URL로 UserPhoto가 저장되는지 확인
-대표사진으로 업로드하는 경우 기존 대표사진 해제 및 User.picture 갱신 확인
-사진 목록 조회 시 사용자의 사진 목록이 응답 DTO로 변환되는지 확인
-대표사진 변경 시 선택한 사진만 대표사진으로 설정되고 User.picture가 변경되는지 확인
