### PR TITLE
[43 - Stack 2/6] 경험 중복 Draft 영속 모델 추가

### DIFF
--- a/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
@@ -1,0 +1,46 @@
+package back.pickd.experience.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_duplicate_groups")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceDuplicateGroup {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_id", nullable = false)
+    private ExperienceExtractionBatch batch;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "existing_experience_id", nullable = false)
+    private UserExperience existingExperience;
+
+    @OneToMany(mappedBy = "duplicateGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceExtractionDraft> drafts = new ArrayList<>();
+
+    public ExperienceDuplicateGroup(UserExperience existingExperience) {
+        this.id = UUID.randomUUID().toString();
+        this.existingExperience = existingExperience;
+    }
+
+    void attachTo(ExperienceExtractionBatch batch) {
+        this.batch = batch;
+    }
+
+    public void addDraft(ExperienceExtractionDraft draft) {
+        draft.attachTo(this);
+        drafts.add(draft);
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
@@ -1,0 +1,59 @@
+package back.pickd.experience.entity;
+
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_extraction_batches")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceExtractionBatch {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ExtractionBatchStatus status;
+
+    @OneToMany(mappedBy = "batch", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceDuplicateGroup> groups = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "processed_at")
+    private OffsetDateTime processedAt;
+
+    public ExperienceExtractionBatch(User user) {
+        this.id = UUID.randomUUID().toString();
+        this.user = user;
+        this.status = ExtractionBatchStatus.PENDING;
+        this.createdAt = OffsetDateTime.now();
+    }
+
+    public void addGroup(ExperienceDuplicateGroup group) {
+        group.attachTo(this);
+        groups.add(group);
+    }
+
+    public void complete() {
+        this.status = ExtractionBatchStatus.COMPLETED;
+        this.processedAt = OffsetDateTime.now();
+        this.groups.clear();
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionDraft.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionDraft.java
@@ -1,0 +1,93 @@
+package back.pickd.experience.entity;
+
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_extraction_drafts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceExtractionDraft {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "duplicate_group_id", nullable = false)
+    private ExperienceDuplicateGroup duplicateGroup;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_type", nullable = false, length = 50)
+    private ExperienceType experienceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_group", nullable = false, length = 20)
+    private ExperienceGroup experienceGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
+
+    @Column(name = "document_content", columnDefinition = "TEXT")
+    private String documentContent;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private Map<String, Object> attributes = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private List<String> keywords = new ArrayList<>();
+
+    @Column(name = "resume_url", nullable = false, columnDefinition = "TEXT")
+    private String resumeUrl;
+
+    @Column(name = "similarity")
+    private Double similarity;
+
+    @Builder
+    public ExperienceExtractionDraft(
+            String title,
+            ExperienceType experienceType,
+            ExperienceGroup experienceGroup,
+            Status status,
+            String documentContent,
+            Map<String, Object> attributes,
+            List<String> keywords,
+            String resumeUrl,
+            Double similarity
+    ) {
+        this.id = UUID.randomUUID().toString();
+        this.title = title;
+        this.experienceType = experienceType;
+        this.experienceGroup = experienceGroup;
+        this.status = status;
+        this.documentContent = documentContent;
+        this.attributes = attributes != null ? new HashMap<>(attributes) : new HashMap<>();
+        this.keywords = keywords != null ? new ArrayList<>(keywords) : new ArrayList<>();
+        this.resumeUrl = resumeUrl;
+        this.similarity = similarity;
+    }
+
+    void attachTo(ExperienceDuplicateGroup duplicateGroup) {
+        this.duplicateGroup = duplicateGroup;
+    }
+}

--- a/src/main/java/back/pickd/experience/enums/ExtractionBatchStatus.java
+++ b/src/main/java/back/pickd/experience/enums/ExtractionBatchStatus.java
@@ -1,0 +1,6 @@
+package back.pickd.experience.enums;
+
+public enum ExtractionBatchStatus {
+    PENDING,
+    COMPLETED
+}

--- a/src/main/java/back/pickd/experience/repository/ExperienceExtractionBatchRepository.java
+++ b/src/main/java/back/pickd/experience/repository/ExperienceExtractionBatchRepository.java
@@ -1,0 +1,25 @@
+package back.pickd.experience.repository;
+
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.user.entity.User;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.List;
+
+public interface ExperienceExtractionBatchRepository
+        extends JpaRepository<ExperienceExtractionBatch, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ExperienceExtractionBatch> findByIdAndUser(String id, User user);
+
+    List<ExperienceExtractionBatch> findByUserOrderByCreatedAtDesc(User user);
+
+    List<ExperienceExtractionBatch> findByUserAndStatusOrderByCreatedAtDesc(
+            User user,
+            ExtractionBatchStatus status
+    );
+}

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
@@ -25,7 +25,6 @@ import back.pickd.experience.support.PresetRegistry;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ExperienceExtractionService {
@@ -66,11 +64,14 @@ public class ExperienceExtractionService {
         List<ExperienceTemp> temps = new ArrayList<>();
         if (aiResponse.getExperiences() != null) {
             for (AiStep1Response.ExperienceSummaryDto summary : aiResponse.getExperiences()) {
+                ExperienceType type = convertType(summary.getExperience_type());
+                ExperienceGroup group = convertGroup(summary.getExperience_group());
+                validateGroupType(group, type);
                 ExperienceTemp temp = ExperienceTemp.builder()
                         .user(user)
                         .experienceName(summary.getExperience_name())
-                        .experienceGroup(summary.getExperience_group())
-                        .experienceType(summary.getExperience_type())
+                        .experienceGroup(toKoreanGroup(group))
+                        .experienceType(type.getKoreanName())
                         .resumeUrl(resumeUrl)
                         .build();
                 temps.add(tempRepository.save(temp));
@@ -198,18 +199,28 @@ public class ExperienceExtractionService {
     }
 
     private ExperienceGroup convertGroup(String koreanGroup) {
-        if ("상세 서술형".equals(koreanGroup)) {
-            return ExperienceGroup.NARRATIVE;
-        }
-        return ExperienceGroup.SPEC;
+        return switch (koreanGroup) {
+            case "상세 서술형" -> ExperienceGroup.NARRATIVE;
+            case "스펙·증빙형" -> ExperienceGroup.SPEC;
+            default -> throw new IllegalArgumentException(
+                    "지원하지 않는 경험 그룹입니다: " + koreanGroup
+            );
+        };
     }
 
     private ExperienceType convertType(String koreanType) {
-        try {
-            return ExperienceType.fromKoreanName(koreanType);
-        } catch (IllegalArgumentException e) {
-            log.warn("Unknown experience type '{}', fallback to PROJECT", koreanType);
-            return ExperienceType.PROJECT;
+        return ExperienceType.fromKoreanName(koreanType);
+    }
+
+    private void validateGroupType(ExperienceGroup group, ExperienceType type) {
+        if (presetRegistry.getExperienceGroup(type) != group) {
+            throw new IllegalArgumentException(
+                    "경험 그룹과 유형이 일치하지 않습니다: " + type.getKoreanName()
+            );
         }
+    }
+
+    private String toKoreanGroup(ExperienceGroup group) {
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
     }
 }

--- a/src/main/java/back/pickd/experience/support/PresetRegistry.java
+++ b/src/main/java/back/pickd/experience/support/PresetRegistry.java
@@ -1,6 +1,8 @@
 package back.pickd.experience.support;
 
+import back.pickd.experience.enums.ExperienceGroup;
 import back.pickd.experience.enums.ExperienceType;
+import back.pickd.global.infra.ai.dto.AiExperiencePresetSchema;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -13,6 +15,14 @@ public class PresetRegistry {
 
     private static final Map<ExperienceType, List<PresetField>> PRESET_MAP =
             new EnumMap<>(ExperienceType.class);
+
+    private static final Set<ExperienceType> SPEC_TYPES = EnumSet.of(
+            ExperienceType.LANGUAGE,
+            ExperienceType.LICENSE,
+            ExperienceType.AWARD,
+            ExperienceType.COURSE,
+            ExperienceType.EDUCATION
+    );
 
     static {
         // 상세 서술형 (Narrative) 프리셋 필드 정의
@@ -114,6 +124,30 @@ public class PresetRegistry {
         return PRESET_MAP.getOrDefault(type, Collections.emptyList());
     }
 
+    public ExperienceGroup getExperienceGroup(ExperienceType type) {
+        return SPEC_TYPES.contains(type) ? ExperienceGroup.SPEC : ExperienceGroup.NARRATIVE;
+    }
+
+    public List<AiExperiencePresetSchema> getAiPresetSchemas(Collection<ExperienceType> types) {
+        if (types == null || types.isEmpty()) {
+            return List.of();
+        }
+
+        return new LinkedHashSet<>(types).stream()
+                .map(type -> new AiExperiencePresetSchema(
+                        toKoreanGroup(getExperienceGroup(type)),
+                        type.name(),
+                        type.getKoreanName(),
+                        getPresetFields(type).stream()
+                                .map(field -> new AiExperiencePresetSchema.Field(
+                                        field.key(),
+                                        field.label()
+                                ))
+                                .toList()
+                ))
+                .toList();
+    }
+
     /**
      * AI가 자의적으로 바꾼 필드명(예: '역할분담', '배정부서')을 백엔드의 표준 키명으로 매핑해주는 보정 유틸리티
      */
@@ -151,5 +185,9 @@ public class PresetRegistry {
                 .replace("_", "")
                 .trim()
                 .toLowerCase(Locale.ROOT);
+    }
+
+    private String toKoreanGroup(ExperienceGroup group) {
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
     }
 }

--- a/src/main/java/back/pickd/global/infra/ai/AiClient.java
+++ b/src/main/java/back/pickd/global/infra/ai/AiClient.java
@@ -2,6 +2,7 @@ package back.pickd.global.infra.ai;
 
 import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
 import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckResponse;
+import back.pickd.global.infra.ai.dto.AiExperiencePresetSchema;
 import back.pickd.global.infra.ai.dto.AiStep1Response;
 import back.pickd.global.infra.ai.dto.AiStep2Response;
 import back.pickd.global.infra.ai.dto.AiJobPostingResponse;
@@ -108,6 +109,43 @@ public class AiClient {
 
         return restClient.post()
                 .uri("/api/v1/extract-experiences/step2")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(bodyBuilder.build())
+                .retrieve()
+                .body(AiStep2Response.class);
+    }
+
+    public AiStep2Response extractStep2V2ByUrl(
+            String resumeUrl,
+            List<AiStep1Response.ExperienceSummaryDto> selectedExperiences,
+            List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences,
+            List<AiExperiencePresetSchema> presetSchemas
+    ) {
+        MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder.part("url", resumeUrl);
+
+        try {
+            bodyBuilder.part(
+                    "selected_experiences",
+                    objectMapper.writeValueAsString(selectedExperiences)
+            );
+            bodyBuilder.part(
+                    "existing_experiences",
+                    objectMapper.writeValueAsString(
+                            existingExperiences != null ? existingExperiences : List.of()
+                    )
+            );
+            bodyBuilder.part(
+                    "preset_schemas",
+                    objectMapper.writeValueAsString(presetSchemas)
+            );
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize AI Step2 V2 request", e);
+            throw new RuntimeException("AI 분석 요청 중 직렬화 오류가 발생했습니다.", e);
+        }
+
+        return restClient.post()
+                .uri("/api/v1/extract-experiences/step2-v2")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(bodyBuilder.build())
                 .retrieve()

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiExperiencePresetSchema.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiExperiencePresetSchema.java
@@ -1,0 +1,30 @@
+package back.pickd.global.infra.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AiExperiencePresetSchema {
+
+    @JsonProperty("experience_group")
+    private final String experienceGroup;
+
+    @JsonProperty("experience_type")
+    private final String experienceType;
+
+    @JsonProperty("experience_type_name")
+    private final String experienceTypeName;
+
+    private final List<Field> fields;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Field {
+        private final String key;
+        private final String label;
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,3 +11,34 @@ CREATE TABLE IF NOT EXISTS oauth2_authorized_client (
   created_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
   PRIMARY KEY (client_registration_id, principal_name)
 );
+
+CREATE TABLE IF NOT EXISTS experience_extraction_batches (
+  id varchar(36) NOT NULL,
+  user_id bigint NOT NULL,
+  status varchar(20) NOT NULL,
+  created_at timestamp NOT NULL,
+  processed_at timestamp DEFAULT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS experience_duplicate_groups (
+  id varchar(36) NOT NULL,
+  batch_id varchar(36) NOT NULL,
+  existing_experience_id varchar(36) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS experience_extraction_drafts (
+  id varchar(36) NOT NULL,
+  duplicate_group_id varchar(36) NOT NULL,
+  title varchar(255) NOT NULL,
+  experience_type varchar(50) NOT NULL,
+  experience_group varchar(20) NOT NULL,
+  status varchar(20) NOT NULL,
+  document_content text DEFAULT NULL,
+  attributes json NOT NULL,
+  keywords json NOT NULL,
+  resume_url text NOT NULL,
+  similarity double DEFAULT NULL,
+  PRIMARY KEY (id)
+);

--- a/src/test/java/back/pickd/experience/service/ExperienceExtractionServiceTest.java
+++ b/src/test/java/back/pickd/experience/service/ExperienceExtractionServiceTest.java
@@ -10,6 +10,8 @@ import back.pickd.experience.repository.ExperienceTempRepository;
 import back.pickd.experience.repository.UserExperienceRepository;
 import back.pickd.experience.support.PresetRegistry;
 import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiStep1Response;
+import back.pickd.global.infra.s3.FileUploadType;
 import back.pickd.global.infra.s3.S3Service;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
@@ -20,10 +22,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -58,6 +62,42 @@ class ExperienceExtractionServiceTest {
     private ExperienceExtractionService experienceExtractionService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void extractStep1RejectsUnsupportedExperienceType() throws Exception {
+        User user = User.builder()
+                .email("user@example.com")
+                .name("테스트")
+                .build();
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "resume.pdf",
+                "application/pdf",
+                new byte[]{1}
+        );
+        AiStep1Response aiResponse = objectMapper.readValue("""
+                {
+                  "experiences": [
+                    {
+                      "experience_name": "지원하지 않는 경험",
+                      "experience_group": "상세 서술형",
+                      "experience_type": "창업"
+                    }
+                  ]
+                }
+                """, AiStep1Response.class);
+
+        when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(s3Service.uploadFile(file, FileUploadType.TEMP_RESUME, null))
+                .thenReturn("https://cdn/resume.pdf");
+        when(aiClient.extractStep1(file)).thenReturn(aiResponse);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> experienceExtractionService.extractStep1("user@example.com", file)
+        );
+        verify(tempRepository, times(0)).save(any());
+    }
 
     @Test
     void confirmStep3CreatesSelectedDraftAndSkipsIgnoredDraft() throws Exception {

--- a/src/test/java/back/pickd/experience/support/PresetRegistryTest.java
+++ b/src/test/java/back/pickd/experience/support/PresetRegistryTest.java
@@ -1,11 +1,13 @@
 package back.pickd.experience.support;
 
 import back.pickd.experience.enums.ExperienceType;
+import back.pickd.global.infra.ai.dto.AiExperiencePresetSchema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -112,5 +114,22 @@ class PresetRegistryTest {
                 ExperienceType.PROJECT,
                 Map.of()
         ).isEmpty());
+    }
+
+    @Test
+    @DisplayName("선택된 경험 유형만 AI Step2 프리셋 스키마로 변환한다")
+    void getAiPresetSchemas_returnsOnlySelectedTypes() {
+        List<AiExperiencePresetSchema> schemas = presetRegistry.getAiPresetSchemas(List.of(
+                ExperienceType.PROJECT,
+                ExperienceType.LANGUAGE,
+                ExperienceType.PROJECT
+        ));
+
+        assertEquals(2, schemas.size());
+        assertEquals("PROJECT", schemas.get(0).getExperienceType());
+        assertEquals("상세 서술형", schemas.get(0).getExperienceGroup());
+        assertEquals("project_name", schemas.get(0).getFields().get(0).getKey());
+        assertEquals("LANGUAGE", schemas.get(1).getExperienceType());
+        assertEquals("스펙·증빙형", schemas.get(1).getExperienceGroup());
     }
 }


### PR DESCRIPTION

---

## Stack 2 PR 본문

## 관련 이슈

- #43
- Stack PR: 2/6
- Base: `Back/feat/43-01-experience-schema-contract`

## 작업 내용

Step2에서 중복으로 판정된 경험을 Step3 사용자 선택 전까지 안전하게 보관하기 위한 Spring 영속 모델을 추가했습니다.

기존에는 중복 후보를 요청 응답에만 포함했기 때문에 응답이 유실되거나 화면이 새로고침되면 중복 처리 상태를 복구하기 어려웠습니다.

이번 PR에서는 중복 추출 결과를 다음 구조로 저장합니다.

```text
ExperienceExtractionBatch
  └─ ExperienceDuplicateGroup
       ├─ 기존 UserExperience
       └─ ExperienceExtractionDraft