### PR TITLE
[43 - Stack 3/6] 경험 추출 V2 중복 처리 흐름 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ dependencies {
 	implementation 'com.google.apis:google-api-services-drive:v3-rev20230822-2.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/back/pickd/experience/controller/ExperienceExtractionV2Controller.java
+++ b/src/main/java/back/pickd/experience/controller/ExperienceExtractionV2Controller.java
@@ -1,0 +1,290 @@
+package back.pickd.experience.controller;
+
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchesResponse;
+import back.pickd.experience.service.ExperienceExtractionV2Service;
+import back.pickd.global.config.OpenApiConfig;
+import back.pickd.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/experiences/extract")
+@RequiredArgsConstructor
+@Tag(
+        name = "Experience Extraction V2",
+        description = "경험 상세 추출, 중복 후보 저장 및 최종 선택 API"
+)
+@SecurityRequirement(name = OpenApiConfig.COOKIE_AUTH)
+public class ExperienceExtractionV2Controller {
+
+    private final ExperienceExtractionV2Service extractionService;
+
+    @GetMapping("/duplicates/pending")
+    @Operation(
+            summary = "미처리 중복 경험 조회",
+            description = """
+                    현재 로그인 사용자의 Step2 미처리 중복 batch를 최신순으로 조회합니다.
+
+                    - Step2 응답을 잃었거나 화면을 새로고침한 경우 Step3 선택 화면을 복구할 수 있습니다.
+                    - 각 batch는 Step3에 전달할 duplicateBatchId와 전체 duplicateGroups를 포함합니다.
+                    - 다른 사용자의 batch와 이미 완료된 batch는 반환하지 않습니다.
+                    - 미처리 batch가 없으면 batches는 빈 배열입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "미처리 중복 경험 조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = PendingBatchesResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "batches": [
+                                                {
+                                                  "duplicateBatchId": "batch-uuid",
+                                                  "createdAt": "2026-06-22T19:30:00+09:00",
+                                                  "duplicateGroups": [
+                                                    {
+                                                      "groupId": "group-uuid",
+                                                      "items": [
+                                                        {
+                                                          "itemId": "existing-experience-id",
+                                                          "source": "EXISTING",
+                                                          "similarity": null,
+                                                          "experience": {
+                                                            "title": "기존 프로젝트",
+                                                            "experienceType": "PROJECT",
+                                                            "experienceGroup": "NARRATIVE",
+                                                            "status": "COMPLETED",
+                                                            "documentContent": "기존 본문",
+                                                            "attributes": {},
+                                                            "keywords": []
+                                                          }
+                                                        },
+                                                        {
+                                                          "itemId": "draft-uuid",
+                                                          "source": "EXTRACTED",
+                                                          "similarity": 0.91,
+                                                          "experience": {
+                                                            "title": "새 추출 프로젝트",
+                                                            "experienceType": "PROJECT",
+                                                            "experienceGroup": "NARRATIVE",
+                                                            "status": "COMPLETED",
+                                                            "documentContent": "새 본문",
+                                                            "attributes": {},
+                                                            "keywords": []
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<PendingBatchesResponse> getPendingDuplicates(
+            @Parameter(hidden = true) Authentication authentication
+    ) {
+        return ResponseEntity.ok(extractionService.getPendingDuplicates(
+                authentication.getName()
+        ));
+    }
+
+    @PostMapping("/step2")
+    @Operation(
+            summary = "선택 경험 상세 추출 및 중복 후보 생성",
+            description = """
+                    Step1에서 선택한 임시 경험을 선택 순서대로 상세 추출합니다.
+
+                    - Spring PresetRegistry에서 선택된 경험 유형의 필드 스키마만 AI 서버에 전달합니다.
+                    - 기존 저장 경험과 같은 요청에서 앞서 저장된 신규 경험을 대상으로 중복을 판정합니다.
+                    - 비중복 경험은 즉시 저장합니다.
+                    - 중복 경험은 서버 draft로 저장하고 duplicateBatchId와 duplicateGroups를 반환합니다.
+                    - 중복 후보가 없으면 duplicateBatchId는 null이고 duplicateGroups는 빈 배열입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "상세 추출 및 중복 분류 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = Step2Response.class),
+                            examples = @ExampleObject(
+                                    name = "중복 후보가 있는 응답",
+                                    value = """
+                                            {
+                                              "savedExperiences": [
+                                                {
+                                                  "id": "saved-experience-id",
+                                                  "userId": 1,
+                                                  "title": "비중복 프로젝트",
+                                                  "experienceType": "PROJECT",
+                                                  "experienceGroup": "NARRATIVE",
+                                                  "status": "COMPLETED",
+                                                  "documentContent": "프로젝트 본문",
+                                                  "attributes": {
+                                                    "project_name": "비중복 프로젝트"
+                                                  },
+                                                  "keywords": ["실행력"],
+                                                  "files": [],
+                                                  "links": []
+                                                }
+                                              ],
+                                              "duplicateBatchId": "batch-uuid",
+                                              "duplicateGroups": [
+                                                {
+                                                  "groupId": "group-uuid",
+                                                  "items": [
+                                                    {
+                                                      "itemId": "existing-experience-id",
+                                                      "source": "EXISTING",
+                                                      "similarity": null,
+                                                      "experience": {
+                                                        "title": "기존 프로젝트",
+                                                        "experienceType": "PROJECT",
+                                                        "experienceGroup": "NARRATIVE",
+                                                        "status": "COMPLETED",
+                                                        "documentContent": "기존 본문",
+                                                        "attributes": {},
+                                                        "keywords": []
+                                                      }
+                                                    },
+                                                    {
+                                                      "itemId": "draft-uuid",
+                                                      "source": "EXTRACTED",
+                                                      "similarity": 0.91,
+                                                      "experience": {
+                                                        "title": "새로 추출한 프로젝트",
+                                                        "experienceType": "PROJECT",
+                                                        "experienceGroup": "NARRATIVE",
+                                                        "status": "COMPLETED",
+                                                        "documentContent": "새 본문",
+                                                        "attributes": {},
+                                                        "keywords": []
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "임시 경험 누락, 소유권 오류, 그룹·유형 불일치 또는 AI 응답 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<Step2Response> extractStep2(
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody @Valid Step2Request request
+    ) {
+        return ResponseEntity.ok(extractionService.extractStep2(
+                authentication.getName(),
+                request.getSelectedTempIds()
+        ));
+    }
+
+    @PostMapping("/step3")
+    @Operation(
+            summary = "중복 경험 최종 선택 반영",
+            description = """
+                    Step2가 반환한 중복 batch의 모든 그룹에 대해 남길 itemId를 제출합니다.
+
+                    - 기존 경험만 선택: 기존 경험 유지, 추출 draft 삭제
+                    - 추출 draft만 선택: 기존 경험 삭제, 선택 draft 신규 저장
+                    - 기존 경험과 draft를 함께 선택: 둘 다 유지
+                    - 여러 draft 선택: 선택한 draft를 모두 신규 경험으로 저장
+                    - 선택되지 않은 기존 경험과 draft는 삭제
+                    - 모든 그룹을 한 요청에 포함해야 하며 하나의 Spring 트랜잭션으로 처리합니다.
+                    - AI 서버는 호출하지 않습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "선택 반영 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = Step3Response.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "selectedExperiences": [
+                                                {
+                                                  "id": "selected-experience-id",
+                                                  "userId": 1,
+                                                  "title": "최종 선택 경험",
+                                                  "experienceType": "PROJECT",
+                                                  "experienceGroup": "NARRATIVE",
+                                                  "status": "COMPLETED",
+                                                  "documentContent": "경험 본문",
+                                                  "attributes": {},
+                                                  "keywords": [],
+                                                  "files": [],
+                                                  "links": []
+                                                }
+                                              ],
+                                              "deletedExperienceIds": ["unselected-existing-id"]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "batch 누락, 그룹 누락, 빈 선택, 잘못된 itemId 또는 이미 처리된 batch",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<Step3Response> confirmStep3(
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody @Valid Step3Request request
+    ) {
+        return ResponseEntity.ok(extractionService.confirmStep3(
+                authentication.getName(),
+                request
+        ));
+    }
+}

--- a/src/main/java/back/pickd/experience/dto/ExperienceExtractionV2Dto.java
+++ b/src/main/java/back/pickd/experience/dto/ExperienceExtractionV2Dto.java
@@ -1,0 +1,294 @@
+package back.pickd.experience.dto;
+
+import back.pickd.experience.entity.ExperienceDuplicateGroup;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.UserExperience;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
+
+public final class ExperienceExtractionV2Dto {
+
+    private ExperienceExtractionV2Dto() {
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step2Request")
+    public static class Step2Request {
+
+        @NotEmpty(message = "선택된 임시 경험 ID는 필수입니다.")
+        @Schema(
+                description = "Step1에서 사용자가 선택한 임시 경험 ID. 배열 순서가 배치 내부 중복 판정 우선순위입니다.",
+                example = "[12, 15, 18]",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<Long> selectedTempIds = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step2Response")
+    public static class Step2Response {
+
+        @Schema(description = "중복이 아니어서 Step2에서 즉시 저장된 경험")
+        private final List<ExperienceResponse> savedExperiences;
+
+        @Schema(
+                description = "Step3 처리에 사용할 중복 batch ID. 중복 후보가 없으면 null",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+                nullable = true
+        )
+        private final String duplicateBatchId;
+
+        @Schema(description = "기존 경험과 추출 draft를 묶은 중복 후보 그룹")
+        private final List<DuplicateGroupResponse> duplicateGroups;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2PendingBatchesResponse")
+    public static class PendingBatchesResponse {
+
+        @Schema(description = "현재 사용자의 미처리 중복 batch. 최신 생성 순으로 반환됩니다.")
+        private final List<PendingBatchResponse> batches;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2PendingBatch")
+    public static class PendingBatchResponse {
+
+        @Schema(
+                description = "Step3 duplicateBatchId로 전달할 미처리 batch ID",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3"
+        )
+        private final String duplicateBatchId;
+
+        @Schema(description = "중복 batch 생성 시각")
+        private final OffsetDateTime createdAt;
+
+        @Schema(description = "Step3에서 선택할 기존 경험과 추출 draft 그룹")
+        private final List<DuplicateGroupResponse> duplicateGroups;
+
+        public static PendingBatchResponse from(
+                back.pickd.experience.entity.ExperienceExtractionBatch batch
+        ) {
+            return new PendingBatchResponse(
+                    batch.getId(),
+                    batch.getCreatedAt(),
+                    batch.getGroups().stream()
+                            .map(DuplicateGroupResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2DuplicateGroup")
+    public static class DuplicateGroupResponse {
+
+        @Schema(
+                description = "Step3 그룹 선택에 사용하는 중복 그룹 ID",
+                example = "9f83540e-5d78-4a08-a284-78cecfdf2e3d"
+        )
+        private final String groupId;
+
+        @Schema(description = "그룹에서 선택 가능한 기존 경험 및 추출 draft")
+        private final List<DuplicateItemResponse> items;
+
+        public static DuplicateGroupResponse from(ExperienceDuplicateGroup group) {
+            List<DuplicateItemResponse> items = new ArrayList<>();
+            items.add(DuplicateItemResponse.fromExisting(group.getExistingExperience()));
+            group.getDrafts().stream()
+                    .map(DuplicateItemResponse::fromDraft)
+                    .forEach(items::add);
+            return new DuplicateGroupResponse(group.getId(), items);
+        }
+    }
+
+    @Schema(description = "중복 후보 데이터의 출처")
+    public enum DuplicateItemSource {
+        EXISTING,
+        EXTRACTED
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2DuplicateItem")
+    public static class DuplicateItemResponse {
+
+        @Schema(
+                description = "Step3 selectedItemIds에 사용할 ID. 기존 경험이면 experience ID, 추출 후보이면 draft ID",
+                example = "6d5d36a9-9856-4117-ac58-dd1254e28e75"
+        )
+        private final String itemId;
+
+        @Schema(
+                description = "기존 저장 경험 또는 새 추출 draft",
+                allowableValues = {"EXISTING", "EXTRACTED"},
+                example = "EXTRACTED"
+        )
+        private final DuplicateItemSource source;
+
+        @Schema(
+                description = "추출 draft와 기준 경험의 유사도. 기존 경험 항목은 null",
+                example = "0.91",
+                nullable = true
+        )
+        private final Double similarity;
+
+        @Schema(description = "비교 화면에 표시할 경험 정보")
+        private final ExperienceSnapshot experience;
+
+        public static DuplicateItemResponse fromExisting(UserExperience experience) {
+            return new DuplicateItemResponse(
+                    experience.getId(),
+                    DuplicateItemSource.EXISTING,
+                    null,
+                    ExperienceSnapshot.from(experience)
+            );
+        }
+
+        public static DuplicateItemResponse fromDraft(ExperienceExtractionDraft draft) {
+            return new DuplicateItemResponse(
+                    draft.getId(),
+                    DuplicateItemSource.EXTRACTED,
+                    draft.getSimilarity(),
+                    ExperienceSnapshot.from(draft)
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Snapshot")
+    public static class ExperienceSnapshot {
+
+        @Schema(description = "경험 제목", example = "금융 AI Agent 프로젝트")
+        private final String title;
+
+        @Schema(description = "경험 유형 enum", example = "PROJECT")
+        private final String experienceType;
+
+        @Schema(
+                description = "경험 대분류 enum",
+                allowableValues = {"NARRATIVE", "SPEC"},
+                example = "NARRATIVE"
+        )
+        private final String experienceGroup;
+
+        @Schema(
+                description = "경험 작성 상태",
+                allowableValues = {"IN_PROGRESS", "COMPLETED"},
+                example = "COMPLETED"
+        )
+        private final String status;
+
+        @Schema(description = "추출된 경험 본문", example = "추천 모델 개선을 담당했습니다.")
+        private final String documentContent;
+
+        @Schema(
+                description = "PresetRegistry 기준 유형별 속성",
+                example = "{\"project_name\":\"금융 AI Agent\",\"role\":\"백엔드 개발\"}"
+        )
+        private final Map<String, Object> attributes;
+
+        @Schema(description = "경험 역량 키워드", example = "[\"문제 해결\", \"실행력\"]")
+        private final List<String> keywords;
+
+        public static ExperienceSnapshot from(UserExperience experience) {
+            return new ExperienceSnapshot(
+                    experience.getTitle(),
+                    experience.getExperienceType().name(),
+                    experience.getExperienceGroup().name(),
+                    experience.getStatus().name(),
+                    experience.getDocumentContent(),
+                    experience.getAttributes() != null ? experience.getAttributes() : new HashMap<>(),
+                    experience.getKeywords() != null ? experience.getKeywords() : new ArrayList<>()
+            );
+        }
+
+        public static ExperienceSnapshot from(ExperienceExtractionDraft draft) {
+            return new ExperienceSnapshot(
+                    draft.getTitle(),
+                    draft.getExperienceType().name(),
+                    draft.getExperienceGroup().name(),
+                    draft.getStatus().name(),
+                    draft.getDocumentContent(),
+                    draft.getAttributes(),
+                    draft.getKeywords()
+            );
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step3Request")
+    public static class Step3Request {
+
+        @NotBlank(message = "중복 batch ID는 필수입니다.")
+        @Schema(
+                description = "Step2에서 반환된 duplicateBatchId",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private String duplicateBatchId;
+
+        @Valid
+        @NotEmpty(message = "중복 그룹 선택 목록은 필수입니다.")
+        @Schema(
+                description = "batch의 모든 중복 그룹에 대한 선택. 그룹 누락은 허용되지 않습니다.",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<GroupSelection> groups = new ArrayList<>();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2GroupSelection")
+    public static class GroupSelection {
+
+        @NotBlank(message = "중복 group ID는 필수입니다.")
+        @Schema(
+                description = "Step2 duplicateGroups의 groupId",
+                example = "9f83540e-5d78-4a08-a284-78cecfdf2e3d",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private String groupId;
+
+        @NotEmpty(message = "그룹마다 하나 이상의 경험을 선택해야 합니다.")
+        @Schema(
+                description = "최종적으로 남길 itemId 목록. 기존 경험과 여러 draft를 함께 선택할 수 있습니다.",
+                example = "[\"existing-experience-id\", \"draft-id\"]",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<String> selectedItemIds = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step3Response")
+    public static class Step3Response {
+
+        @Schema(description = "Step3 처리 후 최종적으로 유지되거나 신규 저장된 경험")
+        private final List<ExperienceResponse> selectedExperiences;
+
+        @Schema(
+                description = "선택되지 않아 삭제된 기존 경험 ID",
+                example = "[\"deleted-existing-experience-id\"]"
+        )
+        private final List<String> deletedExperienceIds;
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
@@ -1,0 +1,46 @@
+package back.pickd.experience.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_duplicate_groups")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceDuplicateGroup {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_id", nullable = false)
+    private ExperienceExtractionBatch batch;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "existing_experience_id", nullable = false)
+    private UserExperience existingExperience;
+
+    @OneToMany(mappedBy = "duplicateGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceExtractionDraft> drafts = new ArrayList<>();
+
+    public ExperienceDuplicateGroup(UserExperience existingExperience) {
+        this.id = UUID.randomUUID().toString();
+        this.existingExperience = existingExperience;
+    }
+
+    void attachTo(ExperienceExtractionBatch batch) {
+        this.batch = batch;
+    }
+
+    public void addDraft(ExperienceExtractionDraft draft) {
+        draft.attachTo(this);
+        drafts.add(draft);
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
@@ -1,0 +1,59 @@
+package back.pickd.experience.entity;
+
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_extraction_batches")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceExtractionBatch {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ExtractionBatchStatus status;
+
+    @OneToMany(mappedBy = "batch", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceDuplicateGroup> groups = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "processed_at")
+    private OffsetDateTime processedAt;
+
+    public ExperienceExtractionBatch(User user) {
+        this.id = UUID.randomUUID().toString();
+        this.user = user;
+        this.status = ExtractionBatchStatus.PENDING;
+        this.createdAt = OffsetDateTime.now();
+    }
+
+    public void addGroup(ExperienceDuplicateGroup group) {
+        group.attachTo(this);
+        groups.add(group);
+    }
+
+    public void complete() {
+        this.status = ExtractionBatchStatus.COMPLETED;
+        this.processedAt = OffsetDateTime.now();
+        this.groups.clear();
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionDraft.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionDraft.java
@@ -1,0 +1,93 @@
+package back.pickd.experience.entity;
+
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_extraction_drafts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceExtractionDraft {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "duplicate_group_id", nullable = false)
+    private ExperienceDuplicateGroup duplicateGroup;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_type", nullable = false, length = 50)
+    private ExperienceType experienceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_group", nullable = false, length = 20)
+    private ExperienceGroup experienceGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
+
+    @Column(name = "document_content", columnDefinition = "TEXT")
+    private String documentContent;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private Map<String, Object> attributes = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private List<String> keywords = new ArrayList<>();
+
+    @Column(name = "resume_url", nullable = false, columnDefinition = "TEXT")
+    private String resumeUrl;
+
+    @Column(name = "similarity")
+    private Double similarity;
+
+    @Builder
+    public ExperienceExtractionDraft(
+            String title,
+            ExperienceType experienceType,
+            ExperienceGroup experienceGroup,
+            Status status,
+            String documentContent,
+            Map<String, Object> attributes,
+            List<String> keywords,
+            String resumeUrl,
+            Double similarity
+    ) {
+        this.id = UUID.randomUUID().toString();
+        this.title = title;
+        this.experienceType = experienceType;
+        this.experienceGroup = experienceGroup;
+        this.status = status;
+        this.documentContent = documentContent;
+        this.attributes = attributes != null ? new HashMap<>(attributes) : new HashMap<>();
+        this.keywords = keywords != null ? new ArrayList<>(keywords) : new ArrayList<>();
+        this.resumeUrl = resumeUrl;
+        this.similarity = similarity;
+    }
+
+    void attachTo(ExperienceDuplicateGroup duplicateGroup) {
+        this.duplicateGroup = duplicateGroup;
+    }
+}

--- a/src/main/java/back/pickd/experience/enums/ExtractionBatchStatus.java
+++ b/src/main/java/back/pickd/experience/enums/ExtractionBatchStatus.java
@@ -1,0 +1,6 @@
+package back.pickd.experience.enums;
+
+public enum ExtractionBatchStatus {
+    PENDING,
+    COMPLETED
+}

--- a/src/main/java/back/pickd/experience/repository/ExperienceExtractionBatchRepository.java
+++ b/src/main/java/back/pickd/experience/repository/ExperienceExtractionBatchRepository.java
@@ -1,0 +1,25 @@
+package back.pickd.experience.repository;
+
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.user.entity.User;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.List;
+
+public interface ExperienceExtractionBatchRepository
+        extends JpaRepository<ExperienceExtractionBatch, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ExperienceExtractionBatch> findByIdAndUser(String id, User user);
+
+    List<ExperienceExtractionBatch> findByUserOrderByCreatedAtDesc(User user);
+
+    List<ExperienceExtractionBatch> findByUserAndStatusOrderByCreatedAtDesc(
+            User user,
+            ExtractionBatchStatus status
+    );
+}

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
@@ -25,7 +25,6 @@ import back.pickd.experience.support.PresetRegistry;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ExperienceExtractionService {
@@ -66,11 +64,14 @@ public class ExperienceExtractionService {
         List<ExperienceTemp> temps = new ArrayList<>();
         if (aiResponse.getExperiences() != null) {
             for (AiStep1Response.ExperienceSummaryDto summary : aiResponse.getExperiences()) {
+                ExperienceType type = convertType(summary.getExperience_type());
+                ExperienceGroup group = convertGroup(summary.getExperience_group());
+                validateGroupType(group, type);
                 ExperienceTemp temp = ExperienceTemp.builder()
                         .user(user)
                         .experienceName(summary.getExperience_name())
-                        .experienceGroup(summary.getExperience_group())
-                        .experienceType(summary.getExperience_type())
+                        .experienceGroup(toKoreanGroup(group))
+                        .experienceType(type.getKoreanName())
                         .resumeUrl(resumeUrl)
                         .build();
                 temps.add(tempRepository.save(temp));
@@ -198,18 +199,28 @@ public class ExperienceExtractionService {
     }
 
     private ExperienceGroup convertGroup(String koreanGroup) {
-        if ("상세 서술형".equals(koreanGroup)) {
-            return ExperienceGroup.NARRATIVE;
-        }
-        return ExperienceGroup.SPEC;
+        return switch (koreanGroup) {
+            case "상세 서술형" -> ExperienceGroup.NARRATIVE;
+            case "스펙·증빙형" -> ExperienceGroup.SPEC;
+            default -> throw new IllegalArgumentException(
+                    "지원하지 않는 경험 그룹입니다: " + koreanGroup
+            );
+        };
     }
 
     private ExperienceType convertType(String koreanType) {
-        try {
-            return ExperienceType.fromKoreanName(koreanType);
-        } catch (IllegalArgumentException e) {
-            log.warn("Unknown experience type '{}', fallback to PROJECT", koreanType);
-            return ExperienceType.PROJECT;
+        return ExperienceType.fromKoreanName(koreanType);
+    }
+
+    private void validateGroupType(ExperienceGroup group, ExperienceType type) {
+        if (presetRegistry.getExperienceGroup(type) != group) {
+            throw new IllegalArgumentException(
+                    "경험 그룹과 유형이 일치하지 않습니다: " + type.getKoreanName()
+            );
         }
+    }
+
+    private String toKoreanGroup(ExperienceGroup group) {
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
     }
 }

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
@@ -1,0 +1,423 @@
+package back.pickd.experience.service;
+
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.DuplicateGroupResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.GroupSelection;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchesResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Response;
+import back.pickd.experience.dto.ExperienceResponse;
+import back.pickd.experience.entity.*;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.experience.enums.Status;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.ExperienceTempRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.experience.support.PresetRegistry;
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
+import back.pickd.global.infra.ai.dto.AiStep1Response;
+import back.pickd.global.infra.ai.dto.AiStep2Response;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ExperienceExtractionV2Service {
+
+    private static final String BATCH_CANDIDATE_PREFIX = "batch:";
+
+    private final AiClient aiClient;
+    private final ExperienceTempRepository tempRepository;
+    private final UserExperienceRepository experienceRepository;
+    private final ExperienceExtractionBatchRepository batchRepository;
+    private final UserService userService;
+    private final ExperienceMergeService experienceMergeService;
+    private final PresetRegistry presetRegistry;
+
+    @Transactional
+    public Step2Response extractStep2(String email, List<Long> selectedTempIds) {
+        User user = userService.findByEmail(email);
+        List<ExperienceTemp> temps = loadSelectedTemps(user, selectedTempIds);
+        String resumeUrl = validateSingleResumeSource(temps);
+
+        List<SelectedExperience> selectedExperiences = temps.stream()
+                .map(this::toSelectedExperience)
+                .toList();
+        List<AiStep1Response.ExperienceSummaryDto> summaries = selectedExperiences.stream()
+                .map(selected -> new AiStep1Response.ExperienceSummaryDto(
+                        selected.temp().getExperienceName(),
+                        toKoreanGroup(selected.group()),
+                        selected.type().getKoreanName()
+                ))
+                .toList();
+        List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences =
+                experienceMergeService.buildExistingExperiencePayloads(user);
+
+        AiStep2Response aiResponse = aiClient.extractStep2V2ByUrl(
+                resumeUrl,
+                summaries,
+                existingExperiences,
+                presetRegistry.getAiPresetSchemas(
+                        selectedExperiences.stream().map(SelectedExperience::type).toList()
+                )
+        );
+        List<AiStep2Response.Step2ExperienceDto> extracted = validateAiResponse(
+                aiResponse,
+                selectedExperiences
+        );
+
+        List<UserExperience> savedExperiences = new ArrayList<>();
+        Map<Integer, UserExperience> savedByTargetIndex = new HashMap<>();
+        Map<String, ExperienceDuplicateGroup> groupsByExistingId = new LinkedHashMap<>();
+        ExperienceExtractionBatch batch = null;
+
+        for (int index = 0; index < extracted.size(); index++) {
+            AiStep2Response.Step2ExperienceDto dto = extracted.get(index);
+            SelectedExperience selected = selectedExperiences.get(index);
+
+            if (!dto.isNeeds_merge()) {
+                UserExperience saved = saveExtractedExperience(
+                        user,
+                        dto,
+                        selected.type(),
+                        selected.group(),
+                        resumeUrl
+                );
+                savedExperiences.add(saved);
+                savedByTargetIndex.put(index, saved);
+                continue;
+            }
+
+            UserExperience existing = resolveMergeCandidate(
+                    user,
+                    dto.getMerge_candidate_id(),
+                    savedByTargetIndex
+            );
+            if (batch == null) {
+                batch = new ExperienceExtractionBatch(user);
+            }
+            ExperienceDuplicateGroup group = groupsByExistingId.get(existing.getId());
+            if (group == null) {
+                group = new ExperienceDuplicateGroup(existing);
+                batch.addGroup(group);
+                groupsByExistingId.put(existing.getId(), group);
+            }
+            group.addDraft(ExperienceExtractionDraft.builder()
+                    .title(dto.getExperience_name())
+                    .experienceType(selected.type())
+                    .experienceGroup(selected.group())
+                    .status(Status.COMPLETED)
+                    .documentContent(dto.getExperience_content())
+                    .attributes(presetRegistry.normalizeAttributes(
+                            selected.type(),
+                            dto.getBasic_info()
+                    ))
+                    .keywords(dto.getKeywords())
+                    .resumeUrl(resumeUrl)
+                    .similarity(dto.getMerge_similarity())
+                    .build());
+        }
+
+        if (batch != null) {
+            batchRepository.save(batch);
+        }
+        tempRepository.deleteByUser(user);
+
+        return new Step2Response(
+                savedExperiences.stream().map(ExperienceResponse::new).toList(),
+                batch != null ? batch.getId() : null,
+                batch != null
+                        ? batch.getGroups().stream().map(DuplicateGroupResponse::from).toList()
+                        : List.of()
+        );
+    }
+
+    @Transactional
+    public Step3Response confirmStep3(String email, Step3Request request) {
+        User user = userService.findByEmail(email);
+        ExperienceExtractionBatch batch = batchRepository.findByIdAndUser(
+                        request.getDuplicateBatchId(),
+                        user
+                )
+                .orElseThrow(() -> new IllegalArgumentException("중복 경험 batch를 찾을 수 없습니다."));
+        if (batch.getStatus() != ExtractionBatchStatus.PENDING) {
+            throw new IllegalStateException("이미 처리된 중복 경험 batch입니다.");
+        }
+
+        Map<String, GroupSelection> selections = indexSelections(request.getGroups());
+        Set<String> expectedGroupIds = batch.getGroups().stream()
+                .map(ExperienceDuplicateGroup::getId)
+                .collect(Collectors.toSet());
+        if (!selections.keySet().equals(expectedGroupIds)) {
+            throw new IllegalArgumentException("batch의 모든 중복 그룹에 대한 선택이 필요합니다.");
+        }
+
+        List<UserExperience> selectedExperiences = new ArrayList<>();
+        List<UserExperience> experiencesToDelete = new ArrayList<>();
+        List<String> deletedExperienceIds = new ArrayList<>();
+
+        for (ExperienceDuplicateGroup group : batch.getGroups()) {
+            Set<String> selectedItemIds = new LinkedHashSet<>(
+                    selections.get(group.getId()).getSelectedItemIds()
+            );
+            if (selectedItemIds.isEmpty()) {
+                throw new IllegalArgumentException("그룹마다 하나 이상의 경험을 선택해야 합니다.");
+            }
+            if (selectedItemIds.size()
+                    != selections.get(group.getId()).getSelectedItemIds().size()) {
+                throw new IllegalArgumentException("동일한 경험을 중복 선택할 수 없습니다.");
+            }
+
+            Set<String> allowedItemIds = new HashSet<>();
+            allowedItemIds.add(group.getExistingExperience().getId());
+            group.getDrafts().stream()
+                    .map(ExperienceExtractionDraft::getId)
+                    .forEach(allowedItemIds::add);
+            if (!allowedItemIds.containsAll(selectedItemIds)) {
+                throw new IllegalArgumentException("중복 그룹에 속하지 않은 경험이 선택되었습니다.");
+            }
+
+            UserExperience existing = group.getExistingExperience();
+            if (selectedItemIds.contains(existing.getId())) {
+                selectedExperiences.add(existing);
+            } else {
+                experiencesToDelete.add(existing);
+                deletedExperienceIds.add(existing.getId());
+            }
+
+            for (ExperienceExtractionDraft draft : group.getDrafts()) {
+                if (selectedItemIds.contains(draft.getId())) {
+                    selectedExperiences.add(saveDraftExperience(user, draft));
+                }
+            }
+        }
+
+        batch.complete();
+        batchRepository.saveAndFlush(batch);
+        if (!experiencesToDelete.isEmpty()) {
+            experienceRepository.deleteAll(experiencesToDelete);
+        }
+
+        return new Step3Response(
+                selectedExperiences.stream().map(ExperienceResponse::new).toList(),
+                deletedExperienceIds
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PendingBatchesResponse getPendingDuplicates(String email) {
+        User user = userService.findByEmail(email);
+        return new PendingBatchesResponse(
+                batchRepository.findByUserAndStatusOrderByCreatedAtDesc(
+                                user,
+                                ExtractionBatchStatus.PENDING
+                        )
+                        .stream()
+                        .map(PendingBatchResponse::from)
+                        .toList()
+        );
+    }
+
+    private List<ExperienceTemp> loadSelectedTemps(User user, List<Long> selectedTempIds) {
+        if (selectedTempIds == null || selectedTempIds.isEmpty()) {
+            throw new IllegalArgumentException("선택된 임시 경험 ID가 없습니다.");
+        }
+        if (new HashSet<>(selectedTempIds).size() != selectedTempIds.size()) {
+            throw new IllegalArgumentException("동일한 임시 경험을 중복 선택할 수 없습니다.");
+        }
+
+        Map<Long, ExperienceTemp> tempsById = tempRepository.findAllById(selectedTempIds)
+                .stream()
+                .collect(Collectors.toMap(ExperienceTemp::getId, Function.identity()));
+        if (tempsById.size() != selectedTempIds.size()) {
+            throw new IllegalArgumentException("요청한 임시 경험 데이터를 찾을 수 없습니다.");
+        }
+
+        List<ExperienceTemp> ordered = selectedTempIds.stream()
+                .map(tempsById::get)
+                .toList();
+        if (ordered.stream().anyMatch(temp -> !isOwnedBy(temp, user))) {
+            throw new IllegalArgumentException("다른 사용자의 임시 경험은 선택할 수 없습니다.");
+        }
+        return ordered;
+    }
+
+    private boolean isOwnedBy(ExperienceTemp temp, User user) {
+        if (temp.getUser() == user) {
+            return true;
+        }
+        return temp.getUser().getId() != null
+                && Objects.equals(temp.getUser().getId(), user.getId());
+    }
+
+    private String validateSingleResumeSource(List<ExperienceTemp> temps) {
+        Set<String> resumeUrls = temps.stream()
+                .map(ExperienceTemp::getResumeUrl)
+                .collect(Collectors.toSet());
+        if (resumeUrls.size() != 1) {
+            throw new IllegalArgumentException("서로 다른 원본 파일의 경험을 함께 추출할 수 없습니다.");
+        }
+        return temps.get(0).getResumeUrl();
+    }
+
+    private SelectedExperience toSelectedExperience(ExperienceTemp temp) {
+        ExperienceType type = convertType(temp.getExperienceType());
+        ExperienceGroup group = convertGroup(temp.getExperienceGroup());
+        validateGroupType(group, type);
+        return new SelectedExperience(temp, type, group);
+    }
+
+    private List<AiStep2Response.Step2ExperienceDto> validateAiResponse(
+            AiStep2Response response,
+            List<SelectedExperience> selectedExperiences
+    ) {
+        if (response == null || response.getExperiences() == null) {
+            throw new IllegalStateException("AI 2차 경험 추출 응답이 없습니다.");
+        }
+        if (response.getExperiences().size() != selectedExperiences.size()) {
+            throw new IllegalStateException("AI 2차 경험 추출 결과 수가 선택한 경험 수와 다릅니다.");
+        }
+
+        for (int index = 0; index < response.getExperiences().size(); index++) {
+            AiStep2Response.Step2ExperienceDto dto = response.getExperiences().get(index);
+            ExperienceType responseType = convertType(dto.getExperience_type());
+            ExperienceGroup responseGroup = convertGroup(dto.getExperience_group());
+            SelectedExperience selected = selectedExperiences.get(index);
+            if (responseType != selected.type() || responseGroup != selected.group()) {
+                throw new IllegalStateException("AI 2차 경험 유형이 선택한 1차 경험과 일치하지 않습니다.");
+            }
+        }
+        return response.getExperiences();
+    }
+
+    private UserExperience resolveMergeCandidate(
+            User user,
+            String candidateId,
+            Map<Integer, UserExperience> savedByTargetIndex
+    ) {
+        if (candidateId == null || candidateId.isBlank()) {
+            throw new IllegalStateException("AI 중복 후보 ID가 없습니다.");
+        }
+        if (candidateId.startsWith(BATCH_CANDIDATE_PREFIX)) {
+            int targetIndex;
+            try {
+                targetIndex = Integer.parseInt(
+                        candidateId.substring(BATCH_CANDIDATE_PREFIX.length())
+                );
+            } catch (NumberFormatException e) {
+                throw new IllegalStateException("AI batch 중복 후보 ID가 올바르지 않습니다.", e);
+            }
+            UserExperience saved = savedByTargetIndex.get(targetIndex);
+            if (saved == null) {
+                throw new IllegalStateException("AI batch 중복 후보가 저장 대상에 없습니다.");
+            }
+            return saved;
+        }
+        return experienceRepository.findByIdAndUser(candidateId, user)
+                .orElseThrow(() -> new IllegalStateException(
+                        "AI 중복 후보를 사용자 경험에서 찾을 수 없습니다."
+                ));
+    }
+
+    private UserExperience saveExtractedExperience(
+            User user,
+            AiStep2Response.Step2ExperienceDto dto,
+            ExperienceType type,
+            ExperienceGroup group,
+            String resumeUrl
+    ) {
+        UserExperience experience = UserExperience.builder()
+                .user(user)
+                .title(dto.getExperience_name())
+                .experienceType(type)
+                .experienceGroup(group)
+                .status(Status.COMPLETED)
+                .documentContent(dto.getExperience_content())
+                .attributes(presetRegistry.normalizeAttributes(type, dto.getBasic_info()))
+                .keywords(dto.getKeywords() != null ? dto.getKeywords() : new ArrayList<>())
+                .build();
+        attachResumeFile(experience, resumeUrl);
+        return experienceRepository.save(experience);
+    }
+
+    private UserExperience saveDraftExperience(User user, ExperienceExtractionDraft draft) {
+        UserExperience experience = UserExperience.builder()
+                .user(user)
+                .title(draft.getTitle())
+                .experienceType(draft.getExperienceType())
+                .experienceGroup(draft.getExperienceGroup())
+                .status(draft.getStatus())
+                .documentContent(draft.getDocumentContent())
+                .attributes(draft.getAttributes())
+                .keywords(draft.getKeywords())
+                .build();
+        attachResumeFile(experience, draft.getResumeUrl());
+        return experienceRepository.save(experience);
+    }
+
+    private void attachResumeFile(UserExperience experience, String resumeUrl) {
+        ExperienceFile resumeFile = ExperienceFile.builder()
+                .userExperience(experience)
+                .originalFilename("자기소개서 원본.pdf")
+                .fileType("application/pdf")
+                .fileSize(0L)
+                .filePath(resumeUrl)
+                .source("RESUME_ORIGINAL")
+                .build();
+        experience.updateFiles(List.of(resumeFile));
+    }
+
+    private Map<String, GroupSelection> indexSelections(List<GroupSelection> selections) {
+        Map<String, GroupSelection> indexed = new HashMap<>();
+        for (GroupSelection selection : selections) {
+            if (indexed.put(selection.getGroupId(), selection) != null) {
+                throw new IllegalArgumentException("동일한 중복 그룹을 중복 제출할 수 없습니다.");
+            }
+        }
+        return indexed;
+    }
+
+    private ExperienceGroup convertGroup(String koreanGroup) {
+        return switch (koreanGroup) {
+            case "상세 서술형" -> ExperienceGroup.NARRATIVE;
+            case "스펙·증빙형" -> ExperienceGroup.SPEC;
+            default -> throw new IllegalArgumentException(
+                    "지원하지 않는 경험 그룹입니다: " + koreanGroup
+            );
+        };
+    }
+
+    private ExperienceType convertType(String koreanType) {
+        return ExperienceType.fromKoreanName(koreanType);
+    }
+
+    private void validateGroupType(ExperienceGroup group, ExperienceType type) {
+        if (presetRegistry.getExperienceGroup(type) != group) {
+            throw new IllegalArgumentException(
+                    "경험 그룹과 유형이 일치하지 않습니다: " + type.getKoreanName()
+            );
+        }
+    }
+
+    private String toKoreanGroup(ExperienceGroup group) {
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
+    }
+
+    private record SelectedExperience(
+            ExperienceTemp temp,
+            ExperienceType type,
+            ExperienceGroup group
+    ) {
+    }
+}

--- a/src/main/java/back/pickd/experience/support/PresetRegistry.java
+++ b/src/main/java/back/pickd/experience/support/PresetRegistry.java
@@ -1,6 +1,8 @@
 package back.pickd.experience.support;
 
+import back.pickd.experience.enums.ExperienceGroup;
 import back.pickd.experience.enums.ExperienceType;
+import back.pickd.global.infra.ai.dto.AiExperiencePresetSchema;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -13,6 +15,14 @@ public class PresetRegistry {
 
     private static final Map<ExperienceType, List<PresetField>> PRESET_MAP =
             new EnumMap<>(ExperienceType.class);
+
+    private static final Set<ExperienceType> SPEC_TYPES = EnumSet.of(
+            ExperienceType.LANGUAGE,
+            ExperienceType.LICENSE,
+            ExperienceType.AWARD,
+            ExperienceType.COURSE,
+            ExperienceType.EDUCATION
+    );
 
     static {
         // 상세 서술형 (Narrative) 프리셋 필드 정의
@@ -114,6 +124,30 @@ public class PresetRegistry {
         return PRESET_MAP.getOrDefault(type, Collections.emptyList());
     }
 
+    public ExperienceGroup getExperienceGroup(ExperienceType type) {
+        return SPEC_TYPES.contains(type) ? ExperienceGroup.SPEC : ExperienceGroup.NARRATIVE;
+    }
+
+    public List<AiExperiencePresetSchema> getAiPresetSchemas(Collection<ExperienceType> types) {
+        if (types == null || types.isEmpty()) {
+            return List.of();
+        }
+
+        return new LinkedHashSet<>(types).stream()
+                .map(type -> new AiExperiencePresetSchema(
+                        toKoreanGroup(getExperienceGroup(type)),
+                        type.name(),
+                        type.getKoreanName(),
+                        getPresetFields(type).stream()
+                                .map(field -> new AiExperiencePresetSchema.Field(
+                                        field.key(),
+                                        field.label()
+                                ))
+                                .toList()
+                ))
+                .toList();
+    }
+
     /**
      * AI가 자의적으로 바꾼 필드명(예: '역할분담', '배정부서')을 백엔드의 표준 키명으로 매핑해주는 보정 유틸리티
      */
@@ -151,5 +185,9 @@ public class PresetRegistry {
                 .replace("_", "")
                 .trim()
                 .toLowerCase(Locale.ROOT);
+    }
+
+    private String toKoreanGroup(ExperienceGroup group) {
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
     }
 }

--- a/src/main/java/back/pickd/global/config/OpenApiConfig.java
+++ b/src/main/java/back/pickd/global/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package back.pickd.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String COOKIE_AUTH = "cookieAuth";
+
+    @Bean
+    public OpenAPI pickdOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("PICKD API")
+                        .version("v2")
+                        .description("PICKD Spring 서버 REST API 명세"))
+                .components(new Components()
+                        .addSecuritySchemes(
+                                COOKIE_AUTH,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.COOKIE)
+                                        .name("accessToken")
+                                        .description("로그인 후 발급되는 JWT accessToken 쿠키")
+                        ));
+    }
+}

--- a/src/main/java/back/pickd/global/error/ErrorResponse.java
+++ b/src/main/java/back/pickd/global/error/ErrorResponse.java
@@ -1,5 +1,6 @@
 package back.pickd.global.error;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,10 +8,21 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "공통 오류 응답")
 public class ErrorResponse {
+
+    @Schema(description = "오류 발생 시각", example = "2026-06-20T17:20:00")
     private final LocalDateTime timestamp;
+
+    @Schema(description = "HTTP 상태 코드", example = "400")
     private final int status;
+
+    @Schema(description = "HTTP 오류 이름", example = "Bad Request")
     private final String error;
+
+    @Schema(description = "오류 상세 메시지", example = "batch의 모든 중복 그룹에 대한 선택이 필요합니다.")
     private final String message;
+
+    @Schema(description = "요청 경로", example = "/api/v2/experiences/extract/step3")
     private final String path;
 }

--- a/src/main/java/back/pickd/global/infra/ai/AiClient.java
+++ b/src/main/java/back/pickd/global/infra/ai/AiClient.java
@@ -2,6 +2,7 @@ package back.pickd.global.infra.ai;
 
 import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
 import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckResponse;
+import back.pickd.global.infra.ai.dto.AiExperiencePresetSchema;
 import back.pickd.global.infra.ai.dto.AiStep1Response;
 import back.pickd.global.infra.ai.dto.AiStep2Response;
 import back.pickd.global.infra.ai.dto.AiJobPostingResponse;
@@ -108,6 +109,43 @@ public class AiClient {
 
         return restClient.post()
                 .uri("/api/v1/extract-experiences/step2")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(bodyBuilder.build())
+                .retrieve()
+                .body(AiStep2Response.class);
+    }
+
+    public AiStep2Response extractStep2V2ByUrl(
+            String resumeUrl,
+            List<AiStep1Response.ExperienceSummaryDto> selectedExperiences,
+            List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences,
+            List<AiExperiencePresetSchema> presetSchemas
+    ) {
+        MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder.part("url", resumeUrl);
+
+        try {
+            bodyBuilder.part(
+                    "selected_experiences",
+                    objectMapper.writeValueAsString(selectedExperiences)
+            );
+            bodyBuilder.part(
+                    "existing_experiences",
+                    objectMapper.writeValueAsString(
+                            existingExperiences != null ? existingExperiences : List.of()
+                    )
+            );
+            bodyBuilder.part(
+                    "preset_schemas",
+                    objectMapper.writeValueAsString(presetSchemas)
+            );
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize AI Step2 V2 request", e);
+            throw new RuntimeException("AI 분석 요청 중 직렬화 오류가 발생했습니다.", e);
+        }
+
+        return restClient.post()
+                .uri("/api/v1/extract-experiences/step2-v2")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(bodyBuilder.build())
                 .retrieve()

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiExperiencePresetSchema.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiExperiencePresetSchema.java
@@ -1,0 +1,30 @@
+package back.pickd.global.infra.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AiExperiencePresetSchema {
+
+    @JsonProperty("experience_group")
+    private final String experienceGroup;
+
+    @JsonProperty("experience_type")
+    private final String experienceType;
+
+    @JsonProperty("experience_type_name")
+    private final String experienceTypeName;
+
+    private final List<Field> fields;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Field {
+        private final String key;
+        private final String label;
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,3 +11,34 @@ CREATE TABLE IF NOT EXISTS oauth2_authorized_client (
   created_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
   PRIMARY KEY (client_registration_id, principal_name)
 );
+
+CREATE TABLE IF NOT EXISTS experience_extraction_batches (
+  id varchar(36) NOT NULL,
+  user_id bigint NOT NULL,
+  status varchar(20) NOT NULL,
+  created_at timestamp NOT NULL,
+  processed_at timestamp DEFAULT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS experience_duplicate_groups (
+  id varchar(36) NOT NULL,
+  batch_id varchar(36) NOT NULL,
+  existing_experience_id varchar(36) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS experience_extraction_drafts (
+  id varchar(36) NOT NULL,
+  duplicate_group_id varchar(36) NOT NULL,
+  title varchar(255) NOT NULL,
+  experience_type varchar(50) NOT NULL,
+  experience_group varchar(20) NOT NULL,
+  status varchar(20) NOT NULL,
+  document_content text DEFAULT NULL,
+  attributes json NOT NULL,
+  keywords json NOT NULL,
+  resume_url text NOT NULL,
+  similarity double DEFAULT NULL,
+  PRIMARY KEY (id)
+);

--- a/src/test/java/back/pickd/experience/service/ExperienceExtractionServiceTest.java
+++ b/src/test/java/back/pickd/experience/service/ExperienceExtractionServiceTest.java
@@ -10,6 +10,8 @@ import back.pickd.experience.repository.ExperienceTempRepository;
 import back.pickd.experience.repository.UserExperienceRepository;
 import back.pickd.experience.support.PresetRegistry;
 import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiStep1Response;
+import back.pickd.global.infra.s3.FileUploadType;
 import back.pickd.global.infra.s3.S3Service;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
@@ -20,10 +22,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -58,6 +62,42 @@ class ExperienceExtractionServiceTest {
     private ExperienceExtractionService experienceExtractionService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void extractStep1RejectsUnsupportedExperienceType() throws Exception {
+        User user = User.builder()
+                .email("user@example.com")
+                .name("테스트")
+                .build();
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "resume.pdf",
+                "application/pdf",
+                new byte[]{1}
+        );
+        AiStep1Response aiResponse = objectMapper.readValue("""
+                {
+                  "experiences": [
+                    {
+                      "experience_name": "지원하지 않는 경험",
+                      "experience_group": "상세 서술형",
+                      "experience_type": "창업"
+                    }
+                  ]
+                }
+                """, AiStep1Response.class);
+
+        when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(s3Service.uploadFile(file, FileUploadType.TEMP_RESUME, null))
+                .thenReturn("https://cdn/resume.pdf");
+        when(aiClient.extractStep1(file)).thenReturn(aiResponse);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> experienceExtractionService.extractStep1("user@example.com", file)
+        );
+        verify(tempRepository, times(0)).save(any());
+    }
 
     @Test
     void confirmStep3CreatesSelectedDraftAndSkipsIgnoredDraft() throws Exception {

--- a/src/test/java/back/pickd/experience/support/PresetRegistryTest.java
+++ b/src/test/java/back/pickd/experience/support/PresetRegistryTest.java
@@ -1,11 +1,13 @@
 package back.pickd.experience.support;
 
 import back.pickd.experience.enums.ExperienceType;
+import back.pickd.global.infra.ai.dto.AiExperiencePresetSchema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -112,5 +114,22 @@ class PresetRegistryTest {
                 ExperienceType.PROJECT,
                 Map.of()
         ).isEmpty());
+    }
+
+    @Test
+    @DisplayName("선택된 경험 유형만 AI Step2 프리셋 스키마로 변환한다")
+    void getAiPresetSchemas_returnsOnlySelectedTypes() {
+        List<AiExperiencePresetSchema> schemas = presetRegistry.getAiPresetSchemas(List.of(
+                ExperienceType.PROJECT,
+                ExperienceType.LANGUAGE,
+                ExperienceType.PROJECT
+        ));
+
+        assertEquals(2, schemas.size());
+        assertEquals("PROJECT", schemas.get(0).getExperienceType());
+        assertEquals("상세 서술형", schemas.get(0).getExperienceGroup());
+        assertEquals("project_name", schemas.get(0).getFields().get(0).getKey());
+        assertEquals("LANGUAGE", schemas.get(1).getExperienceType());
+        assertEquals("스펙·증빙형", schemas.get(1).getExperienceGroup());
     }
 }


### PR DESCRIPTION
## 관련 이슈

- #43
- Stack PR: 3/6
- Base: `Back/feat/43-02-extraction-draft-model`

## 작업 내용

경험 추출 Step2·Step3 V2와 미처리 중복 조회 흐름을 구현했습니다.

### Step2 V2

- Step1에서 선택한 임시 경험을 선택 순서대로 상세 추출
- 선택한 경험 유형의 `PresetRegistry` 스키마를 Python 서버에 전달
- AI 응답의 경험 그룹·유형이 Step1 선택 결과와 일치하는지 검증
- 기존 저장 경험 및 같은 요청의 앞선 신규 경험과 중복 비교
- 비중복 경험은 `UserExperience`로 즉시 저장
- 중복 경험은 batch/group/draft 구조로 임시 저장
- 처리 완료 후 사용자의 `ExperienceTemp` 정리

### Step3 V2

- 사용자가 선택한 기존 경험과 추출 Draft를 최종 반영
- 기존 경험만 선택하면 기존 경험 유지
- Draft만 선택하면 기존 경험 삭제 후 Draft 저장
- 기존 경험과 Draft를 모두 선택하면 모두 유지
- 여러 Draft를 선택하면 모두 신규 경험으로 저장
- 미선택 기존 경험 및 Draft 삭제
- batch 완료 처리 및 재처리 방지
- Python 서버를 호출하지 않고 Spring 트랜잭션으로 처리

### 미처리 중복 조회

- 현재 사용자의 `PENDING` batch를 최신순으로 조회
- Step2 응답 유실 또는 화면 새로고침 시 Step3 상태 복구 지원
- 다른 사용자의 batch 및 완료된 batch 제외

## 추가 API

### 1. Step2 V2

```http
POST /api/v2/experiences/extract/step2
Content-Type: application/json
Cookie: accessToken={JWT}