### PR TITLE
[43 - Stack 2/6] 경험 중복 Draft 영속 모델 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ dependencies {
 	implementation 'com.google.apis:google-api-services-drive:v3-rev20230822-2.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/back/pickd/auth/config/SecurityConfig.java
+++ b/src/main/java/back/pickd/auth/config/SecurityConfig.java
@@ -56,7 +56,21 @@ public class SecurityConfig {
             )
 
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/login", "/error", "/css/**", "/js/**", "/h2-console/**", "/favicon.ico", "/onboarding-test.html", "/api/experiences/extract/temp-token").permitAll()
+                .requestMatchers(
+                    "/",
+                    "/login",
+                    "/error",
+                    "/css/**",
+                    "/js/**",
+                    "/h2-console/**",
+                    "/favicon.ico",
+                    "/onboarding-test.html",
+                    "/experience-extraction-test",
+                    "/api/experiences/extract/temp-token",
+                    "/swagger-ui.html",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**"
+                ).permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/back/pickd/experience/controller/ExperienceExtractionTestController.java
+++ b/src/main/java/back/pickd/experience/controller/ExperienceExtractionTestController.java
@@ -1,0 +1,57 @@
+package back.pickd.experience.controller;
+
+import back.pickd.experience.dto.ExperienceExtractionTestDto.PresetDefinition;
+import back.pickd.experience.dto.ExperienceExtractionTestDto.StateResponse;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.service.ExperienceExtractionTestService;
+import back.pickd.experience.support.PresetRegistry;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Controller
+@Profile("local")
+@RequiredArgsConstructor
+public class ExperienceExtractionTestController {
+
+    private final PresetRegistry presetRegistry;
+    private final ExperienceExtractionTestService testService;
+    private final ObjectMapper objectMapper;
+
+    @GetMapping("/experience-extraction-test")
+    public String page(Authentication authentication, Model model)
+            throws JsonProcessingException {
+        List<PresetDefinition> presets = Arrays.stream(ExperienceType.values())
+                .map(type -> new PresetDefinition(
+                        type.name(),
+                        type.getKoreanName(),
+                        presetRegistry.getExperienceGroup(type).name(),
+                        presetRegistry.getPresetFields(type)
+                ))
+                .toList();
+
+        model.addAttribute("authenticated",
+                authentication != null && authentication.isAuthenticated());
+        model.addAttribute("userEmail",
+                authentication != null ? authentication.getName() : null);
+        model.addAttribute("presetDefinitions", presets);
+        model.addAttribute("presetDefinitionsJson",
+                objectMapper.writeValueAsString(presets));
+        return "experience-extraction-test";
+    }
+
+    @GetMapping("/internal/experience-extraction-test/state")
+    @ResponseBody
+    public StateResponse state(Authentication authentication) {
+        return testService.getState(authentication.getName());
+    }
+}

--- a/src/main/java/back/pickd/experience/controller/ExperienceExtractionV2Controller.java
+++ b/src/main/java/back/pickd/experience/controller/ExperienceExtractionV2Controller.java
@@ -1,0 +1,290 @@
+package back.pickd.experience.controller;
+
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchesResponse;
+import back.pickd.experience.service.ExperienceExtractionV2Service;
+import back.pickd.global.config.OpenApiConfig;
+import back.pickd.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/experiences/extract")
+@RequiredArgsConstructor
+@Tag(
+        name = "Experience Extraction V2",
+        description = "경험 상세 추출, 중복 후보 저장 및 최종 선택 API"
+)
+@SecurityRequirement(name = OpenApiConfig.COOKIE_AUTH)
+public class ExperienceExtractionV2Controller {
+
+    private final ExperienceExtractionV2Service extractionService;
+
+    @GetMapping("/duplicates/pending")
+    @Operation(
+            summary = "미처리 중복 경험 조회",
+            description = """
+                    현재 로그인 사용자의 Step2 미처리 중복 batch를 최신순으로 조회합니다.
+
+                    - Step2 응답을 잃었거나 화면을 새로고침한 경우 Step3 선택 화면을 복구할 수 있습니다.
+                    - 각 batch는 Step3에 전달할 duplicateBatchId와 전체 duplicateGroups를 포함합니다.
+                    - 다른 사용자의 batch와 이미 완료된 batch는 반환하지 않습니다.
+                    - 미처리 batch가 없으면 batches는 빈 배열입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "미처리 중복 경험 조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = PendingBatchesResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "batches": [
+                                                {
+                                                  "duplicateBatchId": "batch-uuid",
+                                                  "createdAt": "2026-06-22T19:30:00+09:00",
+                                                  "duplicateGroups": [
+                                                    {
+                                                      "groupId": "group-uuid",
+                                                      "items": [
+                                                        {
+                                                          "itemId": "existing-experience-id",
+                                                          "source": "EXISTING",
+                                                          "similarity": null,
+                                                          "experience": {
+                                                            "title": "기존 프로젝트",
+                                                            "experienceType": "PROJECT",
+                                                            "experienceGroup": "NARRATIVE",
+                                                            "status": "COMPLETED",
+                                                            "documentContent": "기존 본문",
+                                                            "attributes": {},
+                                                            "keywords": []
+                                                          }
+                                                        },
+                                                        {
+                                                          "itemId": "draft-uuid",
+                                                          "source": "EXTRACTED",
+                                                          "similarity": 0.91,
+                                                          "experience": {
+                                                            "title": "새 추출 프로젝트",
+                                                            "experienceType": "PROJECT",
+                                                            "experienceGroup": "NARRATIVE",
+                                                            "status": "COMPLETED",
+                                                            "documentContent": "새 본문",
+                                                            "attributes": {},
+                                                            "keywords": []
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<PendingBatchesResponse> getPendingDuplicates(
+            @Parameter(hidden = true) Authentication authentication
+    ) {
+        return ResponseEntity.ok(extractionService.getPendingDuplicates(
+                authentication.getName()
+        ));
+    }
+
+    @PostMapping("/step2")
+    @Operation(
+            summary = "선택 경험 상세 추출 및 중복 후보 생성",
+            description = """
+                    Step1에서 선택한 임시 경험을 선택 순서대로 상세 추출합니다.
+
+                    - Spring PresetRegistry에서 선택된 경험 유형의 필드 스키마만 AI 서버에 전달합니다.
+                    - 기존 저장 경험과 같은 요청에서 앞서 저장된 신규 경험을 대상으로 중복을 판정합니다.
+                    - 비중복 경험은 즉시 저장합니다.
+                    - 중복 경험은 서버 draft로 저장하고 duplicateBatchId와 duplicateGroups를 반환합니다.
+                    - 중복 후보가 없으면 duplicateBatchId는 null이고 duplicateGroups는 빈 배열입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "상세 추출 및 중복 분류 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = Step2Response.class),
+                            examples = @ExampleObject(
+                                    name = "중복 후보가 있는 응답",
+                                    value = """
+                                            {
+                                              "savedExperiences": [
+                                                {
+                                                  "id": "saved-experience-id",
+                                                  "userId": 1,
+                                                  "title": "비중복 프로젝트",
+                                                  "experienceType": "PROJECT",
+                                                  "experienceGroup": "NARRATIVE",
+                                                  "status": "COMPLETED",
+                                                  "documentContent": "프로젝트 본문",
+                                                  "attributes": {
+                                                    "project_name": "비중복 프로젝트"
+                                                  },
+                                                  "keywords": ["실행력"],
+                                                  "files": [],
+                                                  "links": []
+                                                }
+                                              ],
+                                              "duplicateBatchId": "batch-uuid",
+                                              "duplicateGroups": [
+                                                {
+                                                  "groupId": "group-uuid",
+                                                  "items": [
+                                                    {
+                                                      "itemId": "existing-experience-id",
+                                                      "source": "EXISTING",
+                                                      "similarity": null,
+                                                      "experience": {
+                                                        "title": "기존 프로젝트",
+                                                        "experienceType": "PROJECT",
+                                                        "experienceGroup": "NARRATIVE",
+                                                        "status": "COMPLETED",
+                                                        "documentContent": "기존 본문",
+                                                        "attributes": {},
+                                                        "keywords": []
+                                                      }
+                                                    },
+                                                    {
+                                                      "itemId": "draft-uuid",
+                                                      "source": "EXTRACTED",
+                                                      "similarity": 0.91,
+                                                      "experience": {
+                                                        "title": "새로 추출한 프로젝트",
+                                                        "experienceType": "PROJECT",
+                                                        "experienceGroup": "NARRATIVE",
+                                                        "status": "COMPLETED",
+                                                        "documentContent": "새 본문",
+                                                        "attributes": {},
+                                                        "keywords": []
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "임시 경험 누락, 소유권 오류, 그룹·유형 불일치 또는 AI 응답 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<Step2Response> extractStep2(
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody @Valid Step2Request request
+    ) {
+        return ResponseEntity.ok(extractionService.extractStep2(
+                authentication.getName(),
+                request.getSelectedTempIds()
+        ));
+    }
+
+    @PostMapping("/step3")
+    @Operation(
+            summary = "중복 경험 최종 선택 반영",
+            description = """
+                    Step2가 반환한 중복 batch의 모든 그룹에 대해 남길 itemId를 제출합니다.
+
+                    - 기존 경험만 선택: 기존 경험 유지, 추출 draft 삭제
+                    - 추출 draft만 선택: 기존 경험 삭제, 선택 draft 신규 저장
+                    - 기존 경험과 draft를 함께 선택: 둘 다 유지
+                    - 여러 draft 선택: 선택한 draft를 모두 신규 경험으로 저장
+                    - 선택되지 않은 기존 경험과 draft는 삭제
+                    - 모든 그룹을 한 요청에 포함해야 하며 하나의 Spring 트랜잭션으로 처리합니다.
+                    - AI 서버는 호출하지 않습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "선택 반영 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = Step3Response.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "selectedExperiences": [
+                                                {
+                                                  "id": "selected-experience-id",
+                                                  "userId": 1,
+                                                  "title": "최종 선택 경험",
+                                                  "experienceType": "PROJECT",
+                                                  "experienceGroup": "NARRATIVE",
+                                                  "status": "COMPLETED",
+                                                  "documentContent": "경험 본문",
+                                                  "attributes": {},
+                                                  "keywords": [],
+                                                  "files": [],
+                                                  "links": []
+                                                }
+                                              ],
+                                              "deletedExperienceIds": ["unselected-existing-id"]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "batch 누락, 그룹 누락, 빈 선택, 잘못된 itemId 또는 이미 처리된 batch",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<Step3Response> confirmStep3(
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody @Valid Step3Request request
+    ) {
+        return ResponseEntity.ok(extractionService.confirmStep3(
+                authentication.getName(),
+                request
+        ));
+    }
+}

--- a/src/main/java/back/pickd/experience/dto/ExperienceExtractionTestDto.java
+++ b/src/main/java/back/pickd/experience/dto/ExperienceExtractionTestDto.java
@@ -1,0 +1,119 @@
+package back.pickd.experience.dto;
+
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.ExperienceTemp;
+import back.pickd.experience.entity.UserExperience;
+import back.pickd.experience.support.PresetRegistry.PresetField;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public final class ExperienceExtractionTestDto {
+
+    private ExperienceExtractionTestDto() {
+    }
+
+    public record PresetDefinition(
+            String type,
+            String koreanName,
+            String group,
+            List<PresetField> fields
+    ) {
+    }
+
+    public record StateResponse(
+            String userEmail,
+            List<ExperienceResponse> experiences,
+            List<TempState> temps,
+            List<BatchState> batches
+    ) {
+    }
+
+    public record TempState(
+            Long id,
+            String experienceName,
+            String experienceGroup,
+            String experienceType,
+            String resumeUrl,
+            LocalDateTime createdAt
+    ) {
+        public static TempState from(ExperienceTemp temp) {
+            return new TempState(
+                    temp.getId(),
+                    temp.getExperienceName(),
+                    temp.getExperienceGroup(),
+                    temp.getExperienceType(),
+                    temp.getResumeUrl(),
+                    temp.getCreatedAt()
+            );
+        }
+    }
+
+    public record BatchState(
+            String id,
+            String status,
+            OffsetDateTime createdAt,
+            OffsetDateTime processedAt,
+            List<DuplicateGroupState> duplicateGroups
+    ) {
+        public static BatchState from(ExperienceExtractionBatch batch) {
+            return new BatchState(
+                    batch.getId(),
+                    batch.getStatus().name(),
+                    batch.getCreatedAt(),
+                    batch.getProcessedAt(),
+                    batch.getGroups().stream()
+                            .map(DuplicateGroupState::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record DuplicateGroupState(
+            String id,
+            ExperienceResponse existingExperience,
+            List<DraftState> drafts
+    ) {
+        public static DuplicateGroupState from(
+                back.pickd.experience.entity.ExperienceDuplicateGroup group
+        ) {
+            return new DuplicateGroupState(
+                    group.getId(),
+                    new ExperienceResponse(group.getExistingExperience()),
+                    group.getDrafts().stream()
+                            .map(DraftState::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record DraftState(
+            String id,
+            String title,
+            String experienceType,
+            String experienceGroup,
+            String status,
+            String documentContent,
+            java.util.Map<String, Object> attributes,
+            List<String> keywords,
+            String resumeUrl,
+            Double similarity
+    ) {
+        public static DraftState from(ExperienceExtractionDraft draft) {
+            return new DraftState(
+                    draft.getId(),
+                    draft.getTitle(),
+                    draft.getExperienceType().name(),
+                    draft.getExperienceGroup().name(),
+                    draft.getStatus().name(),
+                    draft.getDocumentContent(),
+                    draft.getAttributes(),
+                    draft.getKeywords(),
+                    draft.getResumeUrl(),
+                    draft.getSimilarity()
+            );
+        }
+    }
+}

--- a/src/main/java/back/pickd/experience/dto/ExperienceExtractionV2Dto.java
+++ b/src/main/java/back/pickd/experience/dto/ExperienceExtractionV2Dto.java
@@ -1,0 +1,294 @@
+package back.pickd.experience.dto;
+
+import back.pickd.experience.entity.ExperienceDuplicateGroup;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.UserExperience;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
+
+public final class ExperienceExtractionV2Dto {
+
+    private ExperienceExtractionV2Dto() {
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step2Request")
+    public static class Step2Request {
+
+        @NotEmpty(message = "선택된 임시 경험 ID는 필수입니다.")
+        @Schema(
+                description = "Step1에서 사용자가 선택한 임시 경험 ID. 배열 순서가 배치 내부 중복 판정 우선순위입니다.",
+                example = "[12, 15, 18]",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<Long> selectedTempIds = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step2Response")
+    public static class Step2Response {
+
+        @Schema(description = "중복이 아니어서 Step2에서 즉시 저장된 경험")
+        private final List<ExperienceResponse> savedExperiences;
+
+        @Schema(
+                description = "Step3 처리에 사용할 중복 batch ID. 중복 후보가 없으면 null",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+                nullable = true
+        )
+        private final String duplicateBatchId;
+
+        @Schema(description = "기존 경험과 추출 draft를 묶은 중복 후보 그룹")
+        private final List<DuplicateGroupResponse> duplicateGroups;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2PendingBatchesResponse")
+    public static class PendingBatchesResponse {
+
+        @Schema(description = "현재 사용자의 미처리 중복 batch. 최신 생성 순으로 반환됩니다.")
+        private final List<PendingBatchResponse> batches;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2PendingBatch")
+    public static class PendingBatchResponse {
+
+        @Schema(
+                description = "Step3 duplicateBatchId로 전달할 미처리 batch ID",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3"
+        )
+        private final String duplicateBatchId;
+
+        @Schema(description = "중복 batch 생성 시각")
+        private final OffsetDateTime createdAt;
+
+        @Schema(description = "Step3에서 선택할 기존 경험과 추출 draft 그룹")
+        private final List<DuplicateGroupResponse> duplicateGroups;
+
+        public static PendingBatchResponse from(
+                back.pickd.experience.entity.ExperienceExtractionBatch batch
+        ) {
+            return new PendingBatchResponse(
+                    batch.getId(),
+                    batch.getCreatedAt(),
+                    batch.getGroups().stream()
+                            .map(DuplicateGroupResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2DuplicateGroup")
+    public static class DuplicateGroupResponse {
+
+        @Schema(
+                description = "Step3 그룹 선택에 사용하는 중복 그룹 ID",
+                example = "9f83540e-5d78-4a08-a284-78cecfdf2e3d"
+        )
+        private final String groupId;
+
+        @Schema(description = "그룹에서 선택 가능한 기존 경험 및 추출 draft")
+        private final List<DuplicateItemResponse> items;
+
+        public static DuplicateGroupResponse from(ExperienceDuplicateGroup group) {
+            List<DuplicateItemResponse> items = new ArrayList<>();
+            items.add(DuplicateItemResponse.fromExisting(group.getExistingExperience()));
+            group.getDrafts().stream()
+                    .map(DuplicateItemResponse::fromDraft)
+                    .forEach(items::add);
+            return new DuplicateGroupResponse(group.getId(), items);
+        }
+    }
+
+    @Schema(description = "중복 후보 데이터의 출처")
+    public enum DuplicateItemSource {
+        EXISTING,
+        EXTRACTED
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2DuplicateItem")
+    public static class DuplicateItemResponse {
+
+        @Schema(
+                description = "Step3 selectedItemIds에 사용할 ID. 기존 경험이면 experience ID, 추출 후보이면 draft ID",
+                example = "6d5d36a9-9856-4117-ac58-dd1254e28e75"
+        )
+        private final String itemId;
+
+        @Schema(
+                description = "기존 저장 경험 또는 새 추출 draft",
+                allowableValues = {"EXISTING", "EXTRACTED"},
+                example = "EXTRACTED"
+        )
+        private final DuplicateItemSource source;
+
+        @Schema(
+                description = "추출 draft와 기준 경험의 유사도. 기존 경험 항목은 null",
+                example = "0.91",
+                nullable = true
+        )
+        private final Double similarity;
+
+        @Schema(description = "비교 화면에 표시할 경험 정보")
+        private final ExperienceSnapshot experience;
+
+        public static DuplicateItemResponse fromExisting(UserExperience experience) {
+            return new DuplicateItemResponse(
+                    experience.getId(),
+                    DuplicateItemSource.EXISTING,
+                    null,
+                    ExperienceSnapshot.from(experience)
+            );
+        }
+
+        public static DuplicateItemResponse fromDraft(ExperienceExtractionDraft draft) {
+            return new DuplicateItemResponse(
+                    draft.getId(),
+                    DuplicateItemSource.EXTRACTED,
+                    draft.getSimilarity(),
+                    ExperienceSnapshot.from(draft)
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Snapshot")
+    public static class ExperienceSnapshot {
+
+        @Schema(description = "경험 제목", example = "금융 AI Agent 프로젝트")
+        private final String title;
+
+        @Schema(description = "경험 유형 enum", example = "PROJECT")
+        private final String experienceType;
+
+        @Schema(
+                description = "경험 대분류 enum",
+                allowableValues = {"NARRATIVE", "SPEC"},
+                example = "NARRATIVE"
+        )
+        private final String experienceGroup;
+
+        @Schema(
+                description = "경험 작성 상태",
+                allowableValues = {"IN_PROGRESS", "COMPLETED"},
+                example = "COMPLETED"
+        )
+        private final String status;
+
+        @Schema(description = "추출된 경험 본문", example = "추천 모델 개선을 담당했습니다.")
+        private final String documentContent;
+
+        @Schema(
+                description = "PresetRegistry 기준 유형별 속성",
+                example = "{\"project_name\":\"금융 AI Agent\",\"role\":\"백엔드 개발\"}"
+        )
+        private final Map<String, Object> attributes;
+
+        @Schema(description = "경험 역량 키워드", example = "[\"문제 해결\", \"실행력\"]")
+        private final List<String> keywords;
+
+        public static ExperienceSnapshot from(UserExperience experience) {
+            return new ExperienceSnapshot(
+                    experience.getTitle(),
+                    experience.getExperienceType().name(),
+                    experience.getExperienceGroup().name(),
+                    experience.getStatus().name(),
+                    experience.getDocumentContent(),
+                    experience.getAttributes() != null ? experience.getAttributes() : new HashMap<>(),
+                    experience.getKeywords() != null ? experience.getKeywords() : new ArrayList<>()
+            );
+        }
+
+        public static ExperienceSnapshot from(ExperienceExtractionDraft draft) {
+            return new ExperienceSnapshot(
+                    draft.getTitle(),
+                    draft.getExperienceType().name(),
+                    draft.getExperienceGroup().name(),
+                    draft.getStatus().name(),
+                    draft.getDocumentContent(),
+                    draft.getAttributes(),
+                    draft.getKeywords()
+            );
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step3Request")
+    public static class Step3Request {
+
+        @NotBlank(message = "중복 batch ID는 필수입니다.")
+        @Schema(
+                description = "Step2에서 반환된 duplicateBatchId",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private String duplicateBatchId;
+
+        @Valid
+        @NotEmpty(message = "중복 그룹 선택 목록은 필수입니다.")
+        @Schema(
+                description = "batch의 모든 중복 그룹에 대한 선택. 그룹 누락은 허용되지 않습니다.",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<GroupSelection> groups = new ArrayList<>();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2GroupSelection")
+    public static class GroupSelection {
+
+        @NotBlank(message = "중복 group ID는 필수입니다.")
+        @Schema(
+                description = "Step2 duplicateGroups의 groupId",
+                example = "9f83540e-5d78-4a08-a284-78cecfdf2e3d",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private String groupId;
+
+        @NotEmpty(message = "그룹마다 하나 이상의 경험을 선택해야 합니다.")
+        @Schema(
+                description = "최종적으로 남길 itemId 목록. 기존 경험과 여러 draft를 함께 선택할 수 있습니다.",
+                example = "[\"existing-experience-id\", \"draft-id\"]",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<String> selectedItemIds = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step3Response")
+    public static class Step3Response {
+
+        @Schema(description = "Step3 처리 후 최종적으로 유지되거나 신규 저장된 경험")
+        private final List<ExperienceResponse> selectedExperiences;
+
+        @Schema(
+                description = "선택되지 않아 삭제된 기존 경험 ID",
+                example = "[\"deleted-existing-experience-id\"]"
+        )
+        private final List<String> deletedExperienceIds;
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
@@ -1,0 +1,46 @@
+package back.pickd.experience.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_duplicate_groups")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceDuplicateGroup {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_id", nullable = false)
+    private ExperienceExtractionBatch batch;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "existing_experience_id", nullable = false)
+    private UserExperience existingExperience;
+
+    @OneToMany(mappedBy = "duplicateGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceExtractionDraft> drafts = new ArrayList<>();
+
+    public ExperienceDuplicateGroup(UserExperience existingExperience) {
+        this.id = UUID.randomUUID().toString();
+        this.existingExperience = existingExperience;
+    }
+
+    void attachTo(ExperienceExtractionBatch batch) {
+        this.batch = batch;
+    }
+
+    public void addDraft(ExperienceExtractionDraft draft) {
+        draft.attachTo(this);
+        drafts.add(draft);
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
@@ -1,0 +1,59 @@
+package back.pickd.experience.entity;
+
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_extraction_batches")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceExtractionBatch {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ExtractionBatchStatus status;
+
+    @OneToMany(mappedBy = "batch", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceDuplicateGroup> groups = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "processed_at")
+    private OffsetDateTime processedAt;
+
+    public ExperienceExtractionBatch(User user) {
+        this.id = UUID.randomUUID().toString();
+        this.user = user;
+        this.status = ExtractionBatchStatus.PENDING;
+        this.createdAt = OffsetDateTime.now();
+    }
+
+    public void addGroup(ExperienceDuplicateGroup group) {
+        group.attachTo(this);
+        groups.add(group);
+    }
+
+    public void complete() {
+        this.status = ExtractionBatchStatus.COMPLETED;
+        this.processedAt = OffsetDateTime.now();
+        this.groups.clear();
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionDraft.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionDraft.java
@@ -1,0 +1,93 @@
+package back.pickd.experience.entity;
+
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_extraction_drafts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceExtractionDraft {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "duplicate_group_id", nullable = false)
+    private ExperienceDuplicateGroup duplicateGroup;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_type", nullable = false, length = 50)
+    private ExperienceType experienceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_group", nullable = false, length = 20)
+    private ExperienceGroup experienceGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
+
+    @Column(name = "document_content", columnDefinition = "TEXT")
+    private String documentContent;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private Map<String, Object> attributes = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private List<String> keywords = new ArrayList<>();
+
+    @Column(name = "resume_url", nullable = false, columnDefinition = "TEXT")
+    private String resumeUrl;
+
+    @Column(name = "similarity")
+    private Double similarity;
+
+    @Builder
+    public ExperienceExtractionDraft(
+            String title,
+            ExperienceType experienceType,
+            ExperienceGroup experienceGroup,
+            Status status,
+            String documentContent,
+            Map<String, Object> attributes,
+            List<String> keywords,
+            String resumeUrl,
+            Double similarity
+    ) {
+        this.id = UUID.randomUUID().toString();
+        this.title = title;
+        this.experienceType = experienceType;
+        this.experienceGroup = experienceGroup;
+        this.status = status;
+        this.documentContent = documentContent;
+        this.attributes = attributes != null ? new HashMap<>(attributes) : new HashMap<>();
+        this.keywords = keywords != null ? new ArrayList<>(keywords) : new ArrayList<>();
+        this.resumeUrl = resumeUrl;
+        this.similarity = similarity;
+    }
+
+    void attachTo(ExperienceDuplicateGroup duplicateGroup) {
+        this.duplicateGroup = duplicateGroup;
+    }
+}

--- a/src/main/java/back/pickd/experience/enums/ExtractionBatchStatus.java
+++ b/src/main/java/back/pickd/experience/enums/ExtractionBatchStatus.java
@@ -1,0 +1,6 @@
+package back.pickd.experience.enums;
+
+public enum ExtractionBatchStatus {
+    PENDING,
+    COMPLETED
+}

--- a/src/main/java/back/pickd/experience/repository/ExperienceExtractionBatchRepository.java
+++ b/src/main/java/back/pickd/experience/repository/ExperienceExtractionBatchRepository.java
@@ -1,0 +1,25 @@
+package back.pickd.experience.repository;
+
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.user.entity.User;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.List;
+
+public interface ExperienceExtractionBatchRepository
+        extends JpaRepository<ExperienceExtractionBatch, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ExperienceExtractionBatch> findByIdAndUser(String id, User user);
+
+    List<ExperienceExtractionBatch> findByUserOrderByCreatedAtDesc(User user);
+
+    List<ExperienceExtractionBatch> findByUserAndStatusOrderByCreatedAtDesc(
+            User user,
+            ExtractionBatchStatus status
+    );
+}

--- a/src/main/java/back/pickd/experience/repository/UserExperienceRepository.java
+++ b/src/main/java/back/pickd/experience/repository/UserExperienceRepository.java
@@ -5,7 +5,6 @@ import back.pickd.experience.entity.UserExperience;
 import back.pickd.experience.enums.ExperienceGroup;
 import back.pickd.experience.enums.ExperienceType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -15,10 +14,6 @@ import java.util.Optional;
 
 @Repository
 public interface UserExperienceRepository extends JpaRepository<UserExperience, String> {
-
-    @Modifying
-    @Query("delete from UserExperience e where e.user = :user")
-    void deleteByUser(User user);
 
     // 유저의 경험 목록 조회 (최신순)
     List<UserExperience> findByUserOrderByCreatedAtDesc(User user);

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionTestService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionTestService.java
@@ -1,0 +1,45 @@
+package back.pickd.experience.service;
+
+import back.pickd.experience.dto.ExperienceExtractionTestDto.BatchState;
+import back.pickd.experience.dto.ExperienceExtractionTestDto.StateResponse;
+import back.pickd.experience.dto.ExperienceExtractionTestDto.TempState;
+import back.pickd.experience.dto.ExperienceResponse;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.ExperienceTempRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.user.entity.User;
+import back.pickd.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Profile("local")
+@RequiredArgsConstructor
+public class ExperienceExtractionTestService {
+
+    private final UserRepository userRepository;
+    private final UserExperienceRepository experienceRepository;
+    private final ExperienceTempRepository tempRepository;
+    private final ExperienceExtractionBatchRepository batchRepository;
+
+    @Transactional(readOnly = true)
+    public StateResponse getState(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return new StateResponse(
+                email,
+                experienceRepository.findByUserOrderByCreatedAtDesc(user).stream()
+                        .map(ExperienceResponse::new)
+                        .toList(),
+                tempRepository.findByUser(user).stream()
+                        .map(TempState::from)
+                        .toList(),
+                batchRepository.findByUserOrderByCreatedAtDesc(user).stream()
+                        .map(BatchState::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
@@ -1,0 +1,423 @@
+package back.pickd.experience.service;
+
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.DuplicateGroupResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.GroupSelection;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchesResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Response;
+import back.pickd.experience.dto.ExperienceResponse;
+import back.pickd.experience.entity.*;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.experience.enums.Status;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.ExperienceTempRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.experience.support.PresetRegistry;
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
+import back.pickd.global.infra.ai.dto.AiStep1Response;
+import back.pickd.global.infra.ai.dto.AiStep2Response;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ExperienceExtractionV2Service {
+
+    private static final String BATCH_CANDIDATE_PREFIX = "batch:";
+
+    private final AiClient aiClient;
+    private final ExperienceTempRepository tempRepository;
+    private final UserExperienceRepository experienceRepository;
+    private final ExperienceExtractionBatchRepository batchRepository;
+    private final UserService userService;
+    private final ExperienceMergeService experienceMergeService;
+    private final PresetRegistry presetRegistry;
+
+    @Transactional
+    public Step2Response extractStep2(String email, List<Long> selectedTempIds) {
+        User user = userService.findByEmail(email);
+        List<ExperienceTemp> temps = loadSelectedTemps(user, selectedTempIds);
+        String resumeUrl = validateSingleResumeSource(temps);
+
+        List<SelectedExperience> selectedExperiences = temps.stream()
+                .map(this::toSelectedExperience)
+                .toList();
+        List<AiStep1Response.ExperienceSummaryDto> summaries = selectedExperiences.stream()
+                .map(selected -> new AiStep1Response.ExperienceSummaryDto(
+                        selected.temp().getExperienceName(),
+                        toKoreanGroup(selected.group()),
+                        selected.type().getKoreanName()
+                ))
+                .toList();
+        List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences =
+                experienceMergeService.buildExistingExperiencePayloads(user);
+
+        AiStep2Response aiResponse = aiClient.extractStep2V2ByUrl(
+                resumeUrl,
+                summaries,
+                existingExperiences,
+                presetRegistry.getAiPresetSchemas(
+                        selectedExperiences.stream().map(SelectedExperience::type).toList()
+                )
+        );
+        List<AiStep2Response.Step2ExperienceDto> extracted = validateAiResponse(
+                aiResponse,
+                selectedExperiences
+        );
+
+        List<UserExperience> savedExperiences = new ArrayList<>();
+        Map<Integer, UserExperience> savedByTargetIndex = new HashMap<>();
+        Map<String, ExperienceDuplicateGroup> groupsByExistingId = new LinkedHashMap<>();
+        ExperienceExtractionBatch batch = null;
+
+        for (int index = 0; index < extracted.size(); index++) {
+            AiStep2Response.Step2ExperienceDto dto = extracted.get(index);
+            SelectedExperience selected = selectedExperiences.get(index);
+
+            if (!dto.isNeeds_merge()) {
+                UserExperience saved = saveExtractedExperience(
+                        user,
+                        dto,
+                        selected.type(),
+                        selected.group(),
+                        resumeUrl
+                );
+                savedExperiences.add(saved);
+                savedByTargetIndex.put(index, saved);
+                continue;
+            }
+
+            UserExperience existing = resolveMergeCandidate(
+                    user,
+                    dto.getMerge_candidate_id(),
+                    savedByTargetIndex
+            );
+            if (batch == null) {
+                batch = new ExperienceExtractionBatch(user);
+            }
+            ExperienceDuplicateGroup group = groupsByExistingId.get(existing.getId());
+            if (group == null) {
+                group = new ExperienceDuplicateGroup(existing);
+                batch.addGroup(group);
+                groupsByExistingId.put(existing.getId(), group);
+            }
+            group.addDraft(ExperienceExtractionDraft.builder()
+                    .title(dto.getExperience_name())
+                    .experienceType(selected.type())
+                    .experienceGroup(selected.group())
+                    .status(Status.COMPLETED)
+                    .documentContent(dto.getExperience_content())
+                    .attributes(presetRegistry.normalizeAttributes(
+                            selected.type(),
+                            dto.getBasic_info()
+                    ))
+                    .keywords(dto.getKeywords())
+                    .resumeUrl(resumeUrl)
+                    .similarity(dto.getMerge_similarity())
+                    .build());
+        }
+
+        if (batch != null) {
+            batchRepository.save(batch);
+        }
+        tempRepository.deleteByUser(user);
+
+        return new Step2Response(
+                savedExperiences.stream().map(ExperienceResponse::new).toList(),
+                batch != null ? batch.getId() : null,
+                batch != null
+                        ? batch.getGroups().stream().map(DuplicateGroupResponse::from).toList()
+                        : List.of()
+        );
+    }
+
+    @Transactional
+    public Step3Response confirmStep3(String email, Step3Request request) {
+        User user = userService.findByEmail(email);
+        ExperienceExtractionBatch batch = batchRepository.findByIdAndUser(
+                        request.getDuplicateBatchId(),
+                        user
+                )
+                .orElseThrow(() -> new IllegalArgumentException("중복 경험 batch를 찾을 수 없습니다."));
+        if (batch.getStatus() != ExtractionBatchStatus.PENDING) {
+            throw new IllegalStateException("이미 처리된 중복 경험 batch입니다.");
+        }
+
+        Map<String, GroupSelection> selections = indexSelections(request.getGroups());
+        Set<String> expectedGroupIds = batch.getGroups().stream()
+                .map(ExperienceDuplicateGroup::getId)
+                .collect(Collectors.toSet());
+        if (!selections.keySet().equals(expectedGroupIds)) {
+            throw new IllegalArgumentException("batch의 모든 중복 그룹에 대한 선택이 필요합니다.");
+        }
+
+        List<UserExperience> selectedExperiences = new ArrayList<>();
+        List<UserExperience> experiencesToDelete = new ArrayList<>();
+        List<String> deletedExperienceIds = new ArrayList<>();
+
+        for (ExperienceDuplicateGroup group : batch.getGroups()) {
+            Set<String> selectedItemIds = new LinkedHashSet<>(
+                    selections.get(group.getId()).getSelectedItemIds()
+            );
+            if (selectedItemIds.isEmpty()) {
+                throw new IllegalArgumentException("그룹마다 하나 이상의 경험을 선택해야 합니다.");
+            }
+            if (selectedItemIds.size()
+                    != selections.get(group.getId()).getSelectedItemIds().size()) {
+                throw new IllegalArgumentException("동일한 경험을 중복 선택할 수 없습니다.");
+            }
+
+            Set<String> allowedItemIds = new HashSet<>();
+            allowedItemIds.add(group.getExistingExperience().getId());
+            group.getDrafts().stream()
+                    .map(ExperienceExtractionDraft::getId)
+                    .forEach(allowedItemIds::add);
+            if (!allowedItemIds.containsAll(selectedItemIds)) {
+                throw new IllegalArgumentException("중복 그룹에 속하지 않은 경험이 선택되었습니다.");
+            }
+
+            UserExperience existing = group.getExistingExperience();
+            if (selectedItemIds.contains(existing.getId())) {
+                selectedExperiences.add(existing);
+            } else {
+                experiencesToDelete.add(existing);
+                deletedExperienceIds.add(existing.getId());
+            }
+
+            for (ExperienceExtractionDraft draft : group.getDrafts()) {
+                if (selectedItemIds.contains(draft.getId())) {
+                    selectedExperiences.add(saveDraftExperience(user, draft));
+                }
+            }
+        }
+
+        batch.complete();
+        batchRepository.saveAndFlush(batch);
+        if (!experiencesToDelete.isEmpty()) {
+            experienceRepository.deleteAll(experiencesToDelete);
+        }
+
+        return new Step3Response(
+                selectedExperiences.stream().map(ExperienceResponse::new).toList(),
+                deletedExperienceIds
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PendingBatchesResponse getPendingDuplicates(String email) {
+        User user = userService.findByEmail(email);
+        return new PendingBatchesResponse(
+                batchRepository.findByUserAndStatusOrderByCreatedAtDesc(
+                                user,
+                                ExtractionBatchStatus.PENDING
+                        )
+                        .stream()
+                        .map(PendingBatchResponse::from)
+                        .toList()
+        );
+    }
+
+    private List<ExperienceTemp> loadSelectedTemps(User user, List<Long> selectedTempIds) {
+        if (selectedTempIds == null || selectedTempIds.isEmpty()) {
+            throw new IllegalArgumentException("선택된 임시 경험 ID가 없습니다.");
+        }
+        if (new HashSet<>(selectedTempIds).size() != selectedTempIds.size()) {
+            throw new IllegalArgumentException("동일한 임시 경험을 중복 선택할 수 없습니다.");
+        }
+
+        Map<Long, ExperienceTemp> tempsById = tempRepository.findAllById(selectedTempIds)
+                .stream()
+                .collect(Collectors.toMap(ExperienceTemp::getId, Function.identity()));
+        if (tempsById.size() != selectedTempIds.size()) {
+            throw new IllegalArgumentException("요청한 임시 경험 데이터를 찾을 수 없습니다.");
+        }
+
+        List<ExperienceTemp> ordered = selectedTempIds.stream()
+                .map(tempsById::get)
+                .toList();
+        if (ordered.stream().anyMatch(temp -> !isOwnedBy(temp, user))) {
+            throw new IllegalArgumentException("다른 사용자의 임시 경험은 선택할 수 없습니다.");
+        }
+        return ordered;
+    }
+
+    private boolean isOwnedBy(ExperienceTemp temp, User user) {
+        if (temp.getUser() == user) {
+            return true;
+        }
+        return temp.getUser().getId() != null
+                && Objects.equals(temp.getUser().getId(), user.getId());
+    }
+
+    private String validateSingleResumeSource(List<ExperienceTemp> temps) {
+        Set<String> resumeUrls = temps.stream()
+                .map(ExperienceTemp::getResumeUrl)
+                .collect(Collectors.toSet());
+        if (resumeUrls.size() != 1) {
+            throw new IllegalArgumentException("서로 다른 원본 파일의 경험을 함께 추출할 수 없습니다.");
+        }
+        return temps.get(0).getResumeUrl();
+    }
+
+    private SelectedExperience toSelectedExperience(ExperienceTemp temp) {
+        ExperienceType type = convertType(temp.getExperienceType());
+        ExperienceGroup group = convertGroup(temp.getExperienceGroup());
+        validateGroupType(group, type);
+        return new SelectedExperience(temp, type, group);
+    }
+
+    private List<AiStep2Response.Step2ExperienceDto> validateAiResponse(
+            AiStep2Response response,
+            List<SelectedExperience> selectedExperiences
+    ) {
+        if (response == null || response.getExperiences() == null) {
+            throw new IllegalStateException("AI 2차 경험 추출 응답이 없습니다.");
+        }
+        if (response.getExperiences().size() != selectedExperiences.size()) {
+            throw new IllegalStateException("AI 2차 경험 추출 결과 수가 선택한 경험 수와 다릅니다.");
+        }
+
+        for (int index = 0; index < response.getExperiences().size(); index++) {
+            AiStep2Response.Step2ExperienceDto dto = response.getExperiences().get(index);
+            ExperienceType responseType = convertType(dto.getExperience_type());
+            ExperienceGroup responseGroup = convertGroup(dto.getExperience_group());
+            SelectedExperience selected = selectedExperiences.get(index);
+            if (responseType != selected.type() || responseGroup != selected.group()) {
+                throw new IllegalStateException("AI 2차 경험 유형이 선택한 1차 경험과 일치하지 않습니다.");
+            }
+        }
+        return response.getExperiences();
+    }
+
+    private UserExperience resolveMergeCandidate(
+            User user,
+            String candidateId,
+            Map<Integer, UserExperience> savedByTargetIndex
+    ) {
+        if (candidateId == null || candidateId.isBlank()) {
+            throw new IllegalStateException("AI 중복 후보 ID가 없습니다.");
+        }
+        if (candidateId.startsWith(BATCH_CANDIDATE_PREFIX)) {
+            int targetIndex;
+            try {
+                targetIndex = Integer.parseInt(
+                        candidateId.substring(BATCH_CANDIDATE_PREFIX.length())
+                );
+            } catch (NumberFormatException e) {
+                throw new IllegalStateException("AI batch 중복 후보 ID가 올바르지 않습니다.", e);
+            }
+            UserExperience saved = savedByTargetIndex.get(targetIndex);
+            if (saved == null) {
+                throw new IllegalStateException("AI batch 중복 후보가 저장 대상에 없습니다.");
+            }
+            return saved;
+        }
+        return experienceRepository.findByIdAndUser(candidateId, user)
+                .orElseThrow(() -> new IllegalStateException(
+                        "AI 중복 후보를 사용자 경험에서 찾을 수 없습니다."
+                ));
+    }
+
+    private UserExperience saveExtractedExperience(
+            User user,
+            AiStep2Response.Step2ExperienceDto dto,
+            ExperienceType type,
+            ExperienceGroup group,
+            String resumeUrl
+    ) {
+        UserExperience experience = UserExperience.builder()
+                .user(user)
+                .title(dto.getExperience_name())
+                .experienceType(type)
+                .experienceGroup(group)
+                .status(Status.COMPLETED)
+                .documentContent(dto.getExperience_content())
+                .attributes(presetRegistry.normalizeAttributes(type, dto.getBasic_info()))
+                .keywords(dto.getKeywords() != null ? dto.getKeywords() : new ArrayList<>())
+                .build();
+        attachResumeFile(experience, resumeUrl);
+        return experienceRepository.save(experience);
+    }
+
+    private UserExperience saveDraftExperience(User user, ExperienceExtractionDraft draft) {
+        UserExperience experience = UserExperience.builder()
+                .user(user)
+                .title(draft.getTitle())
+                .experienceType(draft.getExperienceType())
+                .experienceGroup(draft.getExperienceGroup())
+                .status(draft.getStatus())
+                .documentContent(draft.getDocumentContent())
+                .attributes(draft.getAttributes())
+                .keywords(draft.getKeywords())
+                .build();
+        attachResumeFile(experience, draft.getResumeUrl());
+        return experienceRepository.save(experience);
+    }
+
+    private void attachResumeFile(UserExperience experience, String resumeUrl) {
+        ExperienceFile resumeFile = ExperienceFile.builder()
+                .userExperience(experience)
+                .originalFilename("자기소개서 원본.pdf")
+                .fileType("application/pdf")
+                .fileSize(0L)
+                .filePath(resumeUrl)
+                .source("RESUME_ORIGINAL")
+                .build();
+        experience.updateFiles(List.of(resumeFile));
+    }
+
+    private Map<String, GroupSelection> indexSelections(List<GroupSelection> selections) {
+        Map<String, GroupSelection> indexed = new HashMap<>();
+        for (GroupSelection selection : selections) {
+            if (indexed.put(selection.getGroupId(), selection) != null) {
+                throw new IllegalArgumentException("동일한 중복 그룹을 중복 제출할 수 없습니다.");
+            }
+        }
+        return indexed;
+    }
+
+    private ExperienceGroup convertGroup(String koreanGroup) {
+        return switch (koreanGroup) {
+            case "상세 서술형" -> ExperienceGroup.NARRATIVE;
+            case "스펙·증빙형" -> ExperienceGroup.SPEC;
+            default -> throw new IllegalArgumentException(
+                    "지원하지 않는 경험 그룹입니다: " + koreanGroup
+            );
+        };
+    }
+
+    private ExperienceType convertType(String koreanType) {
+        return ExperienceType.fromKoreanName(koreanType);
+    }
+
+    private void validateGroupType(ExperienceGroup group, ExperienceType type) {
+        if (presetRegistry.getExperienceGroup(type) != group) {
+            throw new IllegalArgumentException(
+                    "경험 그룹과 유형이 일치하지 않습니다: " + type.getKoreanName()
+            );
+        }
+    }
+
+    private String toKoreanGroup(ExperienceGroup group) {
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
+    }
+
+    private record SelectedExperience(
+            ExperienceTemp temp,
+            ExperienceType type,
+            ExperienceGroup group
+    ) {
+    }
+}

--- a/src/main/java/back/pickd/global/config/OpenApiConfig.java
+++ b/src/main/java/back/pickd/global/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package back.pickd.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String COOKIE_AUTH = "cookieAuth";
+
+    @Bean
+    public OpenAPI pickdOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("PICKD API")
+                        .version("v2")
+                        .description("PICKD Spring 서버 REST API 명세"))
+                .components(new Components()
+                        .addSecuritySchemes(
+                                COOKIE_AUTH,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.COOKIE)
+                                        .name("accessToken")
+                                        .description("로그인 후 발급되는 JWT accessToken 쿠키")
+                        ));
+    }
+}

--- a/src/main/java/back/pickd/global/error/ErrorResponse.java
+++ b/src/main/java/back/pickd/global/error/ErrorResponse.java
@@ -1,5 +1,6 @@
 package back.pickd.global.error;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,10 +8,21 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "공통 오류 응답")
 public class ErrorResponse {
+
+    @Schema(description = "오류 발생 시각", example = "2026-06-20T17:20:00")
     private final LocalDateTime timestamp;
+
+    @Schema(description = "HTTP 상태 코드", example = "400")
     private final int status;
+
+    @Schema(description = "HTTP 오류 이름", example = "Bad Request")
     private final String error;
+
+    @Schema(description = "오류 상세 메시지", example = "batch의 모든 중복 그룹에 대한 선택이 필요합니다.")
     private final String message;
+
+    @Schema(description = "요청 경로", example = "/api/v2/experiences/extract/step3")
     private final String path;
 }

--- a/src/main/java/back/pickd/user/service/OnboardingService.java
+++ b/src/main/java/back/pickd/user/service/OnboardingService.java
@@ -5,6 +5,7 @@ import back.pickd.experience.entity.UserExperience;
 import back.pickd.experience.enums.ExperienceGroup;
 import back.pickd.experience.enums.ExperienceType;
 import back.pickd.experience.enums.Status;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
 import back.pickd.experience.repository.UserExperienceRepository;
 import back.pickd.user.entity.*;
 import back.pickd.user.entity.enums.*;
@@ -25,6 +26,7 @@ public class OnboardingService {
     private final UserInterestRepository interestRepository;
     private final UserPrepStatusRepository prepStatusRepository;
     private final UserExperienceRepository experienceRepository;
+    private final ExperienceExtractionBatchRepository extractionBatchRepository;
     private final UserCertificationRepository certificationRepository;
 
     @Transactional
@@ -87,7 +89,7 @@ public class OnboardingService {
 
     private void updateListInfos(User user, OnboardingRequest dto) {
         if (dto.getExperiences() != null) {
-            experienceRepository.deleteByUser(user);
+            deleteExistingExperiences(user);
             dto.getExperiences().forEach(e -> {
                 ExperienceType expType = ExperienceType.PROJECT;
                 ExperienceGroup expGroup = ExperienceGroup.NARRATIVE;
@@ -147,6 +149,18 @@ public class OnboardingService {
                     .build()
             ));
         }
+    }
+
+    private void deleteExistingExperiences(User user) {
+        extractionBatchRepository.deleteAll(
+                extractionBatchRepository.findByUserOrderByCreatedAtDesc(user)
+        );
+        extractionBatchRepository.flush();
+
+        experienceRepository.deleteAll(
+                experienceRepository.findByUserOrderByCreatedAtDesc(user)
+        );
+        experienceRepository.flush();
     }
 
     @Transactional

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,3 +11,34 @@ CREATE TABLE IF NOT EXISTS oauth2_authorized_client (
   created_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
   PRIMARY KEY (client_registration_id, principal_name)
 );
+
+CREATE TABLE IF NOT EXISTS experience_extraction_batches (
+  id varchar(36) NOT NULL,
+  user_id bigint NOT NULL,
+  status varchar(20) NOT NULL,
+  created_at timestamp NOT NULL,
+  processed_at timestamp DEFAULT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS experience_duplicate_groups (
+  id varchar(36) NOT NULL,
+  batch_id varchar(36) NOT NULL,
+  existing_experience_id varchar(36) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS experience_extraction_drafts (
+  id varchar(36) NOT NULL,
+  duplicate_group_id varchar(36) NOT NULL,
+  title varchar(255) NOT NULL,
+  experience_type varchar(50) NOT NULL,
+  experience_group varchar(20) NOT NULL,
+  status varchar(20) NOT NULL,
+  document_content text DEFAULT NULL,
+  attributes json NOT NULL,
+  keywords json NOT NULL,
+  resume_url text NOT NULL,
+  similarity double DEFAULT NULL,
+  PRIMARY KEY (id)
+);

--- a/src/main/resources/templates/experience-extraction-test.html
+++ b/src/main/resources/templates/experience-extraction-test.html
@@ -1,0 +1,706 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>경험 추출 Local E2E</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f4f6f8;
+            --card: #ffffff;
+            --line: #d8dee6;
+            --text: #18212f;
+            --muted: #617084;
+            --primary: #275efe;
+            --danger: #c9362b;
+            --ok: #16794b;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            color: var(--text);
+            background: var(--bg);
+        }
+        header {
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            padding: 16px 24px;
+            border-bottom: 1px solid var(--line);
+            background: rgba(255, 255, 255, .96);
+        }
+        main {
+            display: grid;
+            grid-template-columns: minmax(0, 1.35fr) minmax(360px, .65fr);
+            gap: 20px;
+            max-width: 1500px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .flow, .side { display: grid; gap: 18px; align-content: start; }
+        .card {
+            padding: 20px;
+            border: 1px solid var(--line);
+            border-radius: 12px;
+            background: var(--card);
+            box-shadow: 0 4px 14px rgba(25, 35, 50, .04);
+        }
+        h1, h2, h3 { margin: 0 0 12px; }
+        h1 { font-size: 20px; }
+        h2 { font-size: 18px; }
+        h3 { font-size: 15px; }
+        p { margin: 6px 0; color: var(--muted); }
+        label { display: grid; gap: 6px; color: var(--muted); font-size: 13px; }
+        input, select, textarea, button { font: inherit; }
+        input[type="text"], select, textarea {
+            width: 100%;
+            padding: 10px 11px;
+            border: 1px solid var(--line);
+            border-radius: 8px;
+            color: var(--text);
+            background: #fff;
+        }
+        textarea { min-height: 100px; resize: vertical; }
+        button, .button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            padding: 9px 13px;
+            border: 1px solid transparent;
+            border-radius: 8px;
+            color: #fff;
+            background: var(--primary);
+            cursor: pointer;
+            text-decoration: none;
+        }
+        button.secondary { color: var(--text); border-color: var(--line); background: #fff; }
+        button.danger { background: var(--danger); }
+        button:disabled { opacity: .5; cursor: not-allowed; }
+        .actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+        .grid-2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+        .list { display: grid; gap: 10px; margin-top: 14px; }
+        .item {
+            padding: 12px;
+            border: 1px solid var(--line);
+            border-radius: 9px;
+            background: #fbfcfd;
+        }
+        .item-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+        .meta { color: var(--muted); font-size: 12px; word-break: break-all; }
+        .badge {
+            display: inline-block;
+            padding: 3px 7px;
+            border-radius: 999px;
+            color: #24415e;
+            background: #e8f0f8;
+            font-size: 11px;
+        }
+        .selected-order { margin: 10px 0 0; padding-left: 24px; }
+        .selected-order li { margin: 7px 0; }
+        .mini { padding: 3px 7px; color: var(--text); border-color: var(--line); background: #fff; }
+        pre {
+            max-height: 420px;
+            margin: 10px 0 0;
+            padding: 12px;
+            overflow: auto;
+            border-radius: 8px;
+            color: #dce8f5;
+            background: #111923;
+            font-size: 12px;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+        .log-entry { padding: 12px 0; border-bottom: 1px solid var(--line); }
+        .log-ok { color: var(--ok); }
+        .log-error { color: var(--danger); }
+        .draft-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 10px; }
+        .attribute-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+        .empty { padding: 16px; color: var(--muted); text-align: center; border: 1px dashed var(--line); border-radius: 8px; }
+        .status-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--danger); }
+        .status-dot.on { background: var(--ok); }
+        .login { display: flex; align-items: center; gap: 9px; }
+        @media (max-width: 980px) {
+            main { grid-template-columns: 1fr; }
+            .grid-2, .attribute-fields { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+<header>
+    <div>
+        <h1>경험 추출 Local E2E</h1>
+        <div class="meta">Step1 → Step2 V2 → Step3 V2 / 실제 S3·Python·OpenAI 호출</div>
+    </div>
+    <div class="login">
+        <span id="auth-dot" class="status-dot" th:classappend="${authenticated} ? ' on' : ''"></span>
+        <span id="auth-text" th:text="${authenticated} ? ${userEmail} : '로그인 필요'">로그인 필요</span>
+        <a class="button" href="/oauth2/authorization/google">Google 로그인</a>
+        <a class="button" href="/logout" style="background:#5d6878">로그아웃</a>
+    </div>
+</header>
+
+<main>
+    <section class="flow">
+        <article class="card">
+            <h2>1. Step1 후보 추출</h2>
+            <p>PDF 입력은 요청 후에도 브라우저에 유지됩니다. 같은 파일로 Step1을 다시 실행할 수 있습니다.</p>
+            <label>
+                분석할 PDF
+                <input id="pdf-file" type="file" accept="application/pdf">
+            </label>
+            <div class="actions">
+                <button id="step1-button" type="button">Step1 실행</button>
+            </div>
+            <div id="step1-candidates" class="list">
+                <div class="empty">아직 추출한 후보가 없습니다.</div>
+            </div>
+            <h3 style="margin-top:16px">Step2 전달 순서</h3>
+            <ol id="selected-order" class="selected-order"></ol>
+        </article>
+
+        <article class="card">
+            <h2>2. Step2 상세 추출·중복 분류</h2>
+            <p>위 순서대로 배치 내부 중복 우선순위를 적용합니다.</p>
+            <div class="actions">
+                <button id="step2-button" type="button">Step2 V2 실행</button>
+            </div>
+            <div id="step2-result" class="list">
+                <div class="empty">Step2 결과가 여기에 표시됩니다.</div>
+            </div>
+        </article>
+
+        <article class="card">
+            <h2>3. Step3 최종 선택</h2>
+            <p>기본 선택은 없습니다. 모든 그룹에서 하나 이상의 기존 경험 또는 Draft를 선택해야 합니다.</p>
+            <div class="actions">
+                <button id="load-pending-button" class="secondary" type="button">
+                    미처리 중복 불러오기
+                </button>
+                <label id="pending-batch-label" style="display:none; min-width:320px">
+                    미처리 batch
+                    <select id="pending-batch-select"></select>
+                </label>
+            </div>
+            <form id="step3-form">
+                <div id="step3-groups" class="list">
+                    <div class="empty">Step2 중복 그룹이 생성되면 선택 항목이 표시됩니다.</div>
+                </div>
+                <div class="actions">
+                    <button id="step3-button" type="submit" disabled>Step3 V2 실행</button>
+                </div>
+            </form>
+        </article>
+
+        <article class="card">
+            <h2>수기 기준 경험 저장</h2>
+            <p>PresetRegistry의 13개 유형과 필드를 그대로 사용합니다.</p>
+            <form id="manual-form">
+                <div class="grid-2">
+                    <label>
+                        경험 유형
+                        <select id="manual-type" required></select>
+                    </label>
+                    <label>
+                        경험 그룹
+                        <input id="manual-group" type="text" readonly>
+                    </label>
+                    <label>
+                        제목
+                        <input id="manual-title" type="text" required>
+                    </label>
+                    <label>
+                        상태
+                        <select id="manual-status">
+                            <option value="COMPLETED">COMPLETED</option>
+                            <option value="IN_PROGRESS">IN_PROGRESS</option>
+                        </select>
+                    </label>
+                </div>
+                <label style="margin-top:12px">
+                    본문
+                    <textarea id="manual-content"></textarea>
+                </label>
+                <label style="margin-top:12px">
+                    키워드 (쉼표 구분)
+                    <input id="manual-keywords" type="text" placeholder="문제 해결, 협업, 실행력">
+                </label>
+                <h3 style="margin-top:16px">Preset attributes</h3>
+                <div id="manual-attributes" class="attribute-fields"></div>
+                <label style="display:flex; grid-template-columns:auto 1fr; align-items:center; margin-top:14px">
+                    <input id="manual-force" type="checkbox" checked>
+                    forceCreate로 중복 검사 없이 기준 데이터 저장
+                </label>
+                <div class="actions">
+                    <button type="submit">수기 경험 저장</button>
+                </div>
+            </form>
+        </article>
+    </section>
+
+    <aside class="side">
+        <article class="card">
+            <div class="item-head">
+                <div>
+                    <h2>현재 사용자 DB 상태</h2>
+                    <p>UserExperience, Temp, Batch, Group, Draft</p>
+                </div>
+                <button id="refresh-state" class="secondary" type="button">새로고침</button>
+            </div>
+            <div id="db-state">
+                <div class="empty">로그인 후 조회할 수 있습니다.</div>
+            </div>
+        </article>
+
+        <article class="card">
+            <div class="item-head">
+                <div>
+                    <h2>API 로그</h2>
+                    <p>요청·응답·상태 코드·처리 시간</p>
+                </div>
+                <button id="clear-log" class="secondary" type="button">비우기</button>
+            </div>
+            <div id="api-log"></div>
+        </article>
+    </aside>
+</main>
+
+<script th:inline="javascript">
+    const presetDefinitions = JSON.parse(/*[[${presetDefinitionsJson}]]*/ '[]');
+    const state = {
+        step1Candidates: [],
+        selectedTempIds: [],
+        duplicateBatchId: null,
+        duplicateGroups: [],
+        pendingBatches: []
+    };
+
+    const byId = id => document.getElementById(id);
+    const escapeHtml = value => String(value ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+    const pretty = value => JSON.stringify(value, null, 2);
+
+    async function apiCall(label, url, options = {}, requestDisplay = null) {
+        const startedAt = performance.now();
+        let response;
+        let payload;
+        try {
+            response = await fetch(url, { credentials: "same-origin", ...options });
+            const text = await response.text();
+            try {
+                payload = text ? JSON.parse(text) : null;
+            } catch {
+                payload = text;
+            }
+        } catch (error) {
+            addLog(label, requestDisplay, { networkError: error.message }, 0,
+                Math.round(performance.now() - startedAt));
+            throw error;
+        }
+
+        addLog(label, requestDisplay, payload, response.status,
+            Math.round(performance.now() - startedAt));
+        if (!response.ok) {
+            throw new Error(payload?.message || payload?.detail || `HTTP ${response.status}`);
+        }
+        return payload;
+    }
+
+    function addLog(label, request, response, status, elapsedMs) {
+        const entry = document.createElement("div");
+        entry.className = "log-entry";
+        const statusClass = status >= 200 && status < 300 ? "log-ok" : "log-error";
+        entry.innerHTML = `
+            <div class="item-head">
+                <strong>${escapeHtml(label)}</strong>
+                <span class="${statusClass}">HTTP ${status || "NETWORK"} · ${elapsedMs}ms</span>
+            </div>
+            <details>
+                <summary>요청</summary>
+                <pre>${escapeHtml(pretty(request))}</pre>
+            </details>
+            <details open>
+                <summary>응답</summary>
+                <pre>${escapeHtml(pretty(response))}</pre>
+            </details>`;
+        byId("api-log").prepend(entry);
+    }
+
+    async function loadAuth() {
+        try {
+            const user = await apiCall("로그인 상태", "/api/user", {}, null);
+            byId("auth-dot").classList.add("on");
+            byId("auth-text").textContent = user.email || user.name || "로그인됨";
+            await refreshState();
+        } catch {
+            byId("auth-dot").classList.remove("on");
+            byId("auth-text").textContent = "로그인 필요";
+        }
+    }
+
+    function renderStep1() {
+        const container = byId("step1-candidates");
+        if (!state.step1Candidates.length) {
+            container.innerHTML = '<div class="empty">추출 후보가 없습니다.</div>';
+            return;
+        }
+        container.innerHTML = state.step1Candidates.map(candidate => `
+            <label class="item" style="display:flex; grid-template-columns:auto 1fr; align-items:start">
+                <input type="checkbox" data-temp-id="${candidate.id}"
+                    ${state.selectedTempIds.includes(candidate.id) ? "checked" : ""}>
+                <span>
+                    <strong>${escapeHtml(candidate.experienceName)}</strong>
+                    <span class="badge">${escapeHtml(candidate.experienceType)}</span>
+                    <span class="badge">${escapeHtml(candidate.experienceGroup)}</span>
+                    <span class="meta">temp ID: ${candidate.id}</span>
+                </span>
+            </label>`).join("");
+        container.querySelectorAll("[data-temp-id]").forEach(input => {
+            input.addEventListener("change", () => {
+                const id = Number(input.dataset.tempId);
+                if (input.checked && !state.selectedTempIds.includes(id)) {
+                    state.selectedTempIds.push(id);
+                } else if (!input.checked) {
+                    state.selectedTempIds = state.selectedTempIds.filter(value => value !== id);
+                }
+                renderSelectedOrder();
+            });
+        });
+        renderSelectedOrder();
+    }
+
+    function renderSelectedOrder() {
+        const order = byId("selected-order");
+        order.innerHTML = state.selectedTempIds.map((id, index) => {
+            const candidate = state.step1Candidates.find(item => item.id === id);
+            return `<li>
+                ${escapeHtml(candidate?.experienceName || id)}
+                <button class="mini" type="button" data-move-up="${index}" ${index === 0 ? "disabled" : ""}>↑</button>
+                <button class="mini" type="button" data-move-down="${index}"
+                    ${index === state.selectedTempIds.length - 1 ? "disabled" : ""}>↓</button>
+            </li>`;
+        }).join("");
+        order.querySelectorAll("[data-move-up]").forEach(button =>
+            button.addEventListener("click", () => moveSelected(Number(button.dataset.moveUp), -1)));
+        order.querySelectorAll("[data-move-down]").forEach(button =>
+            button.addEventListener("click", () => moveSelected(Number(button.dataset.moveDown), 1)));
+    }
+
+    function moveSelected(index, offset) {
+        const target = index + offset;
+        if (target < 0 || target >= state.selectedTempIds.length) return;
+        [state.selectedTempIds[index], state.selectedTempIds[target]] =
+            [state.selectedTempIds[target], state.selectedTempIds[index]];
+        renderSelectedOrder();
+    }
+
+    byId("step1-button").addEventListener("click", async () => {
+        const file = byId("pdf-file").files[0];
+        if (!file) return alert("PDF 파일을 선택하세요.");
+        const form = new FormData();
+        form.append("file", file);
+        try {
+            const result = await apiCall(
+                "POST Step1",
+                "/api/experiences/extract/step1",
+                { method: "POST", body: form },
+                { file: { name: file.name, type: file.type, size: file.size } }
+            );
+            state.step1Candidates = result;
+            state.selectedTempIds = [];
+            state.duplicateBatchId = null;
+            state.duplicateGroups = [];
+            renderStep1();
+            renderStep3();
+            await refreshState();
+        } catch (error) {
+            alert(error.message);
+        }
+    });
+
+    byId("step2-button").addEventListener("click", async () => {
+        if (!state.selectedTempIds.length) return alert("Step2에 전달할 후보를 선택하세요.");
+        const request = { selectedTempIds: state.selectedTempIds };
+        try {
+            const result = await apiCall(
+                "POST Step2 V2",
+                "/api/v2/experiences/extract/step2",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(request)
+                },
+                request
+            );
+            state.duplicateBatchId = result.duplicateBatchId;
+            state.duplicateGroups = result.duplicateGroups || [];
+            renderStep2(result);
+            renderStep3();
+            await refreshState();
+        } catch (error) {
+            alert(error.message);
+        }
+    });
+
+    function renderStep2(result) {
+        const saved = result.savedExperiences || [];
+        const groups = result.duplicateGroups || [];
+        byId("step2-result").innerHTML = `
+            <div class="item">
+                <strong>즉시 저장 ${saved.length}건</strong>
+                ${saved.map(item => `<div>${escapeHtml(item.title)} <span class="meta">${item.id}</span></div>`).join("") || '<div class="meta">없음</div>'}
+            </div>
+            <div class="item">
+                <strong>중복 그룹 ${groups.length}건</strong>
+                <div class="meta">batch: ${escapeHtml(result.duplicateBatchId || "없음")}</div>
+            </div>`;
+    }
+
+    function renderStep3() {
+        const container = byId("step3-groups");
+        if (!state.duplicateGroups.length) {
+            container.innerHTML = '<div class="empty">처리할 중복 그룹이 없습니다.</div>';
+            byId("step3-button").disabled = true;
+            return;
+        }
+        container.innerHTML = state.duplicateGroups.map((group, groupIndex) => `
+            <section class="item" data-group="${group.groupId}">
+                <h3>그룹 ${groupIndex + 1}</h3>
+                <div class="meta">${escapeHtml(group.groupId)}</div>
+                <div class="draft-grid">
+                    ${group.items.map(item => `
+                        <label class="item">
+                            <span style="display:flex; gap:8px; align-items:center">
+                                <input type="checkbox" name="group-${group.groupId}" value="${item.itemId}">
+                                <strong>${escapeHtml(item.source)}</strong>
+                                ${item.similarity == null ? "" : `<span class="badge">similarity ${item.similarity}</span>`}
+                            </span>
+                            <span>${escapeHtml(item.experience.title)}</span>
+                            <span class="meta">${escapeHtml(item.experience.experienceType)} / ${escapeHtml(item.itemId)}</span>
+                            <details>
+                                <summary>상세 데이터</summary>
+                                <pre>${escapeHtml(pretty(item.experience))}</pre>
+                            </details>
+                        </label>`).join("")}
+                </div>
+            </section>`).join("");
+        byId("step3-button").disabled = false;
+    }
+
+    async function loadPendingDuplicates(showEmptyAlert = true) {
+        try {
+            const result = await apiCall(
+                "GET 미처리 중복",
+                "/api/v2/experiences/extract/duplicates/pending",
+                {},
+                null
+            );
+            state.pendingBatches = result.batches || [];
+            const label = byId("pending-batch-label");
+            const select = byId("pending-batch-select");
+
+            if (!state.pendingBatches.length) {
+                label.style.display = "none";
+                if (showEmptyAlert) alert("미처리 중복 batch가 없습니다.");
+                return;
+            }
+
+            select.innerHTML = state.pendingBatches.map(batch =>
+                `<option value="${batch.duplicateBatchId}">
+                    ${escapeHtml(batch.createdAt)} · ${batch.duplicateGroups.length}개 그룹
+                </option>`
+            ).join("");
+            label.style.display = "grid";
+            applyPendingBatch(select.value);
+        } catch (error) {
+            if (showEmptyAlert) alert(error.message);
+        }
+    }
+
+    function applyPendingBatch(batchId) {
+        const batch = state.pendingBatches.find(
+            item => item.duplicateBatchId === batchId
+        );
+        if (!batch) return;
+        state.duplicateBatchId = batch.duplicateBatchId;
+        state.duplicateGroups = batch.duplicateGroups;
+        renderStep3();
+    }
+
+    byId("step3-form").addEventListener("submit", async event => {
+        event.preventDefault();
+        const groups = state.duplicateGroups.map(group => ({
+            groupId: group.groupId,
+            selectedItemIds: [...document.querySelectorAll(`input[name="group-${group.groupId}"]:checked`)]
+                .map(input => input.value)
+        }));
+        if (groups.some(group => group.selectedItemIds.length === 0)) {
+            return alert("각 중복 그룹에서 하나 이상 선택하세요.");
+        }
+        const request = { duplicateBatchId: state.duplicateBatchId, groups };
+        try {
+            await apiCall(
+                "POST Step3 V2",
+                "/api/v2/experiences/extract/step3",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(request)
+                },
+                request
+            );
+            state.duplicateBatchId = null;
+            state.duplicateGroups = [];
+            renderStep3();
+            await refreshState();
+            await loadPendingDuplicates(false);
+        } catch (error) {
+            alert(error.message);
+        }
+    });
+
+    function initManualForm() {
+        const select = byId("manual-type");
+        select.innerHTML = presetDefinitions.map(preset =>
+            `<option value="${preset.type}">${escapeHtml(preset.koreanName)} (${preset.type})</option>`
+        ).join("");
+        select.addEventListener("change", renderManualPreset);
+        renderManualPreset();
+    }
+
+    function renderManualPreset() {
+        const preset = presetDefinitions.find(item => item.type === byId("manual-type").value)
+            || presetDefinitions[0];
+        if (!preset) return;
+        byId("manual-group").value = preset.group;
+        byId("manual-attributes").innerHTML = preset.fields.map(field => `
+            <label>
+                ${escapeHtml(field.label)}
+                <input type="text" data-attribute-key="${escapeHtml(field.key)}">
+                <span class="meta">${escapeHtml(field.key)}</span>
+            </label>`).join("");
+    }
+
+    byId("manual-form").addEventListener("submit", async event => {
+        event.preventDefault();
+        const attributes = {};
+        document.querySelectorAll("[data-attribute-key]").forEach(input => {
+            if (input.value.trim()) attributes[input.dataset.attributeKey] = input.value.trim();
+        });
+        const request = {
+            title: byId("manual-title").value.trim(),
+            experienceType: byId("manual-type").value,
+            experienceGroup: byId("manual-group").value,
+            status: byId("manual-status").value,
+            documentContent: byId("manual-content").value,
+            attributes,
+            keywords: byId("manual-keywords").value.split(",").map(value => value.trim()).filter(Boolean),
+            links: [],
+            forceCreate: byId("manual-force").checked
+        };
+        try {
+            await apiCall(
+                "POST 수기 경험",
+                "/api/experiences",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(request)
+                },
+                request
+            );
+            await refreshState();
+        } catch (error) {
+            alert(error.message);
+        }
+    });
+
+    async function refreshState() {
+        try {
+            const result = await apiCall(
+                "GET DB 상태",
+                "/internal/experience-extraction-test/state",
+                {},
+                null
+            );
+            renderDbState(result);
+        } catch (error) {
+            byId("db-state").innerHTML = `<div class="empty">${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    function renderDbState(result) {
+        byId("db-state").innerHTML = `
+            <div class="item">
+                <strong>${escapeHtml(result.userEmail)}</strong>
+                <div class="meta">
+                    experiences ${result.experiences.length} · temps ${result.temps.length} · batches ${result.batches.length}
+                </div>
+            </div>
+            <details open>
+                <summary>저장 경험 (${result.experiences.length})</summary>
+                <div class="list">
+                    ${result.experiences.map(exp => `
+                        <div class="item">
+                            <div class="item-head">
+                                <strong>${escapeHtml(exp.title)}</strong>
+                                <button class="danger mini" type="button" data-delete-experience="${exp.id}">삭제</button>
+                            </div>
+                            <div class="meta">${escapeHtml(exp.experienceType)} / ${escapeHtml(exp.id)}</div>
+                            <pre>${escapeHtml(pretty(exp))}</pre>
+                        </div>`).join("") || '<div class="empty">없음</div>'}
+                </div>
+            </details>
+            <details>
+                <summary>Temp (${result.temps.length})</summary>
+                <pre>${escapeHtml(pretty(result.temps))}</pre>
+            </details>
+            <details open>
+                <summary>Batch·Group·Draft (${result.batches.length})</summary>
+                <pre>${escapeHtml(pretty(result.batches))}</pre>
+            </details>`;
+        byId("db-state").querySelectorAll("[data-delete-experience]").forEach(button => {
+            button.addEventListener("click", async () => {
+                if (!confirm("이 경험을 삭제할까요?")) return;
+                try {
+                    await apiCall(
+                        "DELETE 경험",
+                        `/api/experiences/${button.dataset.deleteExperience}`,
+                        { method: "DELETE" },
+                        { id: button.dataset.deleteExperience }
+                    );
+                    await refreshState();
+                } catch (error) {
+                    alert(error.message);
+                }
+            });
+        });
+    }
+
+    byId("refresh-state").addEventListener("click", refreshState);
+    byId("load-pending-button").addEventListener(
+        "click",
+        () => loadPendingDuplicates(true)
+    );
+    byId("pending-batch-select").addEventListener(
+        "change",
+        event => applyPendingBatch(event.target.value)
+    );
+    byId("clear-log").addEventListener("click", () => byId("api-log").innerHTML = "");
+
+    initManualForm();
+    renderSelectedOrder();
+    loadAuth();
+</script>
+</body>
+</html>

--- a/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestControllerIntegrationTest.java
+++ b/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestControllerIntegrationTest.java
@@ -1,0 +1,238 @@
+package back.pickd.experience.controller;
+
+import back.pickd.auth.jwt.JwtTokenProvider;
+import back.pickd.experience.entity.ExperienceDuplicateGroup;
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.ExperienceTemp;
+import back.pickd.experience.entity.UserExperience;
+import back.pickd.experience.dto.ExperienceExtractionTestDto.PresetDefinition;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.Status;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.ExperienceTempRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.entity.User;
+import back.pickd.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+class ExperienceExtractionTestControllerIntegrationTest {
+
+    private static final String OWNER_EMAIL = "test-owner@example.com";
+    private static final String OTHER_EMAIL = "test-other@example.com";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserExperienceRepository experienceRepository;
+
+    @Autowired
+    private ExperienceTempRepository tempRepository;
+
+    @Autowired
+    private ExperienceExtractionBatchRepository batchRepository;
+
+    @MockitoBean
+    private S3Service s3Service;
+
+    @MockitoBean
+    private AiClient aiClient;
+
+    private User owner;
+    private User other;
+
+    @BeforeEach
+    void setUp() {
+        clearDatabase();
+        owner = userRepository.save(User.builder()
+                .email(OWNER_EMAIL)
+                .name("테스트 소유자")
+                .build());
+        other = userRepository.save(User.builder()
+                .email(OTHER_EMAIL)
+                .name("다른 사용자")
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    @Test
+    void localPageIsPublicAndProvidesAllPresetDefinitions() throws Exception {
+        MvcResult result = mockMvc.perform(get("/experience-extraction-test"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("experience-extraction-test"))
+                .andExpect(model().attribute("authenticated", false))
+                .andExpect(model().attribute("presetDefinitions", hasSize(13)))
+                .andExpect(content().string(
+                        org.hamcrest.Matchers.containsString("project_name")
+                ))
+                .andExpect(content().string(
+                        org.hamcrest.Matchers.containsString("미처리 중복 불러오기")
+                ))
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<PresetDefinition> presets = (List<PresetDefinition>) result
+                .getModelAndView()
+                .getModel()
+                .get("presetDefinitions");
+        PresetDefinition research = presets.stream()
+                .filter(preset -> "RESEARCH".equals(preset.type()))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("학부연구생", research.koreanName());
+        assertEquals("NARRATIVE", research.group());
+        assertTrue(research.fields().stream()
+                .anyMatch(field -> "lab_name".equals(field.key())));
+    }
+
+    @Test
+    void stateEndpointReturnsOnlyAuthenticatedUsersData() throws Exception {
+        UserExperience ownerExperience = experienceRepository.save(
+                experience(owner, "소유자 프로젝트")
+        );
+        experienceRepository.save(experience(other, "타 사용자 프로젝트"));
+        tempRepository.save(temp(owner, "소유자 Temp"));
+        tempRepository.save(temp(other, "타 사용자 Temp"));
+
+        ExperienceExtractionBatch ownerBatch =
+                new ExperienceExtractionBatch(owner);
+        ExperienceDuplicateGroup ownerGroup =
+                new ExperienceDuplicateGroup(ownerExperience);
+        ownerGroup.addDraft(draft("소유자 Draft"));
+        ownerBatch.addGroup(ownerGroup);
+        batchRepository.saveAndFlush(ownerBatch);
+
+        UserExperience otherExperience = experienceRepository.findByUserOrderByCreatedAtDesc(other)
+                .get(0);
+        ExperienceExtractionBatch otherBatch =
+                new ExperienceExtractionBatch(other);
+        ExperienceDuplicateGroup otherGroup =
+                new ExperienceDuplicateGroup(otherExperience);
+        otherGroup.addDraft(draft("타 사용자 Draft"));
+        otherBatch.addGroup(otherGroup);
+        batchRepository.saveAndFlush(otherBatch);
+
+        mockMvc.perform(get("/internal/experience-extraction-test/state")
+                        .cookie(accessToken(owner)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userEmail").value(OWNER_EMAIL))
+                .andExpect(jsonPath("$.experiences", hasSize(1)))
+                .andExpect(jsonPath("$.experiences[*].title",
+                        hasItem("소유자 프로젝트")))
+                .andExpect(jsonPath("$.temps", hasSize(1)))
+                .andExpect(jsonPath("$.temps[0].experienceName")
+                        .value("소유자 Temp"))
+                .andExpect(jsonPath("$.batches", hasSize(1)))
+                .andExpect(jsonPath("$.batches[0].duplicateGroups", hasSize(1)))
+                .andExpect(jsonPath(
+                        "$.batches[0].duplicateGroups[0].existingExperience.title"
+                ).value("소유자 프로젝트"))
+                .andExpect(jsonPath(
+                        "$.batches[0].duplicateGroups[0].drafts[0].title"
+                ).value("소유자 Draft"))
+                .andExpect(content().string(
+                        org.hamcrest.Matchers.not(
+                                org.hamcrest.Matchers.containsString("타 사용자")
+                        )
+                ));
+    }
+
+    private UserExperience experience(User user, String title) {
+        return UserExperience.builder()
+                .user(user)
+                .title(title)
+                .experienceType(ExperienceType.PROJECT)
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .status(Status.COMPLETED)
+                .documentContent(title + " 본문")
+                .attributes(Map.of("project_name", title))
+                .keywords(List.of("문제 해결"))
+                .build();
+    }
+
+    private ExperienceTemp temp(User user, String name) {
+        return ExperienceTemp.builder()
+                .user(user)
+                .experienceName(name)
+                .experienceGroup("상세 서술형")
+                .experienceType("프로젝트")
+                .resumeUrl("https://cdn.example.com/" + name + ".pdf")
+                .build();
+    }
+
+    private ExperienceExtractionDraft draft(String title) {
+        return ExperienceExtractionDraft.builder()
+                .title(title)
+                .experienceType(ExperienceType.PROJECT)
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .status(Status.COMPLETED)
+                .documentContent(title + " 본문")
+                .attributes(Map.of("project_name", title))
+                .keywords(List.of("협업"))
+                .resumeUrl("https://cdn.example.com/resume.pdf")
+                .similarity(0.91)
+                .build();
+    }
+
+    private Cookie accessToken(User user) {
+        String token = jwtTokenProvider.createToken(
+                user.getEmail(),
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        return new Cookie("accessToken", token);
+    }
+
+    private void clearDatabase() {
+        batchRepository.deleteAll();
+        batchRepository.flush();
+        tempRepository.deleteAll();
+        tempRepository.flush();
+        experienceRepository.deleteAll();
+        experienceRepository.flush();
+        userRepository.deleteAll();
+        userRepository.flush();
+    }
+}

--- a/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestProfileTest.java
+++ b/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestProfileTest.java
@@ -1,0 +1,38 @@
+package back.pickd.experience.controller;
+
+import back.pickd.experience.service.ExperienceExtractionTestService;
+import back.pickd.experience.support.PresetRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ExperienceExtractionTestProfileTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withBean(PresetRegistry.class)
+                    .withBean(ObjectMapper.class)
+                    .withBean(
+                            ExperienceExtractionTestService.class,
+                            () -> mock(ExperienceExtractionTestService.class)
+                    )
+                    .withUserConfiguration(TestConfiguration.class);
+
+    @Test
+    void controllerIsNotCreatedOutsideLocalProfile() {
+        contextRunner
+                .withPropertyValues("spring.profiles.active=prod")
+                .run(context -> assertThat(context)
+                        .doesNotHaveBean(ExperienceExtractionTestController.class));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Import(ExperienceExtractionTestController.class)
+    static class TestConfiguration {
+    }
+}

--- a/src/test/java/back/pickd/user/service/OnboardingServiceIntegrationTest.java
+++ b/src/test/java/back/pickd/user/service/OnboardingServiceIntegrationTest.java
@@ -1,0 +1,165 @@
+package back.pickd.user.service;
+
+import back.pickd.experience.entity.ExperienceDuplicateGroup;
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.ExperienceFile;
+import back.pickd.experience.entity.UserExperience;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.Status;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.dto.onboarding.OnboardingRequest;
+import back.pickd.user.entity.User;
+import back.pickd.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@SpringBootTest
+class OnboardingServiceIntegrationTest {
+
+    @Autowired
+    private OnboardingService onboardingService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserExperienceRepository experienceRepository;
+
+    @Autowired
+    private ExperienceExtractionBatchRepository batchRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private S3Service s3Service;
+
+    @MockitoBean
+    private AiClient aiClient;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        clearDatabase();
+        user = userRepository.save(User.builder()
+                .email("onboarding@example.com")
+                .name("온보딩 사용자")
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    @Test
+    void replacingOnboardingExperiencesDeletesFilesAndPendingDraftsFirst()
+            throws Exception {
+        UserExperience existing = UserExperience.builder()
+                .user(user)
+                .title("기존 경험")
+                .experienceType(ExperienceType.PROJECT)
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .status(Status.COMPLETED)
+                .documentContent("기존 본문")
+                .attributes(Map.of("project_name", "기존 경험"))
+                .keywords(List.of("기존"))
+                .build();
+        existing.updateFiles(List.of(ExperienceFile.builder()
+                .originalFilename("resume.pdf")
+                .fileType("application/pdf")
+                .fileSize(100L)
+                .filePath("https://cdn.example.com/resume.pdf")
+                .source("RESUME_ORIGINAL")
+                .build()));
+        existing = experienceRepository.saveAndFlush(existing);
+
+        ExperienceExtractionBatch batch = new ExperienceExtractionBatch(user);
+        ExperienceDuplicateGroup group = new ExperienceDuplicateGroup(existing);
+        group.addDraft(ExperienceExtractionDraft.builder()
+                .title("중복 Draft")
+                .experienceType(ExperienceType.PROJECT)
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .status(Status.COMPLETED)
+                .documentContent("Draft 본문")
+                .attributes(Map.of("project_name", "중복 Draft"))
+                .keywords(List.of("중복"))
+                .resumeUrl("https://cdn.example.com/resume.pdf")
+                .similarity(0.92)
+                .build());
+        batch.addGroup(group);
+        batchRepository.saveAndFlush(batch);
+
+        String existingId = existing.getId();
+        OnboardingRequest request = objectMapper.readValue("""
+                {
+                  "targetPeriod": "2026 하반기",
+                  "currentStage": "서류 준비",
+                  "focusItems": ["자기소개서"],
+                  "hasResume": true,
+                  "hasBaseEssay": false,
+                  "hasPortfolio": false,
+                  "experiences": [
+                    {
+                      "type": "PROJECT",
+                      "title": "새 온보딩 경험",
+                      "startDate": "2026-01",
+                      "endDate": "2026-03"
+                    }
+                  ]
+                }
+                """, OnboardingRequest.class);
+
+        onboardingService.updateOnboarding(user.getEmail(), request);
+
+        assertFalse(experienceRepository.findById(existingId).isPresent());
+        assertEquals(0, count("experience_files"));
+        assertEquals(0, count("experience_extraction_batches"));
+        assertEquals(0, count("experience_duplicate_groups"));
+        assertEquals(0, count("experience_extraction_drafts"));
+        assertEquals(
+                List.of("새 온보딩 경험"),
+                experienceRepository.findByUserOrderByCreatedAtDesc(user).stream()
+                        .map(UserExperience::getTitle)
+                        .toList()
+        );
+    }
+
+    private int count(String tableName) {
+        Integer count = jdbcTemplate.queryForObject(
+                "select count(*) from " + tableName,
+                Integer.class
+        );
+        return count != null ? count : 0;
+    }
+
+    private void clearDatabase() {
+        batchRepository.deleteAll();
+        batchRepository.flush();
+        experienceRepository.deleteAll();
+        experienceRepository.flush();
+        userRepository.deleteAll();
+        userRepository.flush();
+    }
+}


### PR DESCRIPTION

---

## Stack 2 PR 본문

## 관련 이슈

- #43
- Stack PR: 2/6
- Base: `Back/feat/43-01-experience-schema-contract`

## 작업 내용

Step2에서 중복으로 판정된 경험을 Step3 사용자 선택 전까지 안전하게 보관하기 위한 Spring 영속 모델을 추가했습니다.

기존에는 중복 후보를 요청 응답에만 포함했기 때문에 응답이 유실되거나 화면이 새로고침되면 중복 처리 상태를 복구하기 어려웠습니다.

이번 PR에서는 중복 추출 결과를 다음 구조로 저장합니다.

```text
ExperienceExtractionBatch
  └─ ExperienceDuplicateGroup
       ├─ 기존 UserExperience
       └─ ExperienceExtractionDraft