### PR TITLE
[55 - Stack 1/2] 경험 저장 N+1 쿼리 최적화

### DIFF
--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
@@ -115,8 +115,8 @@ public class ExperienceExtractionService {
         // 3. AI 2차 분석 호출 (S3 CloudFront URL을 던져 2차 정밀 분석 수행)
         AiStep2Response aiResponse = aiClient.extractStep2ByUrl(resumeUrl, selectedSummaries, existingExperiences);
 
-        // 4. 2차 상세 분석 결과 영구 저장 및 파일 연동
-        List<UserExperience> savedExperiences = new ArrayList<>();
+        // 4. 2차 상세 분석 결과 빌드 (저장은 일괄 처리)
+        List<UserExperience> toSave = new ArrayList<>();
         List<Conflict> mergeCandidates = new ArrayList<>();
         if (aiResponse.getExperiences() != null) {
             for (AiStep2Response.Step2ExperienceDto dto : aiResponse.getExperiences()) {
@@ -141,7 +141,7 @@ public class ExperienceExtractionService {
                         .keywords(dto.getKeywords() != null ? dto.getKeywords() : new ArrayList<>())
                         .build();
 
-                // 첨부 파일 등록 (자소서 원본 출처 명시)
+                // 첨부 파일 등록 — CascadeType.ALL 로 saveAll 시 함께 저장됨
                 ExperienceFile resumeFile = ExperienceFile.builder()
                         .userExperience(userExperience)
                         .originalFilename("자기소개서 원본.pdf")
@@ -152,9 +152,12 @@ public class ExperienceExtractionService {
                         .build();
                 userExperience.updateFiles(List.of(resumeFile));
 
-                savedExperiences.add(experienceRepository.save(userExperience));
+                toSave.add(userExperience);
             }
         }
+
+        // 경험 + 파일 일괄 저장 (DB 왕복 1회)
+        List<UserExperience> savedExperiences = experienceRepository.saveAll(toSave);
 
         // 5. 사용 완료된 임시 캐시 데이터 일괄 삭제
         tempRepository.deleteByUser(user);
@@ -169,7 +172,7 @@ public class ExperienceExtractionService {
     public Step3Response confirmStep3(String email, Step3Request request) {
         User user = userService.findByEmail(email);
 
-        List<ExperienceResponse> savedExperiences = new ArrayList<>();
+        List<UserExperience> toSave = new ArrayList<>();
         int skippedCount = 0;
 
         for (Decision decision : request.getDecisions()) {
@@ -192,8 +195,12 @@ public class ExperienceExtractionService {
                     .keywords(decision.getDraft().getKeywords() != null ? decision.getDraft().getKeywords() : new ArrayList<>())
                     .build();
 
-            savedExperiences.add(new ExperienceResponse(experienceRepository.save(experience)));
+            toSave.add(experience);
         }
+
+        // 경험 일괄 저장 (DB 왕복 1회)
+        List<ExperienceResponse> savedExperiences = experienceRepository.saveAll(toSave)
+                .stream().map(ExperienceResponse::new).toList();
 
         return new Step3Response(savedExperiences, skippedCount);
     }

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
@@ -77,7 +77,8 @@ public class ExperienceExtractionV2Service {
                 selectedExperiences
         );
 
-        List<UserExperience> savedExperiences = new ArrayList<>();
+        // UUID를 @PrePersist 이전에 수동 할당 → 루프 내 즉시 참조 가능, save() 지연 가능
+        List<UserExperience> toSave = new ArrayList<>();
         Map<Integer, UserExperience> savedByTargetIndex = new HashMap<>();
         Map<String, ExperienceDuplicateGroup> groupsByExistingId = new LinkedHashMap<>();
         ExperienceExtractionBatch batch = null;
@@ -87,15 +88,15 @@ public class ExperienceExtractionV2Service {
             SelectedExperience selected = selectedExperiences.get(index);
 
             if (!dto.isNeeds_merge()) {
-                UserExperience saved = saveExtractedExperience(
+                UserExperience experience = buildExtractedExperience(
                         user,
                         dto,
                         selected.type(),
                         selected.group(),
                         resumeUrl
                 );
-                savedExperiences.add(saved);
-                savedByTargetIndex.put(index, saved);
+                toSave.add(experience);
+                savedByTargetIndex.put(index, experience);
                 continue;
             }
 
@@ -128,6 +129,9 @@ public class ExperienceExtractionV2Service {
                     .similarity(dto.getMerge_similarity())
                     .build());
         }
+
+        // 경험 + 파일 일괄 저장 (CascadeType.ALL 로 ExperienceFile 함께 INSERT)
+        List<UserExperience> savedExperiences = experienceRepository.saveAll(toSave);
 
         if (batch != null) {
             batchRepository.save(batch);
@@ -198,10 +202,13 @@ public class ExperienceExtractionV2Service {
 
             for (ExperienceExtractionDraft draft : group.getDrafts()) {
                 if (selectedItemIds.contains(draft.getId())) {
-                    selectedExperiences.add(saveDraftExperience(user, draft));
+                    selectedExperiences.add(buildDraftExperience(user, draft));
                 }
             }
         }
+
+        // Draft에서 생성된 경험 일괄 저장 (CascadeType.ALL 로 ExperienceFile 함께 INSERT)
+        experienceRepository.saveAll(selectedExperiences);
 
         batch.complete();
         batchRepository.saveAndFlush(batch);
@@ -330,7 +337,12 @@ public class ExperienceExtractionV2Service {
                 ));
     }
 
-    private UserExperience saveExtractedExperience(
+    /**
+     * UserExperience 객체를 빌드만 하고 저장은 하지 않습니다.
+     * UUID를 @PrePersist 이전에 수동 할당하여 저장 전에도 ID 참조가 가능합니다.
+     * 호출부에서 saveAll()로 일괄 저장하세요.
+     */
+    private UserExperience buildExtractedExperience(
             User user,
             AiStep2Response.Step2ExperienceDto dto,
             ExperienceType type,
@@ -338,6 +350,7 @@ public class ExperienceExtractionV2Service {
             String resumeUrl
     ) {
         UserExperience experience = UserExperience.builder()
+                .id(java.util.UUID.randomUUID().toString())
                 .user(user)
                 .title(dto.getExperience_name())
                 .experienceType(type)
@@ -348,11 +361,16 @@ public class ExperienceExtractionV2Service {
                 .keywords(dto.getKeywords() != null ? dto.getKeywords() : new ArrayList<>())
                 .build();
         attachResumeFile(experience, resumeUrl);
-        return experienceRepository.save(experience);
+        return experience;
     }
 
-    private UserExperience saveDraftExperience(User user, ExperienceExtractionDraft draft) {
+    /**
+     * Draft로부터 UserExperience를 빌드만 하고 저장은 하지 않습니다.
+     * 호출부에서 saveAll()로 일괄 저장하세요.
+     */
+    private UserExperience buildDraftExperience(User user, ExperienceExtractionDraft draft) {
         UserExperience experience = UserExperience.builder()
+                .id(java.util.UUID.randomUUID().toString())
                 .user(user)
                 .title(draft.getTitle())
                 .experienceType(draft.getExperienceType())
@@ -363,7 +381,7 @@ public class ExperienceExtractionV2Service {
                 .keywords(draft.getKeywords())
                 .build();
         attachResumeFile(experience, draft.getResumeUrl());
-        return experienceRepository.save(experience);
+        return experience;
     }
 
     private void attachResumeFile(UserExperience experience, String resumeUrl) {


### PR DESCRIPTION
## 관련 이슈
- #55
- Stack PR: 1/2
- Base: `Back/refactor/optimize-batch-save`

## 문제
`extractStep2`, `confirmStep3` 두 메서드 모두 루프 안에서 `experienceRepository.save()`를 반복 호출합니다.
경험 N개 저장 시 DB 왕복이 N번 발생합니다.

## 작업 내용
- `extractStep2`: 빌드 로직과 저장 로직 분리 후 `saveAll()` 일괄 처리
- `confirmStep3`: 동일하게 `saveAll()` 적용
- `ExperienceFile`은 `CascadeType.ALL`로 연결되어 있어 별도 처리 불필요

## 테스트
- 경험 N개 저장 시 INSERT 쿼리가 1회 배치로 실행되는지 확인
- 파일(ExperienceFile) cascade 저장 정상 동작 확인
- merge 후보 경험은 저장 제외 확인