### PR TITLE
[59] BE 전체 도메인 데이터 정합성 및 무결성 강화

### DIFF
--- a/src/main/java/back/pickd/application/controller/ApplicationController.java
+++ b/src/main/java/back/pickd/application/controller/ApplicationController.java
@@ -1,13 +1,11 @@
 package back.pickd.application.controller;
 
-import back.pickd.application.entity.Application;
-import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.application.dto.request.ApplicationRequest;
+import back.pickd.application.entity.Application;
 import back.pickd.application.service.ApplicationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -15,12 +13,12 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/application")
 public class ApplicationController {
+
     private final ApplicationService applicationService;
-    private final ApplicationRepository applicationRepository;
 
     @GetMapping
-    public List<Application> getAll() {
-        return applicationRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+    public List<Application> getAll(Authentication auth) {
+        return applicationService.getApplications(auth);
     }
 
     @PostMapping

--- a/src/main/java/back/pickd/application/controller/TodoController.java
+++ b/src/main/java/back/pickd/application/controller/TodoController.java
@@ -13,38 +13,32 @@ import java.util.List;
 @RequestMapping("/api/todo")
 @RequiredArgsConstructor
 public class TodoController {
+
     private final TodoService todoService;
 
     @PostMapping
-    public TodoResponse addTodo(
-            @RequestBody TodoRequest dto,
-            Authentication authentication
-    ) {
+    public TodoResponse addTodo(@RequestBody TodoRequest dto, Authentication authentication) {
         return todoService.addTodo(dto, authentication);
     }
 
     @GetMapping
-    public List<TodoResponse> getTodos() {
-        return todoService.getTodos();
+    public List<TodoResponse> getTodos(Authentication authentication) {
+        return todoService.getTodos(authentication);
     }
 
     @GetMapping("/application/{applicationId}")
-    public List<TodoResponse> getTodosByApplication(
-            @PathVariable Long applicationId
-    ) {
-        return todoService.getTodosByApplication(applicationId);
+    public List<TodoResponse> getTodosByApplication(@PathVariable Long applicationId,
+                                                     Authentication authentication) {
+        return todoService.getTodosByApplication(applicationId, authentication);
     }
 
     @PutMapping("/{id}")
-    public void toggleTodo(@PathVariable Long id) {
-        todoService.toggleTodo(id);
+    public void toggleTodo(@PathVariable Long id, Authentication authentication) {
+        todoService.toggleTodo(id, authentication);
     }
 
     @DeleteMapping("/{id}")
-    public void deleteTodo(
-            @PathVariable Long id,
-            Authentication authentication
-    ) {
+    public void deleteTodo(@PathVariable Long id, Authentication authentication) {
         todoService.deleteTodo(id, authentication);
     }
 }

--- a/src/main/java/back/pickd/application/dto/request/ApplicationRequest.java
+++ b/src/main/java/back/pickd/application/dto/request/ApplicationRequest.java
@@ -1,7 +1,10 @@
 package back.pickd.application.dto.request;
 
+import back.pickd.application.enums.ApplicationStatus;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+
 import java.time.LocalDateTime;
 
 @Getter
@@ -12,7 +15,10 @@ public class ApplicationRequest {
     private String jobTitle;
     private String position;
     private String industry;
-    private String status;
+
+    @NotNull
+    private ApplicationStatus status;
+
     private String memo;
 
     private LocalDateTime applyDate;

--- a/src/main/java/back/pickd/application/dto/response/ApplicationResponse.java
+++ b/src/main/java/back/pickd/application/dto/response/ApplicationResponse.java
@@ -1,0 +1,79 @@
+package back.pickd.application.dto.response;
+
+import back.pickd.application.entity.Application;
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.document.entity.Document;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ApplicationResponse {
+
+    private Long id;
+    private List<TodoResponse> todos;
+    private String company;
+    private String jobTitle;
+    private String position;
+    private String industry;
+    private ApplicationStatus status;   // @JsonValue → "지원 예정" 형태로 직렬화
+    private String memo;
+    private LocalDateTime applyDate;
+    private LocalDateTime interviewDate;
+    private LocalDateTime deadlineDate;
+    private String applyEventId;
+    private String interviewEventId;
+    private String deadlineEventId;
+    private boolean important;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<DocumentSummary> documents;
+
+    public static ApplicationResponse from(Application app) {
+        return ApplicationResponse.builder()
+                .id(app.getId())
+                .todos(app.getTodos().stream().map(TodoResponse::from).toList())
+                .company(app.getCompany())
+                .jobTitle(app.getJobTitle())
+                .position(app.getPosition())
+                .industry(app.getIndustry())
+                .status(app.getStatus())
+                .memo(app.getMemo())
+                .applyDate(app.getApplyDate())
+                .interviewDate(app.getInterviewDate())
+                .deadlineDate(app.getDeadlineDate())
+                .applyEventId(app.getApplyEventId())
+                .interviewEventId(app.getInterviewEventId())
+                .deadlineEventId(app.getDeadlineEventId())
+                .important(app.isImportant())
+                .createdAt(app.getCreatedAt())
+                .updatedAt(app.getUpdatedAt())
+                .documents(app.getDocuments().stream().map(DocumentSummary::from).toList())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class DocumentSummary {
+        private Long id;
+        private String title;
+        private String company;
+        private String type;
+        private String status;
+        private Integer progress;
+
+        public static DocumentSummary from(Document doc) {
+            return DocumentSummary.builder()
+                    .id(doc.getId())
+                    .title(doc.getTitle())
+                    .company(doc.getCompany())
+                    .type(doc.getType() != null ? doc.getType().getLabel() : null)
+                    .status(doc.getStatus() != null ? doc.getStatus().getLabel() : null)
+                    .progress(doc.getProgress())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/back/pickd/application/entity/Application.java
+++ b/src/main/java/back/pickd/application/entity/Application.java
@@ -1,39 +1,42 @@
 package back.pickd.application.entity;
 
-import java.util.List;
-
+import back.pickd.application.enums.ApplicationStatus;
 import back.pickd.document.entity.Document;
-
+import back.pickd.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
-
-import java.util.ArrayList;
-import java.time.LocalDateTime;
-
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
+@Table(name = "applications")
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Application {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Builder.Default
-    @JsonManagedReference
-    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Todo> todos = new ArrayList<>();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ApplicationStatus status;
 
     private String company;
     private String jobTitle;
     private String position;
     private String industry;
-    private String status;
     private String memo;
+
     private LocalDateTime applyDate;
     private LocalDateTime interviewDate;
     private LocalDateTime deadlineDate;
@@ -43,13 +46,73 @@ public class Application {
     private String deadlineEventId;
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean important = false;
-    
-    @OneToMany(
-        mappedBy = "application",
-        cascade = CascadeType.ALL,
-        orphanRemoval = true
-    )
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder.Default
+    @JsonManagedReference
+    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Todo> todos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Document> documents = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // ── 도메인 메서드 ──────────────────────────────────────────────────────────
+
+    public void update(String company, String jobTitle, String position, String industry,
+                       ApplicationStatus status, boolean important, String memo,
+                       LocalDateTime applyDate, LocalDateTime interviewDate, LocalDateTime deadlineDate) {
+        this.company = company;
+        this.jobTitle = jobTitle;
+        this.position = position;
+        this.industry = industry;
+        this.status = status;
+        this.important = important;
+        this.memo = memo;
+        this.applyDate = applyDate;
+        this.interviewDate = interviewDate;
+        this.deadlineDate = deadlineDate;
+    }
+
+    public void assignApplyEventId(String eventId) {
+        this.applyEventId = eventId;
+    }
+
+    public void assignInterviewEventId(String eventId) {
+        this.interviewEventId = eventId;
+    }
+
+    public void assignDeadlineEventId(String eventId) {
+        this.deadlineEventId = eventId;
+    }
+
+    public void clearApplyEventId() {
+        this.applyEventId = null;
+    }
+
+    public void clearInterviewEventId() {
+        this.interviewEventId = null;
+    }
+
+    public void clearDeadlineEventId() {
+        this.deadlineEventId = null;
+    }
 }

--- a/src/main/java/back/pickd/application/entity/Application.java
+++ b/src/main/java/back/pickd/application/entity/Application.java
@@ -1,6 +1,7 @@
 package back.pickd.application.entity;
 
 import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.coverletter.entity.CoverLetterItem;
 import back.pickd.document.entity.Document;
 import back.pickd.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
@@ -63,6 +64,10 @@ public class Application {
     @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Document> documents = new ArrayList<>();
+
+    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CoverLetterItem> coverLetterItems = new ArrayList<>();
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/back/pickd/application/entity/Todo.java
+++ b/src/main/java/back/pickd/application/entity/Todo.java
@@ -1,37 +1,70 @@
 package back.pickd.application.entity;
 
+import back.pickd.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 @Entity
+@Table(name = "todos")
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class Todo {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String title;
 
-    private boolean completed;
-    private LocalDateTime dueDateTime;
-
-    @Column(length = 1000)
-    private String memo;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "application_id")
     private Application application;
 
+    private String title;
+
+    @Builder.Default
+    private boolean completed = false;
+
+    private LocalDateTime dueDateTime;
+
+    @Column(length = 1000)
+    private String memo;
+
     @Column(name = "calendar_event_id")
     private String calendarEventId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // ── 도메인 메서드 ──────────────────────────────────────────────────────────
+
+    public void toggleCompleted() {
+        this.completed = !this.completed;
+    }
+
+    public void assignCalendarEventId(String eventId) {
+        this.calendarEventId = eventId;
+    }
 }

--- a/src/main/java/back/pickd/application/enums/ApplicationStatus.java
+++ b/src/main/java/back/pickd/application/enums/ApplicationStatus.java
@@ -1,0 +1,30 @@
+package back.pickd.application.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApplicationStatus {
+
+    PREPARING("지원 예정"),
+    WRITING("작성중"),
+    SUBMITTED("제출 완료"),
+    WAITING("결과 대기"),
+    INTERVIEW("면접 전형"),
+    FINAL("최종 결과");
+
+    private final String label;
+
+    public boolean needsApplyEvent() {
+        return this == PREPARING || this == WRITING;
+    }
+
+    public boolean needsInterviewEvent() {
+        return this == SUBMITTED || this == WAITING || this == INTERVIEW;
+    }
+
+    public boolean needsDeadlineEvent() {
+        return this == FINAL;
+    }
+}

--- a/src/main/java/back/pickd/application/repository/ApplicationRepository.java
+++ b/src/main/java/back/pickd/application/repository/ApplicationRepository.java
@@ -1,6 +1,15 @@
 package back.pickd.application.repository;
 
 import back.pickd.application.entity.Application;
+import back.pickd.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ApplicationRepository extends JpaRepository<Application, Long> {}
+import java.util.List;
+import java.util.Optional;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+
+    List<Application> findAllByUserOrderByIdDesc(User user);
+
+    Optional<Application> findByIdAndUser(Long id, User user);
+}

--- a/src/main/java/back/pickd/application/repository/TodoRepository.java
+++ b/src/main/java/back/pickd/application/repository/TodoRepository.java
@@ -1,26 +1,32 @@
 package back.pickd.application.repository;
 
 import back.pickd.application.entity.Todo;
+import back.pickd.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     @Query("""
-        select t
-        from Todo t
+        select t from Todo t
         left join fetch t.application
+        where t.user = :user
+        order by t.id desc
     """)
-    List<Todo> findAllWithApplication();
+    List<Todo> findAllByUserWithApplication(@Param("user") User user);
 
     @Query("""
-        select t
-        from Todo t
+        select t from Todo t
         left join fetch t.application
         where t.application.id = :applicationId
+        and t.user = :user
     """)
-    List<Todo> findByApplicationId(@Param("applicationId") Long applicationId);
+    List<Todo> findByApplicationIdAndUser(@Param("applicationId") Long applicationId,
+                                          @Param("user") User user);
+
+    Optional<Todo> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/back/pickd/application/service/ApplicationService.java
+++ b/src/main/java/back/pickd/application/service/ApplicationService.java
@@ -1,93 +1,79 @@
 package back.pickd.application.service;
 
+import back.pickd.application.dto.request.ApplicationRequest;
+import back.pickd.application.entity.Application;
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.application.repository.ApplicationRepository;
+import back.pickd.calendar.service.CalendarAsyncService;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventDateTime;
-import com.google.api.client.util.DateTime;
-
-import back.pickd.application.entity.Application;
-import back.pickd.application.repository.ApplicationRepository;
-import back.pickd.application.dto.request.ApplicationRequest;
-import back.pickd.calendar.service.CalendarAsyncService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.security.core.Authentication;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ApplicationService {
+
     private final ApplicationRepository applicationRepository;
     private final CalendarAsyncService calendarAsyncService;
+    private final UserService userService;
 
-    private Event buildEvent(String type, String company, String jobTitle, LocalDateTime dateTime) {
-        Event event = new Event();
-        event.setSummary(company + " " + jobTitle + " " + type);
-
-        DateTime googleDateTime = new DateTime(java.sql.Timestamp.valueOf(dateTime));
-
-        EventDateTime start = new EventDateTime()
-                .setDateTime(googleDateTime)
-                .setTimeZone("Asia/Seoul");
-
-        EventDateTime end = new EventDateTime()
-                .setDateTime(googleDateTime)
-                .setTimeZone("Asia/Seoul");
-        event.setStart(start);
-        event.setEnd(end);
-
-        return event;
+    @Transactional(readOnly = true)
+    public List<Application> getApplications(Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        return applicationRepository.findAllByUserOrderByIdDesc(user);
     }
 
     @Transactional
     public void addApplication(ApplicationRequest dto, Authentication auth) throws Exception {
-        Application app = new Application();
-        app.setCompany(dto.getCompany());
-        app.setJobTitle(dto.getJobTitle());
-        app.setApplyDate(dto.getApplyDate());
-        app.setInterviewDate(dto.getInterviewDate());
-        app.setDeadlineDate(dto.getDeadlineDate());
-        app.setPosition(dto.getPosition());
-        app.setIndustry(dto.getIndustry());
-        app.setStatus(dto.getStatus());
-        app.setImportant(dto.isImportant());
-        app.setMemo(dto.getMemo());
+        User user = userService.findByEmail(auth.getName());
+        ApplicationStatus status = dto.getStatus();
+
+        Application app = Application.builder()
+                .user(user)
+                .company(dto.getCompany())
+                .jobTitle(dto.getJobTitle())
+                .position(dto.getPosition())
+                .industry(dto.getIndustry())
+                .status(status)
+                .important(dto.isImportant())
+                .memo(dto.getMemo())
+                .applyDate(dto.getApplyDate())
+                .interviewDate(dto.getInterviewDate())
+                .deadlineDate(dto.getDeadlineDate())
+                .build();
 
         applicationRepository.save(app);
-        String status = dto.getStatus();
 
-        boolean needApplyEvent =
-                status.equals("지원 예정") ||
-                status.equals("작성중");
-
-        boolean needInterviewEvent =
-                status.equals("제출 완료") ||
-                status.equals("결과 대기") ||
-                status.equals("면접 전형");
-
-        boolean needDeadlineEvent =
-                status.equals("최종 결과");
-
-        if (needApplyEvent && dto.getApplyDate() != null) {
+        if (status.needsApplyEvent() && dto.getApplyDate() != null) {
             Event event = buildEvent("제출", dto.getCompany(), dto.getJobTitle(), dto.getApplyDate());
             calendarAsyncService.createEventAsync(app.getId(), "apply", auth, event);
         }
-        if (needInterviewEvent && dto.getInterviewDate() != null) {
+        if (status.needsInterviewEvent() && dto.getInterviewDate() != null) {
             Event event = buildEvent("면접", dto.getCompany(), dto.getJobTitle(), dto.getInterviewDate());
             calendarAsyncService.createEventAsync(app.getId(), "interview", auth, event);
         }
-        if (needDeadlineEvent && dto.getDeadlineDate() != null) {
+        if (status.needsDeadlineEvent() && dto.getDeadlineDate() != null) {
             Event event = buildEvent("마감", dto.getCompany(), dto.getJobTitle(), dto.getDeadlineDate());
             calendarAsyncService.createEventAsync(app.getId(), "deadline", auth, event);
         }
+
         applicationRepository.save(app);
     }
 
     @Transactional
     public void deleteApplication(Long id, Authentication auth) throws Exception {
-        Application app = applicationRepository.findById(id).orElseThrow();
+        User user = userService.findByEmail(auth.getName());
+        Application app = applicationRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("지원 공고를 찾을 수 없습니다."));
 
         if (app.getApplyEventId() != null) {
             calendarAsyncService.deleteEventAsync(auth, app.getApplyEventId());
@@ -103,74 +89,66 @@ public class ApplicationService {
 
     @Transactional
     public void updateApplication(Long id, ApplicationRequest dto, Authentication auth) throws Exception {
-        Application app = applicationRepository.findById(id).orElseThrow();
+        User user = userService.findByEmail(auth.getName());
+        Application app = applicationRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("지원 공고를 찾을 수 없습니다."));
 
-        app.setCompany(dto.getCompany());
-        app.setJobTitle(dto.getJobTitle());
-        app.setPosition(dto.getPosition());
-        app.setIndustry(dto.getIndustry());
-        app.setStatus(dto.getStatus());
-        app.setImportant(dto.isImportant());
-        app.setMemo(dto.getMemo());
-        app.setApplyDate(dto.getApplyDate());
-        app.setDeadlineDate(dto.getDeadlineDate());
-        app.setInterviewDate(dto.getInterviewDate());
+        ApplicationStatus status = dto.getStatus();
 
-        String status = dto.getStatus();
+        app.update(
+                dto.getCompany(), dto.getJobTitle(), dto.getPosition(), dto.getIndustry(),
+                status, dto.isImportant(), dto.getMemo(),
+                dto.getApplyDate(), dto.getInterviewDate(), dto.getDeadlineDate()
+        );
 
-        boolean needApplyEvent =
-                status.equals("지원 예정") ||
-                status.equals("작성중");
-
-        boolean needInterviewEvent =
-                status.equals("제출 완료") ||
-                status.equals("결과 대기") ||
-                status.equals("면접 전형");
-
-        boolean needDeadlineEvent =
-                status.equals("최종 결과");
-
-        if (needApplyEvent && dto.getApplyDate() != null) {
+        if (status.needsApplyEvent() && dto.getApplyDate() != null) {
             Event event = buildEvent("제출", dto.getCompany(), dto.getJobTitle(), dto.getApplyDate());
             if (app.getApplyEventId() != null) {
                 calendarAsyncService.updateEventAsync(auth, app.getApplyEventId(), event);
             } else {
                 calendarAsyncService.createEventAsync(app.getId(), "apply", auth, event);
             }
-        } else {
-            if (app.getApplyEventId() != null) {
-                calendarAsyncService.deleteEventAsync(auth, app.getApplyEventId());
-                app.setApplyEventId(null);
-            }
+        } else if (app.getApplyEventId() != null) {
+            calendarAsyncService.deleteEventAsync(auth, app.getApplyEventId());
+            app.clearApplyEventId();
         }
-        if (needInterviewEvent && dto.getInterviewDate() != null) {
-            Event event = buildEvent("면접", dto.getCompany(), dto.getJobTitle(), dto.getInterviewDate());
 
+        if (status.needsInterviewEvent() && dto.getInterviewDate() != null) {
+            Event event = buildEvent("면접", dto.getCompany(), dto.getJobTitle(), dto.getInterviewDate());
             if (app.getInterviewEventId() != null) {
                 calendarAsyncService.updateEventAsync(auth, app.getInterviewEventId(), event);
             } else {
                 calendarAsyncService.createEventAsync(app.getId(), "interview", auth, event);
             }
-        } else {
-            if (app.getInterviewEventId() != null) {
-                calendarAsyncService.deleteEventAsync(auth, app.getInterviewEventId());
-                app.setInterviewEventId(null);
-            }
+        } else if (app.getInterviewEventId() != null) {
+            calendarAsyncService.deleteEventAsync(auth, app.getInterviewEventId());
+            app.clearInterviewEventId();
         }
-        if (needDeadlineEvent && dto.getDeadlineDate() != null) {
-            Event event = buildEvent("마감", dto.getCompany(), dto.getJobTitle(), dto.getDeadlineDate());
 
+        if (status.needsDeadlineEvent() && dto.getDeadlineDate() != null) {
+            Event event = buildEvent("마감", dto.getCompany(), dto.getJobTitle(), dto.getDeadlineDate());
             if (app.getDeadlineEventId() != null) {
                 calendarAsyncService.updateEventAsync(auth, app.getDeadlineEventId(), event);
             } else {
                 calendarAsyncService.createEventAsync(app.getId(), "deadline", auth, event);
             }
-        } else {
-            if (app.getDeadlineEventId() != null) {
-                calendarAsyncService.deleteEventAsync(auth, app.getDeadlineEventId());
-                app.setDeadlineEventId(null);
-            }
+        } else if (app.getDeadlineEventId() != null) {
+            calendarAsyncService.deleteEventAsync(auth, app.getDeadlineEventId());
+            app.clearDeadlineEventId();
         }
+
         applicationRepository.save(app);
+    }
+
+    private Event buildEvent(String type, String company, String jobTitle, LocalDateTime dateTime) {
+        Event event = new Event();
+        event.setSummary(company + " " + jobTitle + " " + type);
+        DateTime googleDateTime = new DateTime(java.sql.Timestamp.valueOf(dateTime));
+        EventDateTime eventDateTime = new EventDateTime()
+                .setDateTime(googleDateTime)
+                .setTimeZone("Asia/Seoul");
+        event.setStart(eventDateTime);
+        event.setEnd(eventDateTime);
+        return event;
     }
 }

--- a/src/main/java/back/pickd/application/service/TodoService.java
+++ b/src/main/java/back/pickd/application/service/TodoService.java
@@ -7,6 +7,8 @@ import back.pickd.application.entity.Todo;
 import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.application.repository.TodoRepository;
 import back.pickd.calendar.service.CalendarAsyncService;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -26,23 +28,24 @@ public class TodoService {
     private final TodoRepository todoRepository;
     private final ApplicationRepository applicationRepository;
     private final CalendarAsyncService calendarAsyncService;
+    private final UserService userService;
 
     public TodoResponse addTodo(TodoRequest dto, Authentication authentication) {
-        Todo todo = new Todo();
-        todo.setTitle(dto.getTitle());
-        todo.setCompleted(false);
-        todo.setMemo(dto.getMemo());
+        User user = userService.findByEmail(authentication.getName());
 
-        LocalDateTime dueDateTime = parseDueDateTime(dto.getDueDateTime());
-        todo.setDueDateTime(dueDateTime);
-
+        Application application = null;
         if (dto.getApplicationId() != null) {
-            Application application = applicationRepository
-                    .findById(dto.getApplicationId())
-                    .orElseThrow(() -> new RuntimeException("공고를 찾을 수 없습니다."));
-
-            todo.setApplication(application);
+            application = applicationRepository.findByIdAndUser(dto.getApplicationId(), user)
+                    .orElseThrow(() -> new IllegalArgumentException("지원 공고를 찾을 수 없습니다."));
         }
+
+        Todo todo = Todo.builder()
+                .user(user)
+                .application(application)
+                .title(dto.getTitle())
+                .memo(dto.getMemo())
+                .dueDateTime(parseDueDateTime(dto.getDueDateTime()))
+                .build();
 
         Todo saved = todoRepository.save(todo);
 
@@ -54,34 +57,36 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public List<TodoResponse> getTodos() {
-        return todoRepository.findAllWithApplication()
+    public List<TodoResponse> getTodos(Authentication authentication) {
+        User user = userService.findByEmail(authentication.getName());
+        return todoRepository.findAllByUserWithApplication(user)
                 .stream()
                 .map(TodoResponse::from)
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public List<TodoResponse> getTodosByApplication(Long applicationId) {
-        return todoRepository.findByApplicationId(applicationId)
+    public List<TodoResponse> getTodosByApplication(Long applicationId, Authentication authentication) {
+        User user = userService.findByEmail(authentication.getName());
+        return todoRepository.findByApplicationIdAndUser(applicationId, user)
                 .stream()
                 .map(TodoResponse::from)
                 .toList();
     }
 
-    public void toggleTodo(Long id) {
-        Todo todo = todoRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("할 일을 찾을 수 없습니다."));
-
-        todo.setCompleted(!todo.isCompleted());
+    public void toggleTodo(Long id, Authentication authentication) {
+        User user = userService.findByEmail(authentication.getName());
+        Todo todo = todoRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("할 일을 찾을 수 없습니다."));
+        todo.toggleCompleted();
     }
 
     public void deleteTodo(Long id, Authentication authentication) {
-        Todo todo = todoRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("할 일을 찾을 수 없습니다."));
+        User user = userService.findByEmail(authentication.getName());
+        Todo todo = todoRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("할 일을 찾을 수 없습니다."));
 
         String calendarEventId = todo.getCalendarEventId();
-
         todoRepository.delete(todo);
 
         if (calendarEventId != null && !calendarEventId.isBlank()) {
@@ -93,7 +98,6 @@ public class TodoService {
         if (dueDateTime == null || dueDateTime.isBlank()) {
             return null;
         }
-
         try {
             return LocalDateTime.parse(dueDateTime);
         } catch (DateTimeParseException e) {

--- a/src/main/java/back/pickd/calendar/service/CalendarAsyncService.java
+++ b/src/main/java/back/pickd/calendar/service/CalendarAsyncService.java
@@ -31,13 +31,13 @@ public class CalendarAsyncService {
 
             switch (eventType) {
                 case "apply":
-                    app.setApplyEventId(createdEvent.getId());
+                    app.assignApplyEventId(createdEvent.getId());
                     break;
                 case "interview":
-                    app.setInterviewEventId(createdEvent.getId());
+                    app.assignInterviewEventId(createdEvent.getId());
                     break;
                 case "deadline":
-                    app.setDeadlineEventId(createdEvent.getId());
+                    app.assignDeadlineEventId(createdEvent.getId());
                     break;
                 default:
                     break;
@@ -85,7 +85,7 @@ public class CalendarAsyncService {
             Event createdEvent = calendarService.createTodoEvent(authentication, todo);
 
             if (createdEvent != null && createdEvent.getId() != null) {
-                todo.setCalendarEventId(createdEvent.getId());
+                todo.assignCalendarEventId(createdEvent.getId());
                 todoRepository.save(todo);
             }
         } catch (Exception e) {

--- a/src/main/java/back/pickd/coverletter/controller/CoverLetterItemController.java
+++ b/src/main/java/back/pickd/coverletter/controller/CoverLetterItemController.java
@@ -1,0 +1,56 @@
+package back.pickd.coverletter.controller;
+
+import back.pickd.coverletter.dto.request.CoverLetterItemRequest;
+import back.pickd.coverletter.dto.response.CoverLetterItemResponse;
+import back.pickd.coverletter.service.CoverLetterItemService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cover-letter")
+public class CoverLetterItemController {
+
+    private final CoverLetterItemService coverLetterItemService;
+
+    // GET /api/cover-letter?noticeId=1
+    @GetMapping
+    public List<CoverLetterItemResponse> getByNotice(
+            @RequestParam(required = false) Long noticeId,
+            @RequestParam(required = false) Long applicationId,
+            Authentication auth) {
+        if (noticeId != null) {
+            return coverLetterItemService.getByNotice(noticeId, auth);
+        } else if (applicationId != null) {
+            return coverLetterItemService.getByApplication(applicationId, auth);
+        }
+        throw new IllegalArgumentException("noticeId 또는 applicationId 파라미터가 필요합니다.");
+    }
+
+    // POST /api/cover-letter
+    @PostMapping
+    public CoverLetterItemResponse create(
+            @RequestBody @Valid CoverLetterItemRequest dto,
+            Authentication auth) {
+        return coverLetterItemService.create(dto, auth);
+    }
+
+    // PUT /api/cover-letter/{id}
+    @PutMapping("/{id}")
+    public CoverLetterItemResponse update(
+            @PathVariable Long id,
+            @RequestBody @Valid CoverLetterItemRequest dto,
+            Authentication auth) {
+        return coverLetterItemService.update(id, dto, auth);
+    }
+
+    // DELETE /api/cover-letter/{id}
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id, Authentication auth) {
+        coverLetterItemService.delete(id, auth);
+    }
+}

--- a/src/main/java/back/pickd/coverletter/dto/request/CoverLetterItemRequest.java
+++ b/src/main/java/back/pickd/coverletter/dto/request/CoverLetterItemRequest.java
@@ -1,11 +1,13 @@
 package back.pickd.coverletter.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class CoverLetterItemRequest {
 
     @NotBlank

--- a/src/main/java/back/pickd/coverletter/dto/request/CoverLetterItemRequest.java
+++ b/src/main/java/back/pickd/coverletter/dto/request/CoverLetterItemRequest.java
@@ -1,0 +1,23 @@
+package back.pickd.coverletter.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CoverLetterItemRequest {
+
+    @NotBlank
+    private String question;
+
+    private String answer;
+
+    private Integer maxLength;
+
+    private Integer orderIndex;
+
+    // notice_id 또는 application_id 중 하나만 값이 있어야 함
+    private Long noticeId;
+    private Long applicationId;
+}

--- a/src/main/java/back/pickd/coverletter/dto/response/CoverLetterItemResponse.java
+++ b/src/main/java/back/pickd/coverletter/dto/response/CoverLetterItemResponse.java
@@ -1,0 +1,36 @@
+package back.pickd.coverletter.dto.response;
+
+import back.pickd.coverletter.entity.CoverLetterItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CoverLetterItemResponse {
+
+    private Long id;
+    private Long noticeId;
+    private Long applicationId;
+    private String question;
+    private String answer;
+    private Integer maxLength;
+    private Integer orderIndex;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CoverLetterItemResponse from(CoverLetterItem item) {
+        return CoverLetterItemResponse.builder()
+                .id(item.getId())
+                .noticeId(item.getNotice() != null ? item.getNotice().getId() : null)
+                .applicationId(item.getApplication() != null ? item.getApplication().getId() : null)
+                .question(item.getQuestion())
+                .answer(item.getAnswer())
+                .maxLength(item.getMaxLength())
+                .orderIndex(item.getOrderIndex())
+                .createdAt(item.getCreatedAt())
+                .updatedAt(item.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/back/pickd/coverletter/entity/CoverLetterItem.java
+++ b/src/main/java/back/pickd/coverletter/entity/CoverLetterItem.java
@@ -1,0 +1,73 @@
+package back.pickd.coverletter.entity;
+
+import back.pickd.application.entity.Application;
+import back.pickd.notice.notice.Notice;
+import back.pickd.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cover_letter_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CoverLetterItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "application_id")
+    private Application application;
+
+    @Column(name = "question", nullable = false, columnDefinition = "TEXT")
+    private String question;
+
+    @Column(name = "answer", columnDefinition = "TEXT")
+    private String answer;
+
+    @Column(name = "max_length")
+    private Integer maxLength;
+
+    @Column(name = "order_index", nullable = false)
+    @Builder.Default
+    private Integer orderIndex = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // ── 도메인 메서드 ──────────────────────────────────────────────────────────
+
+    public void update(String question, String answer, Integer maxLength, Integer orderIndex) {
+        this.question = question;
+        this.answer = answer;
+        this.maxLength = maxLength;
+        this.orderIndex = orderIndex;
+    }
+}

--- a/src/main/java/back/pickd/coverletter/repository/CoverLetterItemRepository.java
+++ b/src/main/java/back/pickd/coverletter/repository/CoverLetterItemRepository.java
@@ -1,0 +1,17 @@
+package back.pickd.coverletter.repository;
+
+import back.pickd.coverletter.entity.CoverLetterItem;
+import back.pickd.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CoverLetterItemRepository extends JpaRepository<CoverLetterItem, Long> {
+
+    List<CoverLetterItem> findAllByNoticeIdAndUserOrderByOrderIndexAsc(Long noticeId, User user);
+
+    List<CoverLetterItem> findAllByApplicationIdAndUserOrderByOrderIndexAsc(Long applicationId, User user);
+
+    Optional<CoverLetterItem> findByIdAndUser(Long id, User user);
+}

--- a/src/main/java/back/pickd/coverletter/service/CoverLetterItemService.java
+++ b/src/main/java/back/pickd/coverletter/service/CoverLetterItemService.java
@@ -1,0 +1,98 @@
+package back.pickd.coverletter.service;
+
+import back.pickd.application.entity.Application;
+import back.pickd.application.repository.ApplicationRepository;
+import back.pickd.coverletter.dto.request.CoverLetterItemRequest;
+import back.pickd.coverletter.dto.response.CoverLetterItemResponse;
+import back.pickd.coverletter.entity.CoverLetterItem;
+import back.pickd.coverletter.repository.CoverLetterItemRepository;
+import back.pickd.notice.notice.Notice;
+import back.pickd.notice.notice.NoticeRepository;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CoverLetterItemService {
+
+    private final CoverLetterItemRepository coverLetterItemRepository;
+    private final NoticeRepository noticeRepository;
+    private final ApplicationRepository applicationRepository;
+    private final UserService userService;
+
+    @Transactional(readOnly = true)
+    public List<CoverLetterItemResponse> getByNotice(Long noticeId, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        return coverLetterItemRepository
+                .findAllByNoticeIdAndUserOrderByOrderIndexAsc(noticeId, user)
+                .stream()
+                .map(CoverLetterItemResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CoverLetterItemResponse> getByApplication(Long applicationId, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        return coverLetterItemRepository
+                .findAllByApplicationIdAndUserOrderByOrderIndexAsc(applicationId, user)
+                .stream()
+                .map(CoverLetterItemResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public CoverLetterItemResponse create(CoverLetterItemRequest dto, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+
+        Notice notice = null;
+        Application application = null;
+
+        if (dto.getNoticeId() != null) {
+            notice = noticeRepository.findByIdAndUser(dto.getNoticeId(), user)
+                    .orElseThrow(() -> new IllegalArgumentException("공고를 찾을 수 없습니다."));
+        } else if (dto.getApplicationId() != null) {
+            application = applicationRepository.findByIdAndUser(dto.getApplicationId(), user)
+                    .orElseThrow(() -> new IllegalArgumentException("지원 공고를 찾을 수 없습니다."));
+        } else {
+            throw new IllegalArgumentException("noticeId 또는 applicationId 중 하나는 필수입니다.");
+        }
+
+        CoverLetterItem item = CoverLetterItem.builder()
+                .user(user)
+                .notice(notice)
+                .application(application)
+                .question(dto.getQuestion())
+                .answer(dto.getAnswer())
+                .maxLength(dto.getMaxLength())
+                .orderIndex(dto.getOrderIndex() != null ? dto.getOrderIndex() : 0)
+                .build();
+
+        return CoverLetterItemResponse.from(coverLetterItemRepository.save(item));
+    }
+
+    @Transactional
+    public CoverLetterItemResponse update(Long id, CoverLetterItemRequest dto, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        CoverLetterItem item = coverLetterItemRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("자소서 문항을 찾을 수 없습니다."));
+
+        item.update(dto.getQuestion(), dto.getAnswer(), dto.getMaxLength(),
+                dto.getOrderIndex() != null ? dto.getOrderIndex() : item.getOrderIndex());
+
+        return CoverLetterItemResponse.from(item);
+    }
+
+    @Transactional
+    public void delete(Long id, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        CoverLetterItem item = coverLetterItemRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("자소서 문항을 찾을 수 없습니다."));
+        coverLetterItemRepository.delete(item);
+    }
+}

--- a/src/main/java/back/pickd/document/controller/DocumentController.java
+++ b/src/main/java/back/pickd/document/controller/DocumentController.java
@@ -4,6 +4,7 @@ import back.pickd.document.dto.DocumentRequest;
 import back.pickd.document.entity.Document;
 import back.pickd.document.service.DocumentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -12,27 +13,35 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/document")
 public class DocumentController {
+
     private final DocumentService documentService;
 
+    @GetMapping
+    public List<Document> getAllDocuments(Authentication auth) {
+        return documentService.getAllDocuments(auth);
+    }
+
     @GetMapping("/{applicationId}")
-    public List<Document> getDocuments(
-            @PathVariable Long applicationId
-    ) {
-        return documentService.getDocuments(applicationId);
+    public List<Document> getDocuments(@PathVariable Long applicationId, Authentication auth) {
+        return documentService.getDocuments(applicationId, auth);
     }
 
     @PostMapping("/{applicationId}")
-    public Document addDocument(
-            @PathVariable Long applicationId,
-            @RequestBody DocumentRequest request
-    ) {
-        return documentService.addDocument(applicationId, request);
+    public Document addDocument(@PathVariable Long applicationId,
+                                @RequestBody DocumentRequest request,
+                                Authentication auth) {
+        return documentService.addDocument(applicationId, request, auth);
+    }
+
+    @PutMapping("/{id}")
+    public Document updateDocument(@PathVariable Long id,
+                                   @RequestBody DocumentRequest request,
+                                   Authentication auth) {
+        return documentService.updateDocument(id, request, auth);
     }
 
     @DeleteMapping("/{id}")
-    public void deleteDocument(
-            @PathVariable Long id
-    ) {
-        documentService.deleteDocument(id);
+    public void deleteDocument(@PathVariable Long id, Authentication auth) {
+        documentService.deleteDocument(id, auth);
     }
 }

--- a/src/main/java/back/pickd/document/dto/DocumentRequest.java
+++ b/src/main/java/back/pickd/document/dto/DocumentRequest.java
@@ -1,15 +1,24 @@
 package back.pickd.document.dto;
 
+import back.pickd.document.enums.DocumentStatus;
+import back.pickd.document.enums.DocumentType;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class DocumentRequest {
+
     private String title;
     private String company;
-    private String type; // 포트 폴리오인지 이력서인지
-    private Integer progress; // 글자수로 계산해서 응답 
-    private String status; // nullable 
-    private String content; // 수정 가능해야함. 
+
+    @NotNull
+    private DocumentType type;      // RESUME, PORTFOLIO, COVER_LETTER, ETC
+
+    private DocumentStatus status;  // nullable
+
+    private Integer progress;       // 글자수 기반 계산값
+
+    private String content;         // 수정 가능
 }

--- a/src/main/java/back/pickd/document/entity/Document.java
+++ b/src/main/java/back/pickd/document/entity/Document.java
@@ -1,34 +1,79 @@
 package back.pickd.document.entity;
 
-import java.time.LocalDateTime;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import back.pickd.application.entity.Application;
+import back.pickd.document.enums.DocumentStatus;
+import back.pickd.document.enums.DocumentType;
+import back.pickd.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
+@Table(name = "documents")
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Document {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String title;
-    private String company;
-    private String type;
-    private Integer progress;
-    private String status;
-    private LocalDateTime updatedAt;
 
-    @Column(length = 3000)
-    private String content;
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "application_id")
     private Application application;
+
+    private String title;
+    private String company;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DocumentType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private DocumentStatus status;
+
+    private Integer progress;
+
+    @Column(length = 3000)
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // ── 도메인 메서드 ──────────────────────────────────────────────────────────
+
+    public void update(String title, String company, DocumentType type,
+                       DocumentStatus status, Integer progress, String content) {
+        this.title = title;
+        this.company = company;
+        this.type = type;
+        this.status = status;
+        this.progress = progress;
+        this.content = content;
+    }
 }

--- a/src/main/java/back/pickd/document/enums/DocumentStatus.java
+++ b/src/main/java/back/pickd/document/enums/DocumentStatus.java
@@ -1,0 +1,14 @@
+package back.pickd.document.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DocumentStatus {
+
+    DRAFT("작성중"),
+    COMPLETED("완료");
+
+    private final String label;
+}

--- a/src/main/java/back/pickd/document/enums/DocumentType.java
+++ b/src/main/java/back/pickd/document/enums/DocumentType.java
@@ -1,0 +1,16 @@
+package back.pickd.document.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DocumentType {
+
+    RESUME("이력서"),
+    PORTFOLIO("포트폴리오"),
+    COVER_LETTER("자기소개서"),
+    ETC("기타");
+
+    private final String label;
+}

--- a/src/main/java/back/pickd/document/repository/DocumentRepository.java
+++ b/src/main/java/back/pickd/document/repository/DocumentRepository.java
@@ -1,10 +1,17 @@
 package back.pickd.document.repository;
 
 import back.pickd.document.entity.Document;
+import back.pickd.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DocumentRepository extends JpaRepository<Document, Long> {
-    List<Document> findByApplicationId(Long applicationId);
+
+    List<Document> findAllByUserOrderByIdDesc(User user);
+
+    List<Document> findAllByApplicationIdAndUser(Long applicationId, User user);
+
+    Optional<Document> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/back/pickd/document/service/DocumentService.java
+++ b/src/main/java/back/pickd/document/service/DocumentService.java
@@ -5,46 +5,77 @@ import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.document.dto.DocumentRequest;
 import back.pickd.document.entity.Document;
 import back.pickd.document.repository.DocumentRepository;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class DocumentService {
+
     private final DocumentRepository documentRepository;
     private final ApplicationRepository applicationRepository;
+    private final UserService userService;
 
-    public List<Document> getDocuments(Long applicationId) {
-        return documentRepository.findByApplicationId(applicationId);
+    @Transactional(readOnly = true)
+    public List<Document> getDocuments(Long applicationId, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        return documentRepository.findAllByApplicationIdAndUser(applicationId, user);
     }
-    public Document addDocument(
-            Long applicationId,
-            DocumentRequest request
-    ) {
-        Application application =
-                applicationRepository.findById(applicationId)
-                        .orElseThrow();
+
+    @Transactional(readOnly = true)
+    public List<Document> getAllDocuments(Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        return documentRepository.findAllByUserOrderByIdDesc(user);
+    }
+
+    @Transactional
+    public Document addDocument(Long applicationId, DocumentRequest request, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        Application application = applicationRepository.findByIdAndUser(applicationId, user)
+                .orElseThrow(() -> new IllegalArgumentException("지원 공고를 찾을 수 없습니다."));
 
         Document document = Document.builder()
+                .user(user)
+                .application(application)
                 .title(request.getTitle())
                 .company(request.getCompany())
                 .type(request.getType())
-                .progress(
-                    request.getProgress() == null
-                            ? 0
-                            : request.getProgress()
-                )
                 .status(request.getStatus())
+                .progress(request.getProgress() == null ? 0 : request.getProgress())
                 .content(request.getContent())
-                .updatedAt(LocalDateTime.now())
-                .application(application)
                 .build();
+
         return documentRepository.save(document);
     }
-    public void deleteDocument(Long id) {
-        documentRepository.deleteById(id);
+
+    @Transactional
+    public Document updateDocument(Long id, DocumentRequest request, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        Document document = documentRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("서류를 찾을 수 없습니다."));
+
+        document.update(
+                request.getTitle(),
+                request.getCompany(),
+                request.getType(),
+                request.getStatus(),
+                request.getProgress(),
+                request.getContent()
+        );
+        return documentRepository.save(document);
+    }
+
+    @Transactional
+    public void deleteDocument(Long id, Authentication auth) {
+        User user = userService.findByEmail(auth.getName());
+        Document document = documentRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("서류를 찾을 수 없습니다."));
+        documentRepository.delete(document);
     }
 }

--- a/src/main/java/back/pickd/experience/controller/ExperienceExtractionTestController.java
+++ b/src/main/java/back/pickd/experience/controller/ExperienceExtractionTestController.java
@@ -1,0 +1,57 @@
+package back.pickd.experience.controller;
+
+import back.pickd.experience.dto.ExperienceExtractionTestDto.PresetDefinition;
+import back.pickd.experience.dto.ExperienceExtractionTestDto.StateResponse;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.service.ExperienceExtractionTestService;
+import back.pickd.experience.support.PresetRegistry;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Controller
+@Profile("local")
+@RequiredArgsConstructor
+public class ExperienceExtractionTestController {
+
+    private final PresetRegistry presetRegistry;
+    private final ExperienceExtractionTestService testService;
+    private final ObjectMapper objectMapper;
+
+    @GetMapping("/experience-extraction-test")
+    public String page(Authentication authentication, Model model)
+            throws JsonProcessingException {
+        List<PresetDefinition> presets = Arrays.stream(ExperienceType.values())
+                .map(type -> new PresetDefinition(
+                        type.name(),
+                        type.getKoreanName(),
+                        presetRegistry.getExperienceGroup(type).name(),
+                        presetRegistry.getPresetFields(type)
+                ))
+                .toList();
+
+        model.addAttribute("authenticated",
+                authentication != null && authentication.isAuthenticated());
+        model.addAttribute("userEmail",
+                authentication != null ? authentication.getName() : null);
+        model.addAttribute("presetDefinitions", presets);
+        model.addAttribute("presetDefinitionsJson",
+                objectMapper.writeValueAsString(presets));
+        return "experience-extraction-test";
+    }
+
+    @GetMapping("/internal/experience-extraction-test/state")
+    @ResponseBody
+    public StateResponse state(Authentication authentication) {
+        return testService.getState(authentication.getName());
+    }
+}

--- a/src/main/java/back/pickd/experience/controller/ExperienceExtractionV2Controller.java
+++ b/src/main/java/back/pickd/experience/controller/ExperienceExtractionV2Controller.java
@@ -1,0 +1,290 @@
+package back.pickd.experience.controller;
+
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchesResponse;
+import back.pickd.experience.service.ExperienceExtractionV2Service;
+import back.pickd.global.config.OpenApiConfig;
+import back.pickd.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/experiences/extract")
+@RequiredArgsConstructor
+@Tag(
+        name = "Experience Extraction V2",
+        description = "경험 상세 추출, 중복 후보 저장 및 최종 선택 API"
+)
+@SecurityRequirement(name = OpenApiConfig.COOKIE_AUTH)
+public class ExperienceExtractionV2Controller {
+
+    private final ExperienceExtractionV2Service extractionService;
+
+    @GetMapping("/duplicates/pending")
+    @Operation(
+            summary = "미처리 중복 경험 조회",
+            description = """
+                    현재 로그인 사용자의 Step2 미처리 중복 batch를 최신순으로 조회합니다.
+
+                    - Step2 응답을 잃었거나 화면을 새로고침한 경우 Step3 선택 화면을 복구할 수 있습니다.
+                    - 각 batch는 Step3에 전달할 duplicateBatchId와 전체 duplicateGroups를 포함합니다.
+                    - 다른 사용자의 batch와 이미 완료된 batch는 반환하지 않습니다.
+                    - 미처리 batch가 없으면 batches는 빈 배열입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "미처리 중복 경험 조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = PendingBatchesResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "batches": [
+                                                {
+                                                  "duplicateBatchId": "batch-uuid",
+                                                  "createdAt": "2026-06-22T19:30:00+09:00",
+                                                  "duplicateGroups": [
+                                                    {
+                                                      "groupId": "group-uuid",
+                                                      "items": [
+                                                        {
+                                                          "itemId": "existing-experience-id",
+                                                          "source": "EXISTING",
+                                                          "similarity": null,
+                                                          "experience": {
+                                                            "title": "기존 프로젝트",
+                                                            "experienceType": "PROJECT",
+                                                            "experienceGroup": "NARRATIVE",
+                                                            "status": "COMPLETED",
+                                                            "documentContent": "기존 본문",
+                                                            "attributes": {},
+                                                            "keywords": []
+                                                          }
+                                                        },
+                                                        {
+                                                          "itemId": "draft-uuid",
+                                                          "source": "EXTRACTED",
+                                                          "similarity": 0.91,
+                                                          "experience": {
+                                                            "title": "새 추출 프로젝트",
+                                                            "experienceType": "PROJECT",
+                                                            "experienceGroup": "NARRATIVE",
+                                                            "status": "COMPLETED",
+                                                            "documentContent": "새 본문",
+                                                            "attributes": {},
+                                                            "keywords": []
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<PendingBatchesResponse> getPendingDuplicates(
+            @Parameter(hidden = true) Authentication authentication
+    ) {
+        return ResponseEntity.ok(extractionService.getPendingDuplicates(
+                authentication.getName()
+        ));
+    }
+
+    @PostMapping("/step2")
+    @Operation(
+            summary = "선택 경험 상세 추출 및 중복 후보 생성",
+            description = """
+                    Step1에서 선택한 임시 경험을 선택 순서대로 상세 추출합니다.
+
+                    - Spring PresetRegistry에서 선택된 경험 유형의 필드 스키마만 AI 서버에 전달합니다.
+                    - 기존 저장 경험과 같은 요청에서 앞서 저장된 신규 경험을 대상으로 중복을 판정합니다.
+                    - 비중복 경험은 즉시 저장합니다.
+                    - 중복 경험은 서버 draft로 저장하고 duplicateBatchId와 duplicateGroups를 반환합니다.
+                    - 중복 후보가 없으면 duplicateBatchId는 null이고 duplicateGroups는 빈 배열입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "상세 추출 및 중복 분류 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = Step2Response.class),
+                            examples = @ExampleObject(
+                                    name = "중복 후보가 있는 응답",
+                                    value = """
+                                            {
+                                              "savedExperiences": [
+                                                {
+                                                  "id": "saved-experience-id",
+                                                  "userId": 1,
+                                                  "title": "비중복 프로젝트",
+                                                  "experienceType": "PROJECT",
+                                                  "experienceGroup": "NARRATIVE",
+                                                  "status": "COMPLETED",
+                                                  "documentContent": "프로젝트 본문",
+                                                  "attributes": {
+                                                    "project_name": "비중복 프로젝트"
+                                                  },
+                                                  "keywords": ["실행력"],
+                                                  "files": [],
+                                                  "links": []
+                                                }
+                                              ],
+                                              "duplicateBatchId": "batch-uuid",
+                                              "duplicateGroups": [
+                                                {
+                                                  "groupId": "group-uuid",
+                                                  "items": [
+                                                    {
+                                                      "itemId": "existing-experience-id",
+                                                      "source": "EXISTING",
+                                                      "similarity": null,
+                                                      "experience": {
+                                                        "title": "기존 프로젝트",
+                                                        "experienceType": "PROJECT",
+                                                        "experienceGroup": "NARRATIVE",
+                                                        "status": "COMPLETED",
+                                                        "documentContent": "기존 본문",
+                                                        "attributes": {},
+                                                        "keywords": []
+                                                      }
+                                                    },
+                                                    {
+                                                      "itemId": "draft-uuid",
+                                                      "source": "EXTRACTED",
+                                                      "similarity": 0.91,
+                                                      "experience": {
+                                                        "title": "새로 추출한 프로젝트",
+                                                        "experienceType": "PROJECT",
+                                                        "experienceGroup": "NARRATIVE",
+                                                        "status": "COMPLETED",
+                                                        "documentContent": "새 본문",
+                                                        "attributes": {},
+                                                        "keywords": []
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "임시 경험 누락, 소유권 오류, 그룹·유형 불일치 또는 AI 응답 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<Step2Response> extractStep2(
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody @Valid Step2Request request
+    ) {
+        return ResponseEntity.ok(extractionService.extractStep2(
+                authentication.getName(),
+                request.getSelectedTempIds()
+        ));
+    }
+
+    @PostMapping("/step3")
+    @Operation(
+            summary = "중복 경험 최종 선택 반영",
+            description = """
+                    Step2가 반환한 중복 batch의 모든 그룹에 대해 남길 itemId를 제출합니다.
+
+                    - 기존 경험만 선택: 기존 경험 유지, 추출 draft 삭제
+                    - 추출 draft만 선택: 기존 경험 삭제, 선택 draft 신규 저장
+                    - 기존 경험과 draft를 함께 선택: 둘 다 유지
+                    - 여러 draft 선택: 선택한 draft를 모두 신규 경험으로 저장
+                    - 선택되지 않은 기존 경험과 draft는 삭제
+                    - 모든 그룹을 한 요청에 포함해야 하며 하나의 Spring 트랜잭션으로 처리합니다.
+                    - AI 서버는 호출하지 않습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "선택 반영 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = Step3Response.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "selectedExperiences": [
+                                                {
+                                                  "id": "selected-experience-id",
+                                                  "userId": 1,
+                                                  "title": "최종 선택 경험",
+                                                  "experienceType": "PROJECT",
+                                                  "experienceGroup": "NARRATIVE",
+                                                  "status": "COMPLETED",
+                                                  "documentContent": "경험 본문",
+                                                  "attributes": {},
+                                                  "keywords": [],
+                                                  "files": [],
+                                                  "links": []
+                                                }
+                                              ],
+                                              "deletedExperienceIds": ["unselected-existing-id"]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "batch 누락, 그룹 누락, 빈 선택, 잘못된 itemId 또는 이미 처리된 batch",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<Step3Response> confirmStep3(
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody @Valid Step3Request request
+    ) {
+        return ResponseEntity.ok(extractionService.confirmStep3(
+                authentication.getName(),
+                request
+        ));
+    }
+}

--- a/src/main/java/back/pickd/experience/dto/ExperienceExtractionTestDto.java
+++ b/src/main/java/back/pickd/experience/dto/ExperienceExtractionTestDto.java
@@ -1,0 +1,119 @@
+package back.pickd.experience.dto;
+
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.ExperienceTemp;
+import back.pickd.experience.entity.UserExperience;
+import back.pickd.experience.support.PresetRegistry.PresetField;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public final class ExperienceExtractionTestDto {
+
+    private ExperienceExtractionTestDto() {
+    }
+
+    public record PresetDefinition(
+            String type,
+            String koreanName,
+            String group,
+            List<PresetField> fields
+    ) {
+    }
+
+    public record StateResponse(
+            String userEmail,
+            List<ExperienceResponse> experiences,
+            List<TempState> temps,
+            List<BatchState> batches
+    ) {
+    }
+
+    public record TempState(
+            Long id,
+            String experienceName,
+            String experienceGroup,
+            String experienceType,
+            String resumeUrl,
+            LocalDateTime createdAt
+    ) {
+        public static TempState from(ExperienceTemp temp) {
+            return new TempState(
+                    temp.getId(),
+                    temp.getExperienceName(),
+                    temp.getExperienceGroup(),
+                    temp.getExperienceType(),
+                    temp.getResumeUrl(),
+                    temp.getCreatedAt()
+            );
+        }
+    }
+
+    public record BatchState(
+            String id,
+            String status,
+            OffsetDateTime createdAt,
+            OffsetDateTime processedAt,
+            List<DuplicateGroupState> duplicateGroups
+    ) {
+        public static BatchState from(ExperienceExtractionBatch batch) {
+            return new BatchState(
+                    batch.getId(),
+                    batch.getStatus().name(),
+                    batch.getCreatedAt(),
+                    batch.getProcessedAt(),
+                    batch.getGroups().stream()
+                            .map(DuplicateGroupState::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record DuplicateGroupState(
+            String id,
+            ExperienceResponse existingExperience,
+            List<DraftState> drafts
+    ) {
+        public static DuplicateGroupState from(
+                back.pickd.experience.entity.ExperienceDuplicateGroup group
+        ) {
+            return new DuplicateGroupState(
+                    group.getId(),
+                    new ExperienceResponse(group.getExistingExperience()),
+                    group.getDrafts().stream()
+                            .map(DraftState::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record DraftState(
+            String id,
+            String title,
+            String experienceType,
+            String experienceGroup,
+            String status,
+            String documentContent,
+            java.util.Map<String, Object> attributes,
+            List<String> keywords,
+            String resumeUrl,
+            Double similarity
+    ) {
+        public static DraftState from(ExperienceExtractionDraft draft) {
+            return new DraftState(
+                    draft.getId(),
+                    draft.getTitle(),
+                    draft.getExperienceType().name(),
+                    draft.getExperienceGroup().name(),
+                    draft.getStatus().name(),
+                    draft.getDocumentContent(),
+                    draft.getAttributes(),
+                    draft.getKeywords(),
+                    draft.getResumeUrl(),
+                    draft.getSimilarity()
+            );
+        }
+    }
+}

--- a/src/main/java/back/pickd/experience/dto/ExperienceExtractionV2Dto.java
+++ b/src/main/java/back/pickd/experience/dto/ExperienceExtractionV2Dto.java
@@ -1,0 +1,294 @@
+package back.pickd.experience.dto;
+
+import back.pickd.experience.entity.ExperienceDuplicateGroup;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.UserExperience;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
+
+public final class ExperienceExtractionV2Dto {
+
+    private ExperienceExtractionV2Dto() {
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step2Request")
+    public static class Step2Request {
+
+        @NotEmpty(message = "선택된 임시 경험 ID는 필수입니다.")
+        @Schema(
+                description = "Step1에서 사용자가 선택한 임시 경험 ID. 배열 순서가 배치 내부 중복 판정 우선순위입니다.",
+                example = "[12, 15, 18]",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<Long> selectedTempIds = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step2Response")
+    public static class Step2Response {
+
+        @Schema(description = "중복이 아니어서 Step2에서 즉시 저장된 경험")
+        private final List<ExperienceResponse> savedExperiences;
+
+        @Schema(
+                description = "Step3 처리에 사용할 중복 batch ID. 중복 후보가 없으면 null",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+                nullable = true
+        )
+        private final String duplicateBatchId;
+
+        @Schema(description = "기존 경험과 추출 draft를 묶은 중복 후보 그룹")
+        private final List<DuplicateGroupResponse> duplicateGroups;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2PendingBatchesResponse")
+    public static class PendingBatchesResponse {
+
+        @Schema(description = "현재 사용자의 미처리 중복 batch. 최신 생성 순으로 반환됩니다.")
+        private final List<PendingBatchResponse> batches;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2PendingBatch")
+    public static class PendingBatchResponse {
+
+        @Schema(
+                description = "Step3 duplicateBatchId로 전달할 미처리 batch ID",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3"
+        )
+        private final String duplicateBatchId;
+
+        @Schema(description = "중복 batch 생성 시각")
+        private final OffsetDateTime createdAt;
+
+        @Schema(description = "Step3에서 선택할 기존 경험과 추출 draft 그룹")
+        private final List<DuplicateGroupResponse> duplicateGroups;
+
+        public static PendingBatchResponse from(
+                back.pickd.experience.entity.ExperienceExtractionBatch batch
+        ) {
+            return new PendingBatchResponse(
+                    batch.getId(),
+                    batch.getCreatedAt(),
+                    batch.getGroups().stream()
+                            .map(DuplicateGroupResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2DuplicateGroup")
+    public static class DuplicateGroupResponse {
+
+        @Schema(
+                description = "Step3 그룹 선택에 사용하는 중복 그룹 ID",
+                example = "9f83540e-5d78-4a08-a284-78cecfdf2e3d"
+        )
+        private final String groupId;
+
+        @Schema(description = "그룹에서 선택 가능한 기존 경험 및 추출 draft")
+        private final List<DuplicateItemResponse> items;
+
+        public static DuplicateGroupResponse from(ExperienceDuplicateGroup group) {
+            List<DuplicateItemResponse> items = new ArrayList<>();
+            items.add(DuplicateItemResponse.fromExisting(group.getExistingExperience()));
+            group.getDrafts().stream()
+                    .map(DuplicateItemResponse::fromDraft)
+                    .forEach(items::add);
+            return new DuplicateGroupResponse(group.getId(), items);
+        }
+    }
+
+    @Schema(description = "중복 후보 데이터의 출처")
+    public enum DuplicateItemSource {
+        EXISTING,
+        EXTRACTED
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2DuplicateItem")
+    public static class DuplicateItemResponse {
+
+        @Schema(
+                description = "Step3 selectedItemIds에 사용할 ID. 기존 경험이면 experience ID, 추출 후보이면 draft ID",
+                example = "6d5d36a9-9856-4117-ac58-dd1254e28e75"
+        )
+        private final String itemId;
+
+        @Schema(
+                description = "기존 저장 경험 또는 새 추출 draft",
+                allowableValues = {"EXISTING", "EXTRACTED"},
+                example = "EXTRACTED"
+        )
+        private final DuplicateItemSource source;
+
+        @Schema(
+                description = "추출 draft와 기준 경험의 유사도. 기존 경험 항목은 null",
+                example = "0.91",
+                nullable = true
+        )
+        private final Double similarity;
+
+        @Schema(description = "비교 화면에 표시할 경험 정보")
+        private final ExperienceSnapshot experience;
+
+        public static DuplicateItemResponse fromExisting(UserExperience experience) {
+            return new DuplicateItemResponse(
+                    experience.getId(),
+                    DuplicateItemSource.EXISTING,
+                    null,
+                    ExperienceSnapshot.from(experience)
+            );
+        }
+
+        public static DuplicateItemResponse fromDraft(ExperienceExtractionDraft draft) {
+            return new DuplicateItemResponse(
+                    draft.getId(),
+                    DuplicateItemSource.EXTRACTED,
+                    draft.getSimilarity(),
+                    ExperienceSnapshot.from(draft)
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Snapshot")
+    public static class ExperienceSnapshot {
+
+        @Schema(description = "경험 제목", example = "금융 AI Agent 프로젝트")
+        private final String title;
+
+        @Schema(description = "경험 유형 enum", example = "PROJECT")
+        private final String experienceType;
+
+        @Schema(
+                description = "경험 대분류 enum",
+                allowableValues = {"NARRATIVE", "SPEC"},
+                example = "NARRATIVE"
+        )
+        private final String experienceGroup;
+
+        @Schema(
+                description = "경험 작성 상태",
+                allowableValues = {"IN_PROGRESS", "COMPLETED"},
+                example = "COMPLETED"
+        )
+        private final String status;
+
+        @Schema(description = "추출된 경험 본문", example = "추천 모델 개선을 담당했습니다.")
+        private final String documentContent;
+
+        @Schema(
+                description = "PresetRegistry 기준 유형별 속성",
+                example = "{\"project_name\":\"금융 AI Agent\",\"role\":\"백엔드 개발\"}"
+        )
+        private final Map<String, Object> attributes;
+
+        @Schema(description = "경험 역량 키워드", example = "[\"문제 해결\", \"실행력\"]")
+        private final List<String> keywords;
+
+        public static ExperienceSnapshot from(UserExperience experience) {
+            return new ExperienceSnapshot(
+                    experience.getTitle(),
+                    experience.getExperienceType().name(),
+                    experience.getExperienceGroup().name(),
+                    experience.getStatus().name(),
+                    experience.getDocumentContent(),
+                    experience.getAttributes() != null ? experience.getAttributes() : new HashMap<>(),
+                    experience.getKeywords() != null ? experience.getKeywords() : new ArrayList<>()
+            );
+        }
+
+        public static ExperienceSnapshot from(ExperienceExtractionDraft draft) {
+            return new ExperienceSnapshot(
+                    draft.getTitle(),
+                    draft.getExperienceType().name(),
+                    draft.getExperienceGroup().name(),
+                    draft.getStatus().name(),
+                    draft.getDocumentContent(),
+                    draft.getAttributes(),
+                    draft.getKeywords()
+            );
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step3Request")
+    public static class Step3Request {
+
+        @NotBlank(message = "중복 batch ID는 필수입니다.")
+        @Schema(
+                description = "Step2에서 반환된 duplicateBatchId",
+                example = "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private String duplicateBatchId;
+
+        @Valid
+        @NotEmpty(message = "중복 그룹 선택 목록은 필수입니다.")
+        @Schema(
+                description = "batch의 모든 중복 그룹에 대한 선택. 그룹 누락은 허용되지 않습니다.",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<GroupSelection> groups = new ArrayList<>();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "ExperienceExtractionV2GroupSelection")
+    public static class GroupSelection {
+
+        @NotBlank(message = "중복 group ID는 필수입니다.")
+        @Schema(
+                description = "Step2 duplicateGroups의 groupId",
+                example = "9f83540e-5d78-4a08-a284-78cecfdf2e3d",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private String groupId;
+
+        @NotEmpty(message = "그룹마다 하나 이상의 경험을 선택해야 합니다.")
+        @Schema(
+                description = "최종적으로 남길 itemId 목록. 기존 경험과 여러 draft를 함께 선택할 수 있습니다.",
+                example = "[\"existing-experience-id\", \"draft-id\"]",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        private List<String> selectedItemIds = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ExperienceExtractionV2Step3Response")
+    public static class Step3Response {
+
+        @Schema(description = "Step3 처리 후 최종적으로 유지되거나 신규 저장된 경험")
+        private final List<ExperienceResponse> selectedExperiences;
+
+        @Schema(
+                description = "선택되지 않아 삭제된 기존 경험 ID",
+                example = "[\"deleted-existing-experience-id\"]"
+        )
+        private final List<String> deletedExperienceIds;
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
@@ -1,0 +1,46 @@
+package back.pickd.experience.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_duplicate_groups")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceDuplicateGroup {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_id", nullable = false)
+    private ExperienceExtractionBatch batch;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "existing_experience_id", nullable = false)
+    private UserExperience existingExperience;
+
+    @OneToMany(mappedBy = "duplicateGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceExtractionDraft> drafts = new ArrayList<>();
+
+    public ExperienceDuplicateGroup(UserExperience existingExperience) {
+        this.id = UUID.randomUUID().toString();
+        this.existingExperience = existingExperience;
+    }
+
+    void attachTo(ExperienceExtractionBatch batch) {
+        this.batch = batch;
+    }
+
+    public void addDraft(ExperienceExtractionDraft draft) {
+        draft.attachTo(this);
+        drafts.add(draft);
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
@@ -1,0 +1,59 @@
+package back.pickd.experience.entity;
+
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_extraction_batches")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceExtractionBatch {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ExtractionBatchStatus status;
+
+    @OneToMany(mappedBy = "batch", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceDuplicateGroup> groups = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "processed_at")
+    private OffsetDateTime processedAt;
+
+    public ExperienceExtractionBatch(User user) {
+        this.id = UUID.randomUUID().toString();
+        this.user = user;
+        this.status = ExtractionBatchStatus.PENDING;
+        this.createdAt = OffsetDateTime.now();
+    }
+
+    public void addGroup(ExperienceDuplicateGroup group) {
+        group.attachTo(this);
+        groups.add(group);
+    }
+
+    public void complete() {
+        this.status = ExtractionBatchStatus.COMPLETED;
+        this.processedAt = OffsetDateTime.now();
+        this.groups.clear();
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionDraft.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionDraft.java
@@ -1,0 +1,93 @@
+package back.pickd.experience.entity;
+
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "experience_extraction_drafts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperienceExtractionDraft {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "duplicate_group_id", nullable = false)
+    private ExperienceDuplicateGroup duplicateGroup;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_type", nullable = false, length = 50)
+    private ExperienceType experienceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "experience_group", nullable = false, length = 20)
+    private ExperienceGroup experienceGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
+
+    @Column(name = "document_content", columnDefinition = "TEXT")
+    private String documentContent;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private Map<String, Object> attributes = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    private List<String> keywords = new ArrayList<>();
+
+    @Column(name = "resume_url", nullable = false, columnDefinition = "TEXT")
+    private String resumeUrl;
+
+    @Column(name = "similarity")
+    private Double similarity;
+
+    @Builder
+    public ExperienceExtractionDraft(
+            String title,
+            ExperienceType experienceType,
+            ExperienceGroup experienceGroup,
+            Status status,
+            String documentContent,
+            Map<String, Object> attributes,
+            List<String> keywords,
+            String resumeUrl,
+            Double similarity
+    ) {
+        this.id = UUID.randomUUID().toString();
+        this.title = title;
+        this.experienceType = experienceType;
+        this.experienceGroup = experienceGroup;
+        this.status = status;
+        this.documentContent = documentContent;
+        this.attributes = attributes != null ? new HashMap<>(attributes) : new HashMap<>();
+        this.keywords = keywords != null ? new ArrayList<>(keywords) : new ArrayList<>();
+        this.resumeUrl = resumeUrl;
+        this.similarity = similarity;
+    }
+
+    void attachTo(ExperienceDuplicateGroup duplicateGroup) {
+        this.duplicateGroup = duplicateGroup;
+    }
+}

--- a/src/main/java/back/pickd/experience/enums/ExtractionBatchStatus.java
+++ b/src/main/java/back/pickd/experience/enums/ExtractionBatchStatus.java
@@ -1,0 +1,6 @@
+package back.pickd.experience.enums;
+
+public enum ExtractionBatchStatus {
+    PENDING,
+    COMPLETED
+}

--- a/src/main/java/back/pickd/experience/repository/ExperienceExtractionBatchRepository.java
+++ b/src/main/java/back/pickd/experience/repository/ExperienceExtractionBatchRepository.java
@@ -1,0 +1,25 @@
+package back.pickd.experience.repository;
+
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.user.entity.User;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.List;
+
+public interface ExperienceExtractionBatchRepository
+        extends JpaRepository<ExperienceExtractionBatch, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ExperienceExtractionBatch> findByIdAndUser(String id, User user);
+
+    List<ExperienceExtractionBatch> findByUserOrderByCreatedAtDesc(User user);
+
+    List<ExperienceExtractionBatch> findByUserAndStatusOrderByCreatedAtDesc(
+            User user,
+            ExtractionBatchStatus status
+    );
+}

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionTestService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionTestService.java
@@ -1,0 +1,45 @@
+package back.pickd.experience.service;
+
+import back.pickd.experience.dto.ExperienceExtractionTestDto.BatchState;
+import back.pickd.experience.dto.ExperienceExtractionTestDto.StateResponse;
+import back.pickd.experience.dto.ExperienceExtractionTestDto.TempState;
+import back.pickd.experience.dto.ExperienceResponse;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.ExperienceTempRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.user.entity.User;
+import back.pickd.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Profile("local")
+@RequiredArgsConstructor
+public class ExperienceExtractionTestService {
+
+    private final UserRepository userRepository;
+    private final UserExperienceRepository experienceRepository;
+    private final ExperienceTempRepository tempRepository;
+    private final ExperienceExtractionBatchRepository batchRepository;
+
+    @Transactional(readOnly = true)
+    public StateResponse getState(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return new StateResponse(
+                email,
+                experienceRepository.findByUserOrderByCreatedAtDesc(user).stream()
+                        .map(ExperienceResponse::new)
+                        .toList(),
+                tempRepository.findByUser(user).stream()
+                        .map(TempState::from)
+                        .toList(),
+                batchRepository.findByUserOrderByCreatedAtDesc(user).stream()
+                        .map(BatchState::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
@@ -1,0 +1,453 @@
+package back.pickd.experience.service;
+
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.DuplicateGroupResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.GroupSelection;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.PendingBatchesResponse;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step2Response;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Request;
+import back.pickd.experience.dto.ExperienceExtractionV2Dto.Step3Response;
+import back.pickd.experience.dto.ExperienceResponse;
+import back.pickd.experience.entity.*;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.experience.enums.Status;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.ExperienceTempRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.experience.support.PresetRegistry;
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
+import back.pickd.global.infra.ai.dto.AiStep1Response;
+import back.pickd.global.infra.ai.dto.AiStep2Response;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ExperienceExtractionV2Service {
+
+    private static final String BATCH_CANDIDATE_PREFIX = "batch:";
+
+    private final AiClient aiClient;
+    private final ExperienceTempRepository tempRepository;
+    private final UserExperienceRepository experienceRepository;
+    private final ExperienceExtractionBatchRepository batchRepository;
+    private final UserService userService;
+    private final ExperienceMergeService experienceMergeService;
+    private final PresetRegistry presetRegistry;
+
+    @Transactional
+    public Step2Response extractStep2(String email, List<Long> selectedTempIds) {
+        User user = userService.findByEmail(email);
+        List<ExperienceTemp> temps = loadSelectedTemps(user, selectedTempIds);
+        String resumeUrl = validateSingleResumeSource(temps);
+
+        List<SelectedExperience> selectedExperiences = temps.stream()
+                .map(this::toSelectedExperience)
+                .toList();
+
+        List<AiStep1Response.ExperienceSummaryDto> summaries = selectedExperiences.stream()
+                .map(selected -> new AiStep1Response.ExperienceSummaryDto(
+                        selected.temp().getExperienceName(),
+                        toKoreanGroup(selected.group()),
+                        selected.type().getKoreanName()
+                ))
+                .toList();
+
+        List<AiExperienceMergeCheckRequest.ExperiencePayload> existingExperiences =
+                experienceMergeService.buildExistingExperiencePayloads(user);
+
+        AiStep2Response aiResponse = aiClient.extractStep2V2ByUrl(
+                resumeUrl,
+                summaries,
+                existingExperiences,
+                presetRegistry.getAiPresetSchemas(
+                        selectedExperiences.stream().map(SelectedExperience::type).toList()
+                )
+        );
+
+        List<AiStep2Response.Step2ExperienceDto> extracted = validateAiResponse(
+                aiResponse,
+                selectedExperiences
+        );
+
+        // UUID를 @PrePersist 이전에 수동 할당 → 루프 내 즉시 참조 가능, save() 지연 가능
+        List<UserExperience> toSave = new ArrayList<>();
+        Map<Integer, UserExperience> savedByTargetIndex = new HashMap<>();
+        Map<String, ExperienceDuplicateGroup> groupsByExistingId = new LinkedHashMap<>();
+        ExperienceExtractionBatch batch = null;
+
+        for (int index = 0; index < extracted.size(); index++) {
+            AiStep2Response.Step2ExperienceDto dto = extracted.get(index);
+            SelectedExperience selected = selectedExperiences.get(index);
+
+            if (!dto.isNeeds_merge()) {
+                UserExperience experience = buildExtractedExperience(
+                        user,
+                        dto,
+                        selected.type(),
+                        selected.group(),
+                        resumeUrl
+                );
+                toSave.add(experience);
+                savedByTargetIndex.put(index, experience);
+                continue;
+            }
+
+            UserExperience existing = resolveMergeCandidate(
+                    user,
+                    dto.getMerge_candidate_id(),
+                    savedByTargetIndex
+            );
+
+            if (batch == null) {
+                batch = new ExperienceExtractionBatch(user);
+            }
+
+            ExperienceDuplicateGroup group = groupsByExistingId.get(existing.getId());
+            if (group == null) {
+                group = new ExperienceDuplicateGroup(existing);
+                batch.addGroup(group);
+                groupsByExistingId.put(existing.getId(), group);
+            }
+
+            group.addDraft(ExperienceExtractionDraft.builder()
+                    .title(dto.getExperience_name())
+                    .experienceType(selected.type())
+                    .experienceGroup(selected.group())
+                    .status(Status.COMPLETED)
+                    .documentContent(dto.getExperience_content())
+                    .attributes(presetRegistry.normalizeAttributes(
+                            selected.type(),
+                            dto.getBasic_info()
+                    ))
+                    .keywords(dto.getKeywords())
+                    .resumeUrl(resumeUrl)
+                    .similarity(dto.getMerge_similarity())
+                    .build());
+        }
+
+        // 경험 + 파일 일괄 저장 (CascadeType.ALL 로 ExperienceFile 함께 INSERT)
+        List<UserExperience> savedExperiences = experienceRepository.saveAll(toSave);
+
+        if (batch != null) {
+            batchRepository.save(batch);
+        }
+
+        tempRepository.deleteByUser(user);
+
+        return new Step2Response(
+                savedExperiences.stream().map(ExperienceResponse::new).toList(),
+                batch != null ? batch.getId() : null,
+                batch != null
+                        ? batch.getGroups().stream().map(DuplicateGroupResponse::from).toList()
+                        : List.of()
+        );
+    }
+
+    @Transactional
+    public Step3Response confirmStep3(String email, Step3Request request) {
+        User user = userService.findByEmail(email);
+        ExperienceExtractionBatch batch = batchRepository.findByIdAndUser(
+                        request.getDuplicateBatchId(),
+                        user
+                )
+                .orElseThrow(() -> new IllegalArgumentException("중복 경험 batch를 찾을 수 없습니다."));
+
+        if (batch.getStatus() != ExtractionBatchStatus.PENDING) {
+            throw new IllegalStateException("이미 처리된 중복 경험 batch입니다.");
+        }
+
+        Map<String, GroupSelection> selections = indexSelections(request.getGroups());
+
+        Set<String> expectedGroupIds = batch.getGroups().stream()
+                .map(ExperienceDuplicateGroup::getId)
+                .collect(Collectors.toSet());
+
+        if (!selections.keySet().equals(expectedGroupIds)) {
+            throw new IllegalArgumentException("batch의 모든 중복 그룹에 대한 선택이 필요합니다.");
+        }
+
+        List<UserExperience> selectedExperiences = new ArrayList<>();
+        List<UserExperience> experiencesToDelete = new ArrayList<>();
+        List<String> deletedExperienceIds = new ArrayList<>();
+
+        for (ExperienceDuplicateGroup group : batch.getGroups()) {
+            Set<String> selectedItemIds = new LinkedHashSet<>(
+                    selections.get(group.getId()).getSelectedItemIds()
+            );
+
+            if (selectedItemIds.isEmpty()) {
+                throw new IllegalArgumentException("그룹마다 하나 이상의 경험을 선택해야 합니다.");
+            }
+
+            if (selectedItemIds.size()
+                    != selections.get(group.getId()).getSelectedItemIds().size()) {
+                throw new IllegalArgumentException("동일한 경험을 중복 선택할 수 없습니다.");
+            }
+
+            Set<String> allowedItemIds = new HashSet<>();
+            allowedItemIds.add(group.getExistingExperience().getId());
+            group.getDrafts().stream()
+                    .map(ExperienceExtractionDraft::getId)
+                    .forEach(allowedItemIds::add);
+
+            if (!allowedItemIds.containsAll(selectedItemIds)) {
+                throw new IllegalArgumentException("중복 그룹에 속하지 않은 경험이 선택되었습니다.");
+            }
+
+            UserExperience existing = group.getExistingExperience();
+            if (selectedItemIds.contains(existing.getId())) {
+                selectedExperiences.add(existing);
+            } else {
+                experiencesToDelete.add(existing);
+                deletedExperienceIds.add(existing.getId());
+            }
+
+            for (ExperienceExtractionDraft draft : group.getDrafts()) {
+                if (selectedItemIds.contains(draft.getId())) {
+                    selectedExperiences.add(buildDraftExperience(user, draft));
+                }
+            }
+        }
+
+        // Draft에서 생성된 경험 일괄 저장 (CascadeType.ALL 로 ExperienceFile 함께 INSERT)
+        experienceRepository.saveAll(selectedExperiences);
+
+        batch.complete();
+        batchRepository.saveAndFlush(batch);
+
+        if (!experiencesToDelete.isEmpty()) {
+            experienceRepository.deleteAll(experiencesToDelete);
+        }
+
+        return new Step3Response(
+                selectedExperiences.stream().map(ExperienceResponse::new).toList(),
+                deletedExperienceIds
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PendingBatchesResponse getPendingDuplicates(String email) {
+        User user = userService.findByEmail(email);
+        return new PendingBatchesResponse(
+                batchRepository.findByUserAndStatusOrderByCreatedAtDesc(
+                                user,
+                                ExtractionBatchStatus.PENDING
+                        )
+                        .stream()
+                        .map(PendingBatchResponse::from)
+                        .toList()
+        );
+    }
+
+    private List<ExperienceTemp> loadSelectedTemps(User user, List<Long> selectedTempIds) {
+        if (selectedTempIds == null || selectedTempIds.isEmpty()) {
+            throw new IllegalArgumentException("선택된 임시 경험 ID가 없습니다.");
+        }
+        if (new HashSet<>(selectedTempIds).size() != selectedTempIds.size()) {
+            throw new IllegalArgumentException("동일한 임시 경험을 중복 선택할 수 없습니다.");
+        }
+        Map<Long, ExperienceTemp> tempsById = tempRepository.findAllById(selectedTempIds)
+                .stream()
+                .collect(Collectors.toMap(ExperienceTemp::getId, Function.identity()));
+
+        if (tempsById.size() != selectedTempIds.size()) {
+            throw new IllegalArgumentException("요청한 임시 경험 데이터를 찾을 수 없습니다.");
+        }
+        List<ExperienceTemp> ordered = selectedTempIds.stream()
+                .map(tempsById::get)
+                .toList();
+        if (ordered.stream().anyMatch(temp -> !isOwnedBy(temp, user))) {
+            throw new IllegalArgumentException("다른 사용자의 임시 경험은 선택할 수 없습니다.");
+        }
+        return ordered;
+    }
+
+    private boolean isOwnedBy(ExperienceTemp temp, User user) {
+        if (temp.getUser() == user) {
+            return true;
+        }
+        return temp.getUser().getId() != null
+                && Objects.equals(temp.getUser().getId(), user.getId());
+    }
+
+    private String validateSingleResumeSource(List<ExperienceTemp> temps) {
+        Set<String> resumeUrls = temps.stream()
+                .map(ExperienceTemp::getResumeUrl)
+                .collect(Collectors.toSet());
+        if (resumeUrls.size() != 1) {
+            throw new IllegalArgumentException("서로 다른 원본 파일의 경험을 함께 추출할 수 없습니다.");
+        }
+        return temps.get(0).getResumeUrl();
+    }
+
+    private SelectedExperience toSelectedExperience(ExperienceTemp temp) {
+        ExperienceType type = convertType(temp.getExperienceType());
+        ExperienceGroup group = convertGroup(temp.getExperienceGroup());
+        validateGroupType(group, type);
+        return new SelectedExperience(temp, type, group);
+    }
+
+    private List<AiStep2Response.Step2ExperienceDto> validateAiResponse(
+            AiStep2Response response,
+            List<SelectedExperience> selectedExperiences
+    ) {
+        if (response == null || response.getExperiences() == null) {
+            throw new IllegalStateException("AI 2차 경험 추출 응답이 없습니다.");
+        }
+        if (response.getExperiences().size() != selectedExperiences.size()) {
+            throw new IllegalStateException("AI 2차 경험 추출 결과 수가 선택한 경험 수와 다릅니다.");
+        }
+        for (int index = 0; index < response.getExperiences().size(); index++) {
+            AiStep2Response.Step2ExperienceDto dto = response.getExperiences().get(index);
+            ExperienceType responseType = convertType(dto.getExperience_type());
+            ExperienceGroup responseGroup = convertGroup(dto.getExperience_group());
+            SelectedExperience selected = selectedExperiences.get(index);
+            if (responseType != selected.type() || responseGroup != selected.group()) {
+                throw new IllegalStateException("AI 2차 경험 유형이 선택한 1차 경험과 일치하지 않습니다.");
+            }
+        }
+        return response.getExperiences();
+    }
+
+    private UserExperience resolveMergeCandidate(
+            User user,
+            String candidateId,
+            Map<Integer, UserExperience> savedByTargetIndex
+    ) {
+        if (candidateId == null || candidateId.isBlank()) {
+            throw new IllegalStateException("AI 중복 후보 ID가 없습니다.");
+        }
+        if (candidateId.startsWith(BATCH_CANDIDATE_PREFIX)) {
+            int targetIndex;
+            try {
+                targetIndex = Integer.parseInt(
+                        candidateId.substring(BATCH_CANDIDATE_PREFIX.length())
+                );
+            } catch (NumberFormatException e) {
+                throw new IllegalStateException("AI batch 중복 후보 ID가 올바르지 않습니다.", e);
+            }
+            UserExperience saved = savedByTargetIndex.get(targetIndex);
+            if (saved == null) {
+                throw new IllegalStateException("AI batch 중복 후보가 저장 대상에 없습니다.");
+            }
+            return saved;
+        }
+        return experienceRepository.findByIdAndUser(candidateId, user)
+                .orElseThrow(() -> new IllegalStateException(
+                        "AI 중복 후보를 사용자 경험에서 찾을 수 없습니다."
+                ));
+    }
+
+    /**
+     * UserExperience 객체를 빌드만 하고 저장은 하지 않습니다.
+     * UUID를 @PrePersist 이전에 수동 할당하여 저장 전에도 ID 참조가 가능합니다.
+     * 호출부에서 saveAll()로 일괄 저장하세요.
+     */
+    private UserExperience buildExtractedExperience(
+            User user,
+            AiStep2Response.Step2ExperienceDto dto,
+            ExperienceType type,
+            ExperienceGroup group,
+            String resumeUrl
+    ) {
+        UserExperience experience = UserExperience.builder()
+                .id(java.util.UUID.randomUUID().toString())
+                .user(user)
+                .title(dto.getExperience_name())
+                .experienceType(type)
+                .experienceGroup(group)
+                .status(Status.COMPLETED)
+                .documentContent(dto.getExperience_content())
+                .attributes(presetRegistry.normalizeAttributes(type, dto.getBasic_info()))
+                .keywords(dto.getKeywords() != null ? dto.getKeywords() : new ArrayList<>())
+                .build();
+        attachResumeFile(experience, resumeUrl);
+        return experience;
+    }
+
+    /**
+     * Draft로부터 UserExperience를 빌드만 하고 저장은 하지 않습니다.
+     * 호출부에서 saveAll()로 일괄 저장하세요.
+     */
+    private UserExperience buildDraftExperience(User user, ExperienceExtractionDraft draft) {
+        UserExperience experience = UserExperience.builder()
+                .id(java.util.UUID.randomUUID().toString())
+                .user(user)
+                .title(draft.getTitle())
+                .experienceType(draft.getExperienceType())
+                .experienceGroup(draft.getExperienceGroup())
+                .status(draft.getStatus())
+                .documentContent(draft.getDocumentContent())
+                .attributes(draft.getAttributes())
+                .keywords(draft.getKeywords())
+                .build();
+        attachResumeFile(experience, draft.getResumeUrl());
+        return experience;
+    }
+
+    private void attachResumeFile(UserExperience experience, String resumeUrl) {
+        ExperienceFile resumeFile = ExperienceFile.builder()
+                .userExperience(experience)
+                .originalFilename("자기소개서 원본.pdf")
+                .fileType("application/pdf")
+                .fileSize(0L)
+                .filePath(resumeUrl)
+                .source("RESUME_ORIGINAL")
+                .build();
+        experience.updateFiles(List.of(resumeFile));
+    }
+
+    private Map<String, GroupSelection> indexSelections(List<GroupSelection> selections) {
+        Map<String, GroupSelection> indexed = new HashMap<>();
+        for (GroupSelection selection : selections) {
+            if (indexed.put(selection.getGroupId(), selection) != null) {
+                throw new IllegalArgumentException("동일한 중복 그룹을 중복 제출할 수 없습니다.");
+            }
+        }
+        return indexed;
+    }
+
+    private ExperienceGroup convertGroup(String koreanGroup) {
+        return switch (koreanGroup) {
+            case "상세 서술형" -> ExperienceGroup.NARRATIVE;
+            case "스펙·증빙형" -> ExperienceGroup.SPEC;
+            default -> throw new IllegalArgumentException(
+                    "지원하지 않는 경험 그룹입니다: " + koreanGroup
+            );
+        };
+    }
+
+    private ExperienceType convertType(String koreanType) {
+        return ExperienceType.fromKoreanName(koreanType);
+    }
+
+    private void validateGroupType(ExperienceGroup group, ExperienceType type) {
+        if (presetRegistry.getExperienceGroup(type) != group) {
+            throw new IllegalArgumentException(
+                    "경험 그룹과 유형이 일치하지 않습니다: " + type.getKoreanName()
+            );
+        }
+    }
+
+    private String toKoreanGroup(ExperienceGroup group) {
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
+    }
+
+    private record SelectedExperience(
+            ExperienceTemp temp,
+            ExperienceType type,
+            ExperienceGroup group
+    ) {
+    }
+}

--- a/src/main/java/back/pickd/global/config/OpenApiConfig.java
+++ b/src/main/java/back/pickd/global/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package back.pickd.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String COOKIE_AUTH = "cookieAuth";
+
+    @Bean
+    public OpenAPI pickdOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("PICKD API")
+                        .version("v2")
+                        .description("PICKD Spring 서버 REST API 명세"))
+                .components(new Components()
+                        .addSecuritySchemes(
+                                COOKIE_AUTH,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.COOKIE)
+                                        .name("accessToken")
+                                        .description("로그인 후 발급되는 JWT accessToken 쿠키")
+                        ));
+    }
+}

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiExperiencePresetSchema.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiExperiencePresetSchema.java
@@ -1,0 +1,30 @@
+package back.pickd.global.infra.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AiExperiencePresetSchema {
+
+    @JsonProperty("experience_group")
+    private final String experienceGroup;
+
+    @JsonProperty("experience_type")
+    private final String experienceType;
+
+    @JsonProperty("experience_type_name")
+    private final String experienceTypeName;
+
+    private final List<Field> fields;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Field {
+        private final String key;
+        private final String label;
+    }
+}

--- a/src/main/java/back/pickd/notice/notice/Notice.java
+++ b/src/main/java/back/pickd/notice/notice/Notice.java
@@ -56,20 +56,13 @@ public class Notice {
     @Column(name = "notice_url", columnDefinition = "TEXT")
     private String noticeUrl;
 
-    @Column(columnDefinition = "TEXT")
-    private String opportunities;
-
-    @Column(columnDefinition = "TEXT")
-    private String threats;
-
     @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<NoticeSection> sections = new ArrayList<>();
 
     @Builder
     public Notice(User user, String companyName, String noticeName, JobCategory category,
                   String startedAt, String endedAt, EmploymentType employmentType, String headcount,
-                  String region1depth, String workplaceAddress, String noticeUrl,
-                  String opportunities, String threats) {
+                  String region1depth, String workplaceAddress, String noticeUrl) {
         this.user = user;
         this.companyName = companyName;
         this.noticeName = noticeName;
@@ -81,8 +74,6 @@ public class Notice {
         this.region1depth = region1depth;
         this.workplaceAddress = workplaceAddress;
         this.noticeUrl = noticeUrl;
-        this.opportunities = opportunities;
-        this.threats = threats;
     }
 
     public void addSection(NoticeSection section) {

--- a/src/main/java/back/pickd/notice/notice/Notice.java
+++ b/src/main/java/back/pickd/notice/notice/Notice.java
@@ -1,5 +1,6 @@
 package back.pickd.notice.notice;
 
+import back.pickd.coverletter.entity.CoverLetterItem;
 import back.pickd.notice.enums.EmploymentType;
 import back.pickd.notice.enums.JobCategory;
 import back.pickd.notice.section.NoticeSection;
@@ -58,6 +59,9 @@ public class Notice {
 
     @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<NoticeSection> sections = new ArrayList<>();
+
+    @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CoverLetterItem> coverLetterItems = new ArrayList<>();
 
     @Builder
     public Notice(User user, String companyName, String noticeName, JobCategory category,

--- a/src/main/java/back/pickd/notice/notice/Notice.java
+++ b/src/main/java/back/pickd/notice/notice/Notice.java
@@ -21,7 +21,7 @@ public class Notice {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(name = "company_name", nullable = false)

--- a/src/main/java/back/pickd/notice/notice/NoticeRepository.java
+++ b/src/main/java/back/pickd/notice/notice/NoticeRepository.java
@@ -1,8 +1,16 @@
 package back.pickd.notice.notice;
 
+import back.pickd.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    List<Notice> findAllByUserOrderByIdDesc(User user);
+
+    Optional<Notice> findByIdAndUser(Long id, User user);
 }

--- a/src/main/resources/templates/experience-extraction-test.html
+++ b/src/main/resources/templates/experience-extraction-test.html
@@ -1,0 +1,706 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>경험 추출 Local E2E</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f4f6f8;
+            --card: #ffffff;
+            --line: #d8dee6;
+            --text: #18212f;
+            --muted: #617084;
+            --primary: #275efe;
+            --danger: #c9362b;
+            --ok: #16794b;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            color: var(--text);
+            background: var(--bg);
+        }
+        header {
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            padding: 16px 24px;
+            border-bottom: 1px solid var(--line);
+            background: rgba(255, 255, 255, .96);
+        }
+        main {
+            display: grid;
+            grid-template-columns: minmax(0, 1.35fr) minmax(360px, .65fr);
+            gap: 20px;
+            max-width: 1500px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .flow, .side { display: grid; gap: 18px; align-content: start; }
+        .card {
+            padding: 20px;
+            border: 1px solid var(--line);
+            border-radius: 12px;
+            background: var(--card);
+            box-shadow: 0 4px 14px rgba(25, 35, 50, .04);
+        }
+        h1, h2, h3 { margin: 0 0 12px; }
+        h1 { font-size: 20px; }
+        h2 { font-size: 18px; }
+        h3 { font-size: 15px; }
+        p { margin: 6px 0; color: var(--muted); }
+        label { display: grid; gap: 6px; color: var(--muted); font-size: 13px; }
+        input, select, textarea, button { font: inherit; }
+        input[type="text"], select, textarea {
+            width: 100%;
+            padding: 10px 11px;
+            border: 1px solid var(--line);
+            border-radius: 8px;
+            color: var(--text);
+            background: #fff;
+        }
+        textarea { min-height: 100px; resize: vertical; }
+        button, .button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            padding: 9px 13px;
+            border: 1px solid transparent;
+            border-radius: 8px;
+            color: #fff;
+            background: var(--primary);
+            cursor: pointer;
+            text-decoration: none;
+        }
+        button.secondary { color: var(--text); border-color: var(--line); background: #fff; }
+        button.danger { background: var(--danger); }
+        button:disabled { opacity: .5; cursor: not-allowed; }
+        .actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+        .grid-2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+        .list { display: grid; gap: 10px; margin-top: 14px; }
+        .item {
+            padding: 12px;
+            border: 1px solid var(--line);
+            border-radius: 9px;
+            background: #fbfcfd;
+        }
+        .item-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+        .meta { color: var(--muted); font-size: 12px; word-break: break-all; }
+        .badge {
+            display: inline-block;
+            padding: 3px 7px;
+            border-radius: 999px;
+            color: #24415e;
+            background: #e8f0f8;
+            font-size: 11px;
+        }
+        .selected-order { margin: 10px 0 0; padding-left: 24px; }
+        .selected-order li { margin: 7px 0; }
+        .mini { padding: 3px 7px; color: var(--text); border-color: var(--line); background: #fff; }
+        pre {
+            max-height: 420px;
+            margin: 10px 0 0;
+            padding: 12px;
+            overflow: auto;
+            border-radius: 8px;
+            color: #dce8f5;
+            background: #111923;
+            font-size: 12px;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+        .log-entry { padding: 12px 0; border-bottom: 1px solid var(--line); }
+        .log-ok { color: var(--ok); }
+        .log-error { color: var(--danger); }
+        .draft-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 10px; }
+        .attribute-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+        .empty { padding: 16px; color: var(--muted); text-align: center; border: 1px dashed var(--line); border-radius: 8px; }
+        .status-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--danger); }
+        .status-dot.on { background: var(--ok); }
+        .login { display: flex; align-items: center; gap: 9px; }
+        @media (max-width: 980px) {
+            main { grid-template-columns: 1fr; }
+            .grid-2, .attribute-fields { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+<header>
+    <div>
+        <h1>경험 추출 Local E2E</h1>
+        <div class="meta">Step1 → Step2 V2 → Step3 V2 / 실제 S3·Python·OpenAI 호출</div>
+    </div>
+    <div class="login">
+        <span id="auth-dot" class="status-dot" th:classappend="${authenticated} ? ' on' : ''"></span>
+        <span id="auth-text" th:text="${authenticated} ? ${userEmail} : '로그인 필요'">로그인 필요</span>
+        <a class="button" href="/oauth2/authorization/google">Google 로그인</a>
+        <a class="button" href="/logout" style="background:#5d6878">로그아웃</a>
+    </div>
+</header>
+
+<main>
+    <section class="flow">
+        <article class="card">
+            <h2>1. Step1 후보 추출</h2>
+            <p>PDF 입력은 요청 후에도 브라우저에 유지됩니다. 같은 파일로 Step1을 다시 실행할 수 있습니다.</p>
+            <label>
+                분석할 PDF
+                <input id="pdf-file" type="file" accept="application/pdf">
+            </label>
+            <div class="actions">
+                <button id="step1-button" type="button">Step1 실행</button>
+            </div>
+            <div id="step1-candidates" class="list">
+                <div class="empty">아직 추출한 후보가 없습니다.</div>
+            </div>
+            <h3 style="margin-top:16px">Step2 전달 순서</h3>
+            <ol id="selected-order" class="selected-order"></ol>
+        </article>
+
+        <article class="card">
+            <h2>2. Step2 상세 추출·중복 분류</h2>
+            <p>위 순서대로 배치 내부 중복 우선순위를 적용합니다.</p>
+            <div class="actions">
+                <button id="step2-button" type="button">Step2 V2 실행</button>
+            </div>
+            <div id="step2-result" class="list">
+                <div class="empty">Step2 결과가 여기에 표시됩니다.</div>
+            </div>
+        </article>
+
+        <article class="card">
+            <h2>3. Step3 최종 선택</h2>
+            <p>기본 선택은 없습니다. 모든 그룹에서 하나 이상의 기존 경험 또는 Draft를 선택해야 합니다.</p>
+            <div class="actions">
+                <button id="load-pending-button" class="secondary" type="button">
+                    미처리 중복 불러오기
+                </button>
+                <label id="pending-batch-label" style="display:none; min-width:320px">
+                    미처리 batch
+                    <select id="pending-batch-select"></select>
+                </label>
+            </div>
+            <form id="step3-form">
+                <div id="step3-groups" class="list">
+                    <div class="empty">Step2 중복 그룹이 생성되면 선택 항목이 표시됩니다.</div>
+                </div>
+                <div class="actions">
+                    <button id="step3-button" type="submit" disabled>Step3 V2 실행</button>
+                </div>
+            </form>
+        </article>
+
+        <article class="card">
+            <h2>수기 기준 경험 저장</h2>
+            <p>PresetRegistry의 13개 유형과 필드를 그대로 사용합니다.</p>
+            <form id="manual-form">
+                <div class="grid-2">
+                    <label>
+                        경험 유형
+                        <select id="manual-type" required></select>
+                    </label>
+                    <label>
+                        경험 그룹
+                        <input id="manual-group" type="text" readonly>
+                    </label>
+                    <label>
+                        제목
+                        <input id="manual-title" type="text" required>
+                    </label>
+                    <label>
+                        상태
+                        <select id="manual-status">
+                            <option value="COMPLETED">COMPLETED</option>
+                            <option value="IN_PROGRESS">IN_PROGRESS</option>
+                        </select>
+                    </label>
+                </div>
+                <label style="margin-top:12px">
+                    본문
+                    <textarea id="manual-content"></textarea>
+                </label>
+                <label style="margin-top:12px">
+                    키워드 (쉼표 구분)
+                    <input id="manual-keywords" type="text" placeholder="문제 해결, 협업, 실행력">
+                </label>
+                <h3 style="margin-top:16px">Preset attributes</h3>
+                <div id="manual-attributes" class="attribute-fields"></div>
+                <label style="display:flex; grid-template-columns:auto 1fr; align-items:center; margin-top:14px">
+                    <input id="manual-force" type="checkbox" checked>
+                    forceCreate로 중복 검사 없이 기준 데이터 저장
+                </label>
+                <div class="actions">
+                    <button type="submit">수기 경험 저장</button>
+                </div>
+            </form>
+        </article>
+    </section>
+
+    <aside class="side">
+        <article class="card">
+            <div class="item-head">
+                <div>
+                    <h2>현재 사용자 DB 상태</h2>
+                    <p>UserExperience, Temp, Batch, Group, Draft</p>
+                </div>
+                <button id="refresh-state" class="secondary" type="button">새로고침</button>
+            </div>
+            <div id="db-state">
+                <div class="empty">로그인 후 조회할 수 있습니다.</div>
+            </div>
+        </article>
+
+        <article class="card">
+            <div class="item-head">
+                <div>
+                    <h2>API 로그</h2>
+                    <p>요청·응답·상태 코드·처리 시간</p>
+                </div>
+                <button id="clear-log" class="secondary" type="button">비우기</button>
+            </div>
+            <div id="api-log"></div>
+        </article>
+    </aside>
+</main>
+
+<script th:inline="javascript">
+    const presetDefinitions = JSON.parse(/*[[${presetDefinitionsJson}]]*/ '[]');
+    const state = {
+        step1Candidates: [],
+        selectedTempIds: [],
+        duplicateBatchId: null,
+        duplicateGroups: [],
+        pendingBatches: []
+    };
+
+    const byId = id => document.getElementById(id);
+    const escapeHtml = value => String(value ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+    const pretty = value => JSON.stringify(value, null, 2);
+
+    async function apiCall(label, url, options = {}, requestDisplay = null) {
+        const startedAt = performance.now();
+        let response;
+        let payload;
+        try {
+            response = await fetch(url, { credentials: "same-origin", ...options });
+            const text = await response.text();
+            try {
+                payload = text ? JSON.parse(text) : null;
+            } catch {
+                payload = text;
+            }
+        } catch (error) {
+            addLog(label, requestDisplay, { networkError: error.message }, 0,
+                Math.round(performance.now() - startedAt));
+            throw error;
+        }
+
+        addLog(label, requestDisplay, payload, response.status,
+            Math.round(performance.now() - startedAt));
+        if (!response.ok) {
+            throw new Error(payload?.message || payload?.detail || `HTTP ${response.status}`);
+        }
+        return payload;
+    }
+
+    function addLog(label, request, response, status, elapsedMs) {
+        const entry = document.createElement("div");
+        entry.className = "log-entry";
+        const statusClass = status >= 200 && status < 300 ? "log-ok" : "log-error";
+        entry.innerHTML = `
+            <div class="item-head">
+                <strong>${escapeHtml(label)}</strong>
+                <span class="${statusClass}">HTTP ${status || "NETWORK"} · ${elapsedMs}ms</span>
+            </div>
+            <details>
+                <summary>요청</summary>
+                <pre>${escapeHtml(pretty(request))}</pre>
+            </details>
+            <details open>
+                <summary>응답</summary>
+                <pre>${escapeHtml(pretty(response))}</pre>
+            </details>`;
+        byId("api-log").prepend(entry);
+    }
+
+    async function loadAuth() {
+        try {
+            const user = await apiCall("로그인 상태", "/api/user", {}, null);
+            byId("auth-dot").classList.add("on");
+            byId("auth-text").textContent = user.email || user.name || "로그인됨";
+            await refreshState();
+        } catch {
+            byId("auth-dot").classList.remove("on");
+            byId("auth-text").textContent = "로그인 필요";
+        }
+    }
+
+    function renderStep1() {
+        const container = byId("step1-candidates");
+        if (!state.step1Candidates.length) {
+            container.innerHTML = '<div class="empty">추출 후보가 없습니다.</div>';
+            return;
+        }
+        container.innerHTML = state.step1Candidates.map(candidate => `
+            <label class="item" style="display:flex; grid-template-columns:auto 1fr; align-items:start">
+                <input type="checkbox" data-temp-id="${candidate.id}"
+                    ${state.selectedTempIds.includes(candidate.id) ? "checked" : ""}>
+                <span>
+                    <strong>${escapeHtml(candidate.experienceName)}</strong>
+                    <span class="badge">${escapeHtml(candidate.experienceType)}</span>
+                    <span class="badge">${escapeHtml(candidate.experienceGroup)}</span>
+                    <span class="meta">temp ID: ${candidate.id}</span>
+                </span>
+            </label>`).join("");
+        container.querySelectorAll("[data-temp-id]").forEach(input => {
+            input.addEventListener("change", () => {
+                const id = Number(input.dataset.tempId);
+                if (input.checked && !state.selectedTempIds.includes(id)) {
+                    state.selectedTempIds.push(id);
+                } else if (!input.checked) {
+                    state.selectedTempIds = state.selectedTempIds.filter(value => value !== id);
+                }
+                renderSelectedOrder();
+            });
+        });
+        renderSelectedOrder();
+    }
+
+    function renderSelectedOrder() {
+        const order = byId("selected-order");
+        order.innerHTML = state.selectedTempIds.map((id, index) => {
+            const candidate = state.step1Candidates.find(item => item.id === id);
+            return `<li>
+                ${escapeHtml(candidate?.experienceName || id)}
+                <button class="mini" type="button" data-move-up="${index}" ${index === 0 ? "disabled" : ""}>↑</button>
+                <button class="mini" type="button" data-move-down="${index}"
+                    ${index === state.selectedTempIds.length - 1 ? "disabled" : ""}>↓</button>
+            </li>`;
+        }).join("");
+        order.querySelectorAll("[data-move-up]").forEach(button =>
+            button.addEventListener("click", () => moveSelected(Number(button.dataset.moveUp), -1)));
+        order.querySelectorAll("[data-move-down]").forEach(button =>
+            button.addEventListener("click", () => moveSelected(Number(button.dataset.moveDown), 1)));
+    }
+
+    function moveSelected(index, offset) {
+        const target = index + offset;
+        if (target < 0 || target >= state.selectedTempIds.length) return;
+        [state.selectedTempIds[index], state.selectedTempIds[target]] =
+            [state.selectedTempIds[target], state.selectedTempIds[index]];
+        renderSelectedOrder();
+    }
+
+    byId("step1-button").addEventListener("click", async () => {
+        const file = byId("pdf-file").files[0];
+        if (!file) return alert("PDF 파일을 선택하세요.");
+        const form = new FormData();
+        form.append("file", file);
+        try {
+            const result = await apiCall(
+                "POST Step1",
+                "/api/experiences/extract/step1",
+                { method: "POST", body: form },
+                { file: { name: file.name, type: file.type, size: file.size } }
+            );
+            state.step1Candidates = result;
+            state.selectedTempIds = [];
+            state.duplicateBatchId = null;
+            state.duplicateGroups = [];
+            renderStep1();
+            renderStep3();
+            await refreshState();
+        } catch (error) {
+            alert(error.message);
+        }
+    });
+
+    byId("step2-button").addEventListener("click", async () => {
+        if (!state.selectedTempIds.length) return alert("Step2에 전달할 후보를 선택하세요.");
+        const request = { selectedTempIds: state.selectedTempIds };
+        try {
+            const result = await apiCall(
+                "POST Step2 V2",
+                "/api/v2/experiences/extract/step2",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(request)
+                },
+                request
+            );
+            state.duplicateBatchId = result.duplicateBatchId;
+            state.duplicateGroups = result.duplicateGroups || [];
+            renderStep2(result);
+            renderStep3();
+            await refreshState();
+        } catch (error) {
+            alert(error.message);
+        }
+    });
+
+    function renderStep2(result) {
+        const saved = result.savedExperiences || [];
+        const groups = result.duplicateGroups || [];
+        byId("step2-result").innerHTML = `
+            <div class="item">
+                <strong>즉시 저장 ${saved.length}건</strong>
+                ${saved.map(item => `<div>${escapeHtml(item.title)} <span class="meta">${item.id}</span></div>`).join("") || '<div class="meta">없음</div>'}
+            </div>
+            <div class="item">
+                <strong>중복 그룹 ${groups.length}건</strong>
+                <div class="meta">batch: ${escapeHtml(result.duplicateBatchId || "없음")}</div>
+            </div>`;
+    }
+
+    function renderStep3() {
+        const container = byId("step3-groups");
+        if (!state.duplicateGroups.length) {
+            container.innerHTML = '<div class="empty">처리할 중복 그룹이 없습니다.</div>';
+            byId("step3-button").disabled = true;
+            return;
+        }
+        container.innerHTML = state.duplicateGroups.map((group, groupIndex) => `
+            <section class="item" data-group="${group.groupId}">
+                <h3>그룹 ${groupIndex + 1}</h3>
+                <div class="meta">${escapeHtml(group.groupId)}</div>
+                <div class="draft-grid">
+                    ${group.items.map(item => `
+                        <label class="item">
+                            <span style="display:flex; gap:8px; align-items:center">
+                                <input type="checkbox" name="group-${group.groupId}" value="${item.itemId}">
+                                <strong>${escapeHtml(item.source)}</strong>
+                                ${item.similarity == null ? "" : `<span class="badge">similarity ${item.similarity}</span>`}
+                            </span>
+                            <span>${escapeHtml(item.experience.title)}</span>
+                            <span class="meta">${escapeHtml(item.experience.experienceType)} / ${escapeHtml(item.itemId)}</span>
+                            <details>
+                                <summary>상세 데이터</summary>
+                                <pre>${escapeHtml(pretty(item.experience))}</pre>
+                            </details>
+                        </label>`).join("")}
+                </div>
+            </section>`).join("");
+        byId("step3-button").disabled = false;
+    }
+
+    async function loadPendingDuplicates(showEmptyAlert = true) {
+        try {
+            const result = await apiCall(
+                "GET 미처리 중복",
+                "/api/v2/experiences/extract/duplicates/pending",
+                {},
+                null
+            );
+            state.pendingBatches = result.batches || [];
+            const label = byId("pending-batch-label");
+            const select = byId("pending-batch-select");
+
+            if (!state.pendingBatches.length) {
+                label.style.display = "none";
+                if (showEmptyAlert) alert("미처리 중복 batch가 없습니다.");
+                return;
+            }
+
+            select.innerHTML = state.pendingBatches.map(batch =>
+                `<option value="${batch.duplicateBatchId}">
+                    ${escapeHtml(batch.createdAt)} · ${batch.duplicateGroups.length}개 그룹
+                </option>`
+            ).join("");
+            label.style.display = "grid";
+            applyPendingBatch(select.value);
+        } catch (error) {
+            if (showEmptyAlert) alert(error.message);
+        }
+    }
+
+    function applyPendingBatch(batchId) {
+        const batch = state.pendingBatches.find(
+            item => item.duplicateBatchId === batchId
+        );
+        if (!batch) return;
+        state.duplicateBatchId = batch.duplicateBatchId;
+        state.duplicateGroups = batch.duplicateGroups;
+        renderStep3();
+    }
+
+    byId("step3-form").addEventListener("submit", async event => {
+        event.preventDefault();
+        const groups = state.duplicateGroups.map(group => ({
+            groupId: group.groupId,
+            selectedItemIds: [...document.querySelectorAll(`input[name="group-${group.groupId}"]:checked`)]
+                .map(input => input.value)
+        }));
+        if (groups.some(group => group.selectedItemIds.length === 0)) {
+            return alert("각 중복 그룹에서 하나 이상 선택하세요.");
+        }
+        const request = { duplicateBatchId: state.duplicateBatchId, groups };
+        try {
+            await apiCall(
+                "POST Step3 V2",
+                "/api/v2/experiences/extract/step3",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(request)
+                },
+                request
+            );
+            state.duplicateBatchId = null;
+            state.duplicateGroups = [];
+            renderStep3();
+            await refreshState();
+            await loadPendingDuplicates(false);
+        } catch (error) {
+            alert(error.message);
+        }
+    });
+
+    function initManualForm() {
+        const select = byId("manual-type");
+        select.innerHTML = presetDefinitions.map(preset =>
+            `<option value="${preset.type}">${escapeHtml(preset.koreanName)} (${preset.type})</option>`
+        ).join("");
+        select.addEventListener("change", renderManualPreset);
+        renderManualPreset();
+    }
+
+    function renderManualPreset() {
+        const preset = presetDefinitions.find(item => item.type === byId("manual-type").value)
+            || presetDefinitions[0];
+        if (!preset) return;
+        byId("manual-group").value = preset.group;
+        byId("manual-attributes").innerHTML = preset.fields.map(field => `
+            <label>
+                ${escapeHtml(field.label)}
+                <input type="text" data-attribute-key="${escapeHtml(field.key)}">
+                <span class="meta">${escapeHtml(field.key)}</span>
+            </label>`).join("");
+    }
+
+    byId("manual-form").addEventListener("submit", async event => {
+        event.preventDefault();
+        const attributes = {};
+        document.querySelectorAll("[data-attribute-key]").forEach(input => {
+            if (input.value.trim()) attributes[input.dataset.attributeKey] = input.value.trim();
+        });
+        const request = {
+            title: byId("manual-title").value.trim(),
+            experienceType: byId("manual-type").value,
+            experienceGroup: byId("manual-group").value,
+            status: byId("manual-status").value,
+            documentContent: byId("manual-content").value,
+            attributes,
+            keywords: byId("manual-keywords").value.split(",").map(value => value.trim()).filter(Boolean),
+            links: [],
+            forceCreate: byId("manual-force").checked
+        };
+        try {
+            await apiCall(
+                "POST 수기 경험",
+                "/api/experiences",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(request)
+                },
+                request
+            );
+            await refreshState();
+        } catch (error) {
+            alert(error.message);
+        }
+    });
+
+    async function refreshState() {
+        try {
+            const result = await apiCall(
+                "GET DB 상태",
+                "/internal/experience-extraction-test/state",
+                {},
+                null
+            );
+            renderDbState(result);
+        } catch (error) {
+            byId("db-state").innerHTML = `<div class="empty">${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    function renderDbState(result) {
+        byId("db-state").innerHTML = `
+            <div class="item">
+                <strong>${escapeHtml(result.userEmail)}</strong>
+                <div class="meta">
+                    experiences ${result.experiences.length} · temps ${result.temps.length} · batches ${result.batches.length}
+                </div>
+            </div>
+            <details open>
+                <summary>저장 경험 (${result.experiences.length})</summary>
+                <div class="list">
+                    ${result.experiences.map(exp => `
+                        <div class="item">
+                            <div class="item-head">
+                                <strong>${escapeHtml(exp.title)}</strong>
+                                <button class="danger mini" type="button" data-delete-experience="${exp.id}">삭제</button>
+                            </div>
+                            <div class="meta">${escapeHtml(exp.experienceType)} / ${escapeHtml(exp.id)}</div>
+                            <pre>${escapeHtml(pretty(exp))}</pre>
+                        </div>`).join("") || '<div class="empty">없음</div>'}
+                </div>
+            </details>
+            <details>
+                <summary>Temp (${result.temps.length})</summary>
+                <pre>${escapeHtml(pretty(result.temps))}</pre>
+            </details>
+            <details open>
+                <summary>Batch·Group·Draft (${result.batches.length})</summary>
+                <pre>${escapeHtml(pretty(result.batches))}</pre>
+            </details>`;
+        byId("db-state").querySelectorAll("[data-delete-experience]").forEach(button => {
+            button.addEventListener("click", async () => {
+                if (!confirm("이 경험을 삭제할까요?")) return;
+                try {
+                    await apiCall(
+                        "DELETE 경험",
+                        `/api/experiences/${button.dataset.deleteExperience}`,
+                        { method: "DELETE" },
+                        { id: button.dataset.deleteExperience }
+                    );
+                    await refreshState();
+                } catch (error) {
+                    alert(error.message);
+                }
+            });
+        });
+    }
+
+    byId("refresh-state").addEventListener("click", refreshState);
+    byId("load-pending-button").addEventListener(
+        "click",
+        () => loadPendingDuplicates(true)
+    );
+    byId("pending-batch-select").addEventListener(
+        "change",
+        event => applyPendingBatch(event.target.value)
+    );
+    byId("clear-log").addEventListener("click", () => byId("api-log").innerHTML = "");
+
+    initManualForm();
+    renderSelectedOrder();
+    loadAuth();
+</script>
+</body>
+</html>

--- a/src/test/java/back/pickd/application/enums/ApplicationStatusTest.java
+++ b/src/test/java/back/pickd/application/enums/ApplicationStatusTest.java
@@ -1,0 +1,143 @@
+package back.pickd.application.enums;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("ApplicationStatus 단위 테스트")
+class ApplicationStatusTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // ── @JsonValue 직렬화 ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("JSON 직렬화")
+    class Serialization {
+
+        @Test
+        @DisplayName("PREPARING은 '지원 예정'으로 직렬화된다")
+        void serializesPreparing() throws Exception {
+            String json = objectMapper.writeValueAsString(ApplicationStatus.PREPARING);
+            assertThat(json).isEqualTo("\"지원 예정\"");
+        }
+
+        @Test
+        @DisplayName("SUBMITTED은 '제출 완료'로 직렬화된다")
+        void serializesSubmitted() throws Exception {
+            String json = objectMapper.writeValueAsString(ApplicationStatus.SUBMITTED);
+            assertThat(json).isEqualTo("\"제출 완료\"");
+        }
+
+        @Test
+        @DisplayName("모든 enum 값이 label로 직렬화된다")
+        void allEnumsSerializeToLabel() throws Exception {
+            for (ApplicationStatus status : ApplicationStatus.values()) {
+                String json = objectMapper.writeValueAsString(status);
+                assertThat(json).isEqualTo("\"" + status.getLabel() + "\"");
+            }
+        }
+    }
+
+    // ── @JsonCreator 역직렬화 ──────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("JSON 역직렬화")
+    class Deserialization {
+
+        @Test
+        @DisplayName("'지원 예정' 문자열을 PREPARING으로 역직렬화한다")
+        void deserializesPreparingLabel() throws Exception {
+            ApplicationStatus result = objectMapper.readValue("\"지원 예정\"", ApplicationStatus.class);
+            assertThat(result).isEqualTo(ApplicationStatus.PREPARING);
+        }
+
+        @Test
+        @DisplayName("'면접 전형' 문자열을 INTERVIEW로 역직렬화한다")
+        void deserializesInterviewLabel() throws Exception {
+            ApplicationStatus result = objectMapper.readValue("\"면접 전형\"", ApplicationStatus.class);
+            assertThat(result).isEqualTo(ApplicationStatus.INTERVIEW);
+        }
+
+        @Test
+        @DisplayName("모든 label이 올바른 enum으로 역직렬화된다")
+        void allLabelsDeserializeCorrectly() throws Exception {
+            for (ApplicationStatus expected : ApplicationStatus.values()) {
+                ApplicationStatus result = objectMapper.readValue(
+                        "\"" + expected.getLabel() + "\"", ApplicationStatus.class);
+                assertThat(result).isEqualTo(expected);
+            }
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 label이면 IllegalArgumentException이 발생한다")
+        void throwsForUnknownLabel() {
+            assertThatThrownBy(() -> ApplicationStatus.from("없는상태"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("지원하지 않는 지원 상태입니다");
+        }
+    }
+
+    // ── 캘린더 이벤트 필요 여부 ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("needsApplyEvent")
+    class NeedsApplyEvent {
+
+        @ParameterizedTest
+        @EnumSource(value = ApplicationStatus.class, names = {"PREPARING", "WRITING"})
+        @DisplayName("PREPARING, WRITING은 apply 이벤트가 필요하다")
+        void returnsTrueForPreparingAndWriting(ApplicationStatus status) {
+            assertThat(status.needsApplyEvent()).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = ApplicationStatus.class, names = {"SUBMITTED", "WAITING", "INTERVIEW", "FINAL"})
+        @DisplayName("그 외 상태는 apply 이벤트가 필요하지 않다")
+        void returnsFalseForOtherStatuses(ApplicationStatus status) {
+            assertThat(status.needsApplyEvent()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("needsInterviewEvent")
+    class NeedsInterviewEvent {
+
+        @ParameterizedTest
+        @EnumSource(value = ApplicationStatus.class, names = {"SUBMITTED", "WAITING", "INTERVIEW"})
+        @DisplayName("SUBMITTED, WAITING, INTERVIEW는 interview 이벤트가 필요하다")
+        void returnsTrueForInterviewStatuses(ApplicationStatus status) {
+            assertThat(status.needsInterviewEvent()).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = ApplicationStatus.class, names = {"PREPARING", "WRITING", "FINAL"})
+        @DisplayName("그 외 상태는 interview 이벤트가 필요하지 않다")
+        void returnsFalseForOtherStatuses(ApplicationStatus status) {
+            assertThat(status.needsInterviewEvent()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("needsDeadlineEvent")
+    class NeedsDeadlineEvent {
+
+        @Test
+        @DisplayName("FINAL만 deadline 이벤트가 필요하다")
+        void returnsTrueOnlyForFinal() {
+            assertThat(ApplicationStatus.FINAL.needsDeadlineEvent()).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = ApplicationStatus.class, names = {"PREPARING", "WRITING", "SUBMITTED", "WAITING", "INTERVIEW"})
+        @DisplayName("FINAL 외 상태는 deadline 이벤트가 필요하지 않다")
+        void returnsFalseForNonFinalStatuses(ApplicationStatus status) {
+            assertThat(status.needsDeadlineEvent()).isFalse();
+        }
+    }
+}

--- a/src/test/java/back/pickd/application/service/ApplicationServiceTest.java
+++ b/src/test/java/back/pickd/application/service/ApplicationServiceTest.java
@@ -1,0 +1,274 @@
+package back.pickd.application.service;
+
+import back.pickd.application.dto.request.ApplicationRequest;
+import back.pickd.application.dto.response.ApplicationResponse;
+import back.pickd.application.entity.Application;
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.application.repository.ApplicationRepository;
+import back.pickd.calendar.service.CalendarAsyncService;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ApplicationService 단위 테스트")
+class ApplicationServiceTest {
+
+    @Mock ApplicationRepository applicationRepository;
+    @Mock CalendarAsyncService calendarAsyncService;
+    @Mock UserService userService;
+    @Mock Authentication authentication;
+
+    @InjectMocks ApplicationService applicationService;
+
+    User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("test@test.com")
+                .name("테스트유저")
+                .build();
+        when(authentication.getName()).thenReturn("test@test.com");
+        when(userService.findByEmail("test@test.com")).thenReturn(user);
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+    private Application buildApp(Long id, ApplicationStatus status) {
+        return Application.builder()
+                .user(user)
+                .company("카카오")
+                .jobTitle("백엔드 개발")
+                .status(status)
+                .important(false)
+                .build();
+    }
+
+    private ApplicationRequest buildRequest(ApplicationStatus status) {
+        ApplicationRequest req = new ApplicationRequest();
+        req.setCompany("카카오");
+        req.setJobTitle("백엔드 개발");
+        req.setStatus(status);
+        req.setImportant(false);
+        return req;
+    }
+
+    // ── getApplications ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getApplications")
+    class GetApplications {
+
+        @Test
+        @DisplayName("현재 사용자 공고 목록을 최신순으로 반환한다")
+        void returnsUserApplicationsOrderedByIdDesc() {
+            Application app1 = buildApp(1L, ApplicationStatus.PREPARING);
+            Application app2 = buildApp(2L, ApplicationStatus.SUBMITTED);
+            when(applicationRepository.findAllByUserOrderByIdDesc(user)).thenReturn(List.of(app2, app1));
+
+            List<ApplicationResponse> result = applicationService.getApplications(authentication);
+
+            assertThat(result).hasSize(2);
+            verify(applicationRepository).findAllByUserOrderByIdDesc(user);
+        }
+
+        @Test
+        @DisplayName("공고가 없으면 빈 리스트를 반환한다")
+        void returnsEmptyListWhenNoApplications() {
+            when(applicationRepository.findAllByUserOrderByIdDesc(user)).thenReturn(List.of());
+
+            List<ApplicationResponse> result = applicationService.getApplications(authentication);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ── addApplication ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("addApplication")
+    class AddApplication {
+
+        @Test
+        @DisplayName("PREPARING 상태이고 applyDate가 있으면 apply 캘린더 이벤트를 생성한다")
+        void createsApplyCalendarEventForPreparingStatus() throws Exception {
+            ApplicationRequest req = buildRequest(ApplicationStatus.PREPARING);
+            req.setApplyDate(LocalDateTime.now().plusDays(3));
+            when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            applicationService.addApplication(req, authentication);
+
+            verify(calendarAsyncService).createEventAsync(any(), eq("apply"), eq(authentication), any());
+            verify(calendarAsyncService, never()).createEventAsync(any(), eq("interview"), any(), any());
+            verify(calendarAsyncService, never()).createEventAsync(any(), eq("deadline"), any(), any());
+        }
+
+        @Test
+        @DisplayName("SUBMITTED 상태이고 interviewDate가 있으면 interview 캘린더 이벤트를 생성한다")
+        void createsInterviewCalendarEventForSubmittedStatus() throws Exception {
+            ApplicationRequest req = buildRequest(ApplicationStatus.SUBMITTED);
+            req.setInterviewDate(LocalDateTime.now().plusDays(7));
+            when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            applicationService.addApplication(req, authentication);
+
+            verify(calendarAsyncService).createEventAsync(any(), eq("interview"), eq(authentication), any());
+            verify(calendarAsyncService, never()).createEventAsync(any(), eq("apply"), any(), any());
+        }
+
+        @Test
+        @DisplayName("FINAL 상태이고 deadlineDate가 있으면 deadline 캘린더 이벤트를 생성한다")
+        void createsDeadlineCalendarEventForFinalStatus() throws Exception {
+            ApplicationRequest req = buildRequest(ApplicationStatus.FINAL);
+            req.setDeadlineDate(LocalDateTime.now().plusDays(14));
+            when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            applicationService.addApplication(req, authentication);
+
+            verify(calendarAsyncService).createEventAsync(any(), eq("deadline"), eq(authentication), any());
+        }
+
+        @Test
+        @DisplayName("날짜가 null이면 캘린더 이벤트를 생성하지 않는다")
+        void doesNotCreateCalendarEventWhenDateIsNull() throws Exception {
+            ApplicationRequest req = buildRequest(ApplicationStatus.PREPARING);
+            // applyDate = null
+            when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            applicationService.addApplication(req, authentication);
+
+            verify(calendarAsyncService, never()).createEventAsync(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("Application 저장 시 User가 설정된다")
+        void savesApplicationWithUser() throws Exception {
+            ApplicationRequest req = buildRequest(ApplicationStatus.WRITING);
+            ArgumentCaptor<Application> captor = ArgumentCaptor.forClass(Application.class);
+            when(applicationRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            applicationService.addApplication(req, authentication);
+
+            assertThat(captor.getValue().getUser()).isEqualTo(user);
+            assertThat(captor.getValue().getCompany()).isEqualTo("카카오");
+        }
+    }
+
+    // ── deleteApplication ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("deleteApplication")
+    class DeleteApplication {
+
+        @Test
+        @DisplayName("소유자가 맞으면 Application을 삭제한다")
+        void deletesApplicationWhenOwnerMatches() throws Exception {
+            Application app = buildApp(1L, ApplicationStatus.PREPARING);
+            when(applicationRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(app));
+
+            applicationService.deleteApplication(1L, authentication);
+
+            verify(applicationRepository).delete(app);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 Application 삭제 시 예외가 발생한다")
+        void throwsWhenDeletingOtherUsersApplication() {
+            when(applicationRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> applicationService.deleteApplication(99L, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("지원 공고를 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("applyEventId가 있으면 캘린더 이벤트를 삭제한다")
+        void deletesCalendarEventWhenApplyEventIdExists() throws Exception {
+            Application app = Application.builder()
+                    .user(user)
+                    .company("카카오")
+                    .jobTitle("백엔드")
+                    .status(ApplicationStatus.PREPARING)
+                    .important(false)
+                    .build();
+            app.assignApplyEventId("apply-event-id-123");
+            when(applicationRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(app));
+
+            applicationService.deleteApplication(1L, authentication);
+
+            verify(calendarAsyncService).deleteEventAsync(authentication, "apply-event-id-123");
+            verify(applicationRepository).delete(app);
+        }
+
+        @Test
+        @DisplayName("캘린더 이벤트가 없으면 캘린더 삭제를 호출하지 않는다")
+        void doesNotDeleteCalendarEventWhenNoEventIds() throws Exception {
+            Application app = buildApp(1L, ApplicationStatus.WRITING);
+            when(applicationRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(app));
+
+            applicationService.deleteApplication(1L, authentication);
+
+            verify(calendarAsyncService, never()).deleteEventAsync(any(), any());
+        }
+    }
+
+    // ── updateApplication ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("updateApplication")
+    class UpdateApplication {
+
+        @Test
+        @DisplayName("다른 사용자의 Application 수정 시 예외가 발생한다")
+        void throwsWhenUpdatingOtherUsersApplication() {
+            when(applicationRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+            ApplicationRequest req = buildRequest(ApplicationStatus.WRITING);
+
+            assertThatThrownBy(() -> applicationService.updateApplication(99L, authentication, req))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("지원 공고를 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("상태가 바뀌어 캘린더 이벤트가 필요 없어지면 기존 이벤트를 삭제한다")
+        void deletesCalendarEventWhenStatusNoLongerNeedsIt() throws Exception {
+            Application app = Application.builder()
+                    .user(user)
+                    .company("카카오")
+                    .jobTitle("백엔드")
+                    .status(ApplicationStatus.PREPARING)
+                    .important(false)
+                    .build();
+            app.assignApplyEventId("old-event-id");
+            when(applicationRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(app));
+
+            // FINAL 상태로 변경 → needsApplyEvent() = false
+            ApplicationRequest req = buildRequest(ApplicationStatus.FINAL);
+            req.setDeadlineDate(LocalDateTime.now().plusDays(7));
+            when(applicationRepository.save(any())).thenReturn(app);
+
+            applicationService.updateApplication(1L, authentication, req);
+
+            verify(calendarAsyncService).deleteEventAsync(authentication, "old-event-id");
+        }
+    }
+}

--- a/src/test/java/back/pickd/application/service/TodoServiceTest.java
+++ b/src/test/java/back/pickd/application/service/TodoServiceTest.java
@@ -1,0 +1,287 @@
+package back.pickd.application.service;
+
+import back.pickd.application.dto.request.TodoRequest;
+import back.pickd.application.dto.response.TodoResponse;
+import back.pickd.application.entity.Application;
+import back.pickd.application.entity.Todo;
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.application.repository.ApplicationRepository;
+import back.pickd.application.repository.TodoRepository;
+import back.pickd.calendar.service.CalendarAsyncService;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TodoService 단위 테스트")
+class TodoServiceTest {
+
+    @Mock TodoRepository todoRepository;
+    @Mock ApplicationRepository applicationRepository;
+    @Mock CalendarAsyncService calendarAsyncService;
+    @Mock UserService userService;
+    @Mock Authentication authentication;
+
+    @InjectMocks TodoService todoService;
+
+    User user;
+    Application application;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().email("test@test.com").name("테스터").build();
+        application = Application.builder()
+                .user(user).company("카카오").jobTitle("백엔드")
+                .status(ApplicationStatus.WRITING).important(false).build();
+
+        when(authentication.getName()).thenReturn("test@test.com");
+        when(userService.findByEmail("test@test.com")).thenReturn(user);
+    }
+
+    private Todo buildTodo(boolean withCalendarEvent) {
+        Todo todo = Todo.builder()
+                .user(user)
+                .application(application)
+                .title("자소서 작성")
+                .memo("1번 문항")
+                .build();
+        if (withCalendarEvent) {
+            todo.assignCalendarEventId("event-id-abc");
+        }
+        return todo;
+    }
+
+    // ── addTodo ────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("addTodo")
+    class AddTodo {
+
+        @Test
+        @DisplayName("applicationId 없이 독립 Todo를 생성할 수 있다")
+        void createsStandaloneTodo() {
+            TodoRequest req = new TodoRequest();
+            req.setTitle("독립 할 일");
+            // applicationId = null
+            when(todoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            TodoResponse response = todoService.addTodo(req, authentication);
+
+            ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+            verify(todoRepository).save(captor.capture());
+            assertThat(captor.getValue().getApplication()).isNull();
+            assertThat(captor.getValue().getUser()).isEqualTo(user);
+        }
+
+        @Test
+        @DisplayName("applicationId가 있으면 Application 소유권을 검증한 후 Todo를 생성한다")
+        void createsTodoLinkedToApplication() {
+            TodoRequest req = new TodoRequest();
+            req.setTitle("공고 연결 할 일");
+            req.setApplicationId(1L);
+            when(applicationRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(application));
+            when(todoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            todoService.addTodo(req, authentication);
+
+            ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+            verify(todoRepository).save(captor.capture());
+            assertThat(captor.getValue().getApplication()).isEqualTo(application);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 Application에 Todo 생성 시 예외가 발생한다")
+        void throwsWhenApplicationNotOwned() {
+            TodoRequest req = new TodoRequest();
+            req.setTitle("할 일");
+            req.setApplicationId(99L);
+            when(applicationRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> todoService.addTodo(req, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("지원 공고를 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("dueDateTime이 있으면 캘린더 이벤트를 생성한다")
+        void createsCalendarEventWhenDueDateTimeExists() {
+            TodoRequest req = new TodoRequest();
+            req.setTitle("마감 있는 할 일");
+            req.setDueDateTime("2026-12-01T09:00:00");
+            when(todoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            todoService.addTodo(req, authentication);
+
+            verify(calendarAsyncService).createTodoEventAsync(any(), eq(authentication));
+        }
+
+        @Test
+        @DisplayName("dueDateTime이 없으면 캘린더 이벤트를 생성하지 않는다")
+        void doesNotCreateCalendarEventWhenNoDueDateTime() {
+            TodoRequest req = new TodoRequest();
+            req.setTitle("마감 없는 할 일");
+            when(todoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            todoService.addTodo(req, authentication);
+
+            verify(calendarAsyncService, never()).createTodoEventAsync(any(), any());
+        }
+
+        @Test
+        @DisplayName("ISO offset 형식의 dueDateTime도 파싱된다")
+        void parsesOffsetDateTimeFormat() {
+            TodoRequest req = new TodoRequest();
+            req.setTitle("오프셋 날짜 할 일");
+            req.setDueDateTime("2026-12-01T09:00:00+09:00");
+            when(todoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            assertThatCode(() -> todoService.addTodo(req, authentication))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    // ── getTodos ───────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getTodos")
+    class GetTodos {
+
+        @Test
+        @DisplayName("사용자의 전체 Todo 목록을 반환한다")
+        void returnsAllTodosForUser() {
+            when(todoRepository.findAllByUserWithApplication(user))
+                    .thenReturn(List.of(buildTodo(false), buildTodo(false)));
+
+            List<TodoResponse> result = todoService.getTodos(authentication);
+
+            assertThat(result).hasSize(2);
+            verify(todoRepository).findAllByUserWithApplication(user);
+        }
+    }
+
+    // ── getTodosByApplication ──────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getTodosByApplication")
+    class GetTodosByApplication {
+
+        @Test
+        @DisplayName("특정 공고에 속한 Todo 목록을 반환한다")
+        void returnsTodosForApplication() {
+            when(todoRepository.findByApplicationIdAndUser(1L, user))
+                    .thenReturn(List.of(buildTodo(false)));
+
+            List<TodoResponse> result = todoService.getTodosByApplication(1L, authentication);
+
+            assertThat(result).hasSize(1);
+            verify(todoRepository).findByApplicationIdAndUser(1L, user);
+        }
+    }
+
+    // ── toggleTodo ─────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("toggleTodo")
+    class ToggleTodo {
+
+        @Test
+        @DisplayName("completed가 false인 Todo를 toggle하면 true가 된다")
+        void togglesCompletedFromFalseToTrue() {
+            Todo todo = buildTodo(false);
+            assertThat(todo.isCompleted()).isFalse();
+            when(todoRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(todo));
+
+            todoService.toggleTodo(1L, authentication);
+
+            assertThat(todo.isCompleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("completed가 true인 Todo를 toggle하면 false가 된다")
+        void togglesCompletedFromTrueToFalse() {
+            Todo todo = buildTodo(false);
+            todo.toggleCompleted(); // true로 만들기
+            when(todoRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(todo));
+
+            todoService.toggleTodo(1L, authentication);
+
+            assertThat(todo.isCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 Todo toggle 시 예외가 발생한다")
+        void throwsWhenTogglingOtherUsersTodo() {
+            when(todoRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> todoService.toggleTodo(99L, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("할 일을 찾을 수 없습니다");
+        }
+    }
+
+    // ── deleteTodo ─────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("deleteTodo")
+    class DeleteTodo {
+
+        @Test
+        @DisplayName("소유자가 맞으면 Todo를 삭제한다")
+        void deletesTodoForOwner() {
+            Todo todo = buildTodo(false);
+            when(todoRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(todo));
+
+            todoService.deleteTodo(1L, authentication);
+
+            verify(todoRepository).delete(todo);
+        }
+
+        @Test
+        @DisplayName("calendarEventId가 있으면 캘린더 이벤트를 삭제한다")
+        void deletesCalendarEventWhenEventIdExists() {
+            Todo todo = buildTodo(true); // calendarEventId = "event-id-abc"
+            when(todoRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(todo));
+
+            todoService.deleteTodo(1L, authentication);
+
+            verify(calendarAsyncService).deleteEventAsync(authentication, "event-id-abc");
+        }
+
+        @Test
+        @DisplayName("calendarEventId가 없으면 캘린더 삭제를 호출하지 않는다")
+        void doesNotDeleteCalendarEventWhenNoEventId() {
+            Todo todo = buildTodo(false);
+            when(todoRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(todo));
+
+            todoService.deleteTodo(1L, authentication);
+
+            verify(calendarAsyncService, never()).deleteEventAsync(any(), any());
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 Todo 삭제 시 예외가 발생한다")
+        void throwsWhenDeletingOtherUsersTodo() {
+            when(todoRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> todoService.deleteTodo(99L, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("할 일을 찾을 수 없습니다");
+        }
+    }
+}

--- a/src/test/java/back/pickd/coverletter/service/CoverLetterItemServiceTest.java
+++ b/src/test/java/back/pickd/coverletter/service/CoverLetterItemServiceTest.java
@@ -1,0 +1,286 @@
+package back.pickd.coverletter.service;
+
+import back.pickd.application.entity.Application;
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.application.repository.ApplicationRepository;
+import back.pickd.coverletter.dto.request.CoverLetterItemRequest;
+import back.pickd.coverletter.dto.response.CoverLetterItemResponse;
+import back.pickd.coverletter.entity.CoverLetterItem;
+import back.pickd.coverletter.repository.CoverLetterItemRepository;
+import back.pickd.notice.enums.JobCategory;
+import back.pickd.notice.notice.Notice;
+import back.pickd.notice.notice.NoticeRepository;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CoverLetterItemService 단위 테스트")
+class CoverLetterItemServiceTest {
+
+    @Mock CoverLetterItemRepository coverLetterItemRepository;
+    @Mock NoticeRepository noticeRepository;
+    @Mock ApplicationRepository applicationRepository;
+    @Mock UserService userService;
+    @Mock Authentication authentication;
+
+    @InjectMocks CoverLetterItemService coverLetterItemService;
+
+    User user;
+    Notice notice;
+    Application application;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().email("test@test.com").name("테스터").build();
+
+        notice = Notice.builder()
+                .user(user)
+                .companyName("카카오")
+                .noticeName("2026 상반기 공채")
+                .category(JobCategory.BACKEND)
+                .startedAt("2026-01-01")
+                .build();
+
+        application = Application.builder()
+                .user(user).company("카카오").jobTitle("백엔드")
+                .status(ApplicationStatus.WRITING).important(false).build();
+
+        when(authentication.getName()).thenReturn("test@test.com");
+        when(userService.findByEmail("test@test.com")).thenReturn(user);
+    }
+
+    private CoverLetterItem buildItem(Notice n, Application app) {
+        return CoverLetterItem.builder()
+                .user(user)
+                .notice(n)
+                .application(app)
+                .question("지원 동기를 서술하세요.")
+                .answer("저는...")
+                .maxLength(500)
+                .orderIndex(0)
+                .build();
+    }
+
+    private CoverLetterItemRequest buildRequest(Long noticeId, Long appId) {
+        return new CoverLetterItemRequest("지원 동기를 서술하세요.", "저는...", 500, 0, noticeId, appId);
+    }
+
+    // ── getByNotice ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getByNotice")
+    class GetByNotice {
+
+        @Test
+        @DisplayName("공고 ID로 자소서 문항 목록을 orderIndex 오름차순으로 반환한다")
+        void returnsItemsOrderedByIndex() {
+            when(coverLetterItemRepository.findAllByNoticeIdAndUserOrderByOrderIndexAsc(1L, user))
+                    .thenReturn(List.of(buildItem(notice, null)));
+
+            List<CoverLetterItemResponse> result = coverLetterItemService.getByNotice(1L, authentication);
+
+            assertThat(result).hasSize(1);
+            verify(coverLetterItemRepository).findAllByNoticeIdAndUserOrderByOrderIndexAsc(1L, user);
+        }
+
+        @Test
+        @DisplayName("문항이 없으면 빈 리스트를 반환한다")
+        void returnsEmptyListWhenNoItems() {
+            when(coverLetterItemRepository.findAllByNoticeIdAndUserOrderByOrderIndexAsc(1L, user))
+                    .thenReturn(List.of());
+
+            List<CoverLetterItemResponse> result = coverLetterItemService.getByNotice(1L, authentication);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ── getByApplication ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getByApplication")
+    class GetByApplication {
+
+        @Test
+        @DisplayName("지원 공고 ID로 자소서 문항 목록을 반환한다")
+        void returnsItemsByApplicationId() {
+            when(coverLetterItemRepository.findAllByApplicationIdAndUserOrderByOrderIndexAsc(1L, user))
+                    .thenReturn(List.of(buildItem(null, application)));
+
+            List<CoverLetterItemResponse> result = coverLetterItemService.getByApplication(1L, authentication);
+
+            assertThat(result).hasSize(1);
+        }
+    }
+
+    // ── create ─────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("noticeId로 Notice에 연결된 문항을 생성한다")
+        void createsItemLinkedToNotice() {
+            when(noticeRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(notice));
+            ArgumentCaptor<CoverLetterItem> captor = ArgumentCaptor.forClass(CoverLetterItem.class);
+            when(coverLetterItemRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            coverLetterItemService.create(buildRequest(1L, null), authentication);
+
+            CoverLetterItem saved = captor.getValue();
+            assertThat(saved.getNotice()).isEqualTo(notice);
+            assertThat(saved.getApplication()).isNull();
+            assertThat(saved.getUser()).isEqualTo(user);
+            assertThat(saved.getQuestion()).isEqualTo("지원 동기를 서술하세요.");
+        }
+
+        @Test
+        @DisplayName("applicationId로 Application에 연결된 문항을 생성한다")
+        void createsItemLinkedToApplication() {
+            when(applicationRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(application));
+            ArgumentCaptor<CoverLetterItem> captor = ArgumentCaptor.forClass(CoverLetterItem.class);
+            when(coverLetterItemRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            coverLetterItemService.create(buildRequest(null, 1L), authentication);
+
+            CoverLetterItem saved = captor.getValue();
+            assertThat(saved.getApplication()).isEqualTo(application);
+            assertThat(saved.getNotice()).isNull();
+        }
+
+        @Test
+        @DisplayName("noticeId와 applicationId가 모두 null이면 예외가 발생한다")
+        void throwsWhenBothIdsAreNull() {
+            assertThatThrownBy(() -> coverLetterItemService.create(buildRequest(null, null), authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("noticeId 또는 applicationId 중 하나는 필수입니다");
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 Notice에 문항 생성 시 예외가 발생한다")
+        void throwsWhenNoticeNotOwnedByUser() {
+            when(noticeRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> coverLetterItemService.create(buildRequest(99L, null), authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("공고를 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 Application에 문항 생성 시 예외가 발생한다")
+        void throwsWhenApplicationNotOwnedByUser() {
+            when(applicationRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> coverLetterItemService.create(buildRequest(null, 99L), authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("지원 공고를 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("orderIndex가 null이면 0으로 저장된다")
+        void savesOrderIndexAsZeroWhenNull() {
+            // orderIndex = null 로 생성
+            CoverLetterItemRequest req = new CoverLetterItemRequest("지원 동기를 서술하세요.", "저는...", 500, null, 1L, null);
+            when(noticeRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(notice));
+            ArgumentCaptor<CoverLetterItem> captor = ArgumentCaptor.forClass(CoverLetterItem.class);
+            when(coverLetterItemRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            coverLetterItemService.create(req, authentication);
+
+            assertThat(captor.getValue().getOrderIndex()).isEqualTo(0);
+        }
+    }
+
+    // ── update ─────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        @DisplayName("소유자가 맞으면 문항 내용을 수정한다")
+        void updatesItemContent() {
+            CoverLetterItem item = buildItem(notice, null);
+            when(coverLetterItemRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(item));
+
+            CoverLetterItemRequest req = new CoverLetterItemRequest("수정된 문항", "수정된 답변", 1000, 2, null, null);
+
+            coverLetterItemService.update(1L, req, authentication);
+
+            assertThat(item.getQuestion()).isEqualTo("수정된 문항");
+            assertThat(item.getAnswer()).isEqualTo("수정된 답변");
+            assertThat(item.getMaxLength()).isEqualTo(1000);
+            assertThat(item.getOrderIndex()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 문항 수정 시 예외가 발생한다")
+        void throwsWhenUpdatingOtherUsersItem() {
+            when(coverLetterItemRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> coverLetterItemService.update(99L, buildRequest(null, null), authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("자소서 문항을 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("update 시 orderIndex가 null이면 기존 값을 유지한다")
+        void keepsExistingOrderIndexWhenUpdateOrderIndexIsNull() {
+            CoverLetterItem item = buildItem(notice, null);
+            // item.orderIndex = 0 (빌더 기본값)
+            when(coverLetterItemRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(item));
+
+            CoverLetterItemRequest req = new CoverLetterItemRequest("지원 동기를 서술하세요.", "저는...", 500, null, null, null);
+
+            coverLetterItemService.update(1L, req, authentication);
+
+            assertThat(item.getOrderIndex()).isEqualTo(0);
+        }
+    }
+
+    // ── delete ─────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("delete")
+    class Delete {
+
+        @Test
+        @DisplayName("소유자가 맞으면 문항을 삭제한다")
+        void deletesItemForOwner() {
+            CoverLetterItem item = buildItem(notice, null);
+            when(coverLetterItemRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(item));
+
+            coverLetterItemService.delete(1L, authentication);
+
+            verify(coverLetterItemRepository).delete(item);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 문항 삭제 시 예외가 발생한다")
+        void throwsWhenDeletingOtherUsersItem() {
+            when(coverLetterItemRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> coverLetterItemService.delete(99L, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("자소서 문항을 찾을 수 없습니다");
+        }
+    }
+}

--- a/src/test/java/back/pickd/coverletter/service/CoverLetterItemServiceTest.java
+++ b/src/test/java/back/pickd/coverletter/service/CoverLetterItemServiceTest.java
@@ -54,7 +54,7 @@ class CoverLetterItemServiceTest {
                 .user(user)
                 .companyName("카카오")
                 .noticeName("2026 상반기 공채")
-                .category(JobCategory.BACKEND)
+                .category(JobCategory.FULL_TIME)
                 .startedAt("2026-01-01")
                 .build();
 

--- a/src/test/java/back/pickd/document/service/DocumentServiceTest.java
+++ b/src/test/java/back/pickd/document/service/DocumentServiceTest.java
@@ -1,0 +1,228 @@
+package back.pickd.document.service;
+
+import back.pickd.application.entity.Application;
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.application.repository.ApplicationRepository;
+import back.pickd.document.dto.DocumentRequest;
+import back.pickd.document.entity.Document;
+import back.pickd.document.enums.DocumentStatus;
+import back.pickd.document.enums.DocumentType;
+import back.pickd.document.repository.DocumentRepository;
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DocumentService 단위 테스트")
+class DocumentServiceTest {
+
+    @Mock DocumentRepository documentRepository;
+    @Mock ApplicationRepository applicationRepository;
+    @Mock UserService userService;
+    @Mock Authentication authentication;
+
+    @InjectMocks DocumentService documentService;
+
+    User user;
+    Application application;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().email("test@test.com").name("테스터").build();
+        application = Application.builder()
+                .user(user).company("카카오").jobTitle("백엔드")
+                .status(ApplicationStatus.WRITING).important(false).build();
+
+        when(authentication.getName()).thenReturn("test@test.com");
+        when(userService.findByEmail("test@test.com")).thenReturn(user);
+    }
+
+    private DocumentRequest buildRequest() {
+        DocumentRequest req = new DocumentRequest();
+        req.setTitle("자기소개서");
+        req.setCompany("카카오");
+        req.setType(DocumentType.COVER_LETTER);
+        req.setStatus(DocumentStatus.DRAFT);
+        req.setProgress(30);
+        req.setContent("내용...");
+        return req;
+    }
+
+    private Document buildDocument() {
+        return Document.builder()
+                .user(user)
+                .application(application)
+                .title("자기소개서")
+                .company("카카오")
+                .type(DocumentType.COVER_LETTER)
+                .status(DocumentStatus.DRAFT)
+                .progress(30)
+                .content("내용...")
+                .build();
+    }
+
+    // ── getAllDocuments ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getAllDocuments")
+    class GetAllDocuments {
+
+        @Test
+        @DisplayName("사용자의 전체 서류를 최신순으로 반환한다")
+        void returnsAllDocumentsForUser() {
+            Document doc1 = buildDocument();
+            Document doc2 = buildDocument();
+            when(documentRepository.findAllByUserOrderByIdDesc(user)).thenReturn(List.of(doc2, doc1));
+
+            List<Document> result = documentService.getAllDocuments(authentication);
+
+            assertThat(result).hasSize(2);
+            verify(documentRepository).findAllByUserOrderByIdDesc(user);
+        }
+    }
+
+    // ── getDocuments (by applicationId) ───────────────────────────────────────
+
+    @Nested
+    @DisplayName("getDocuments")
+    class GetDocuments {
+
+        @Test
+        @DisplayName("특정 공고에 속한 서류 목록을 반환한다")
+        void returnsDocumentsByApplicationId() {
+            when(documentRepository.findAllByApplicationIdAndUser(1L, user))
+                    .thenReturn(List.of(buildDocument()));
+
+            List<Document> result = documentService.getDocuments(1L, authentication);
+
+            assertThat(result).hasSize(1);
+            verify(documentRepository).findAllByApplicationIdAndUser(1L, user);
+        }
+    }
+
+    // ── addDocument ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("addDocument")
+    class AddDocument {
+
+        @Test
+        @DisplayName("소유권 검증 후 서류를 저장한다")
+        void savesDocumentAfterOwnershipCheck() {
+            when(applicationRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(application));
+            ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+            when(documentRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            documentService.addDocument(1L, buildRequest(), authentication);
+
+            Document saved = captor.getValue();
+            assertThat(saved.getUser()).isEqualTo(user);
+            assertThat(saved.getApplication()).isEqualTo(application);
+            assertThat(saved.getType()).isEqualTo(DocumentType.COVER_LETTER);
+        }
+
+        @Test
+        @DisplayName("progress가 null이면 0으로 저장된다")
+        void savesProgressAsZeroWhenNull() {
+            DocumentRequest req = buildRequest();
+            req.setProgress(null);
+            when(applicationRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(application));
+            ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+            when(documentRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            documentService.addDocument(1L, req, authentication);
+
+            assertThat(captor.getValue().getProgress()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 Application에 서류 추가 시 예외가 발생한다")
+        void throwsWhenApplicationNotOwnedByUser() {
+            when(applicationRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> documentService.addDocument(99L, buildRequest(), authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("지원 공고를 찾을 수 없습니다");
+        }
+    }
+
+    // ── updateDocument ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("updateDocument")
+    class UpdateDocument {
+
+        @Test
+        @DisplayName("소유자가 맞으면 서류 내용을 수정한다")
+        void updatesDocumentContent() {
+            Document doc = buildDocument();
+            when(documentRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(doc));
+            when(documentRepository.save(doc)).thenReturn(doc);
+
+            DocumentRequest req = buildRequest();
+            req.setTitle("수정된 자소서");
+            req.setStatus(DocumentStatus.COMPLETED);
+            req.setProgress(100);
+
+            documentService.updateDocument(1L, req, authentication);
+
+            assertThat(doc.getTitle()).isEqualTo("수정된 자소서");
+            assertThat(doc.getStatus()).isEqualTo(DocumentStatus.COMPLETED);
+            assertThat(doc.getProgress()).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 서류 수정 시 예외가 발생한다")
+        void throwsWhenUpdatingOtherUsersDocument() {
+            when(documentRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> documentService.updateDocument(99L, buildRequest(), authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("서류를 찾을 수 없습니다");
+        }
+    }
+
+    // ── deleteDocument ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("deleteDocument")
+    class DeleteDocument {
+
+        @Test
+        @DisplayName("소유자가 맞으면 서류를 삭제한다")
+        void deletesDocumentForOwner() {
+            Document doc = buildDocument();
+            when(documentRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(doc));
+
+            documentService.deleteDocument(1L, authentication);
+
+            verify(documentRepository).delete(doc);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 서류 삭제 시 예외가 발생한다")
+        void throwsWhenDeletingOtherUsersDocument() {
+            when(documentRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> documentService.deleteDocument(99L, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("서류를 찾을 수 없습니다");
+        }
+    }
+}

--- a/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestControllerIntegrationTest.java
+++ b/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestControllerIntegrationTest.java
@@ -1,0 +1,238 @@
+package back.pickd.experience.controller;
+
+import back.pickd.auth.jwt.JwtTokenProvider;
+import back.pickd.experience.entity.ExperienceDuplicateGroup;
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.ExperienceTemp;
+import back.pickd.experience.entity.UserExperience;
+import back.pickd.experience.dto.ExperienceExtractionTestDto.PresetDefinition;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.Status;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.ExperienceTempRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.entity.User;
+import back.pickd.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+class ExperienceExtractionTestControllerIntegrationTest {
+
+    private static final String OWNER_EMAIL = "test-owner@example.com";
+    private static final String OTHER_EMAIL = "test-other@example.com";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserExperienceRepository experienceRepository;
+
+    @Autowired
+    private ExperienceTempRepository tempRepository;
+
+    @Autowired
+    private ExperienceExtractionBatchRepository batchRepository;
+
+    @MockitoBean
+    private S3Service s3Service;
+
+    @MockitoBean
+    private AiClient aiClient;
+
+    private User owner;
+    private User other;
+
+    @BeforeEach
+    void setUp() {
+        clearDatabase();
+        owner = userRepository.save(User.builder()
+                .email(OWNER_EMAIL)
+                .name("테스트 소유자")
+                .build());
+        other = userRepository.save(User.builder()
+                .email(OTHER_EMAIL)
+                .name("다른 사용자")
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    @Test
+    void localPageIsPublicAndProvidesAllPresetDefinitions() throws Exception {
+        MvcResult result = mockMvc.perform(get("/experience-extraction-test"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("experience-extraction-test"))
+                .andExpect(model().attribute("authenticated", false))
+                .andExpect(model().attribute("presetDefinitions", hasSize(13)))
+                .andExpect(content().string(
+                        org.hamcrest.Matchers.containsString("project_name")
+                ))
+                .andExpect(content().string(
+                        org.hamcrest.Matchers.containsString("미처리 중복 불러오기")
+                ))
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<PresetDefinition> presets = (List<PresetDefinition>) result
+                .getModelAndView()
+                .getModel()
+                .get("presetDefinitions");
+        PresetDefinition research = presets.stream()
+                .filter(preset -> "RESEARCH".equals(preset.type()))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("학부연구생", research.koreanName());
+        assertEquals("NARRATIVE", research.group());
+        assertTrue(research.fields().stream()
+                .anyMatch(field -> "lab_name".equals(field.key())));
+    }
+
+    @Test
+    void stateEndpointReturnsOnlyAuthenticatedUsersData() throws Exception {
+        UserExperience ownerExperience = experienceRepository.save(
+                experience(owner, "소유자 프로젝트")
+        );
+        experienceRepository.save(experience(other, "타 사용자 프로젝트"));
+        tempRepository.save(temp(owner, "소유자 Temp"));
+        tempRepository.save(temp(other, "타 사용자 Temp"));
+
+        ExperienceExtractionBatch ownerBatch =
+                new ExperienceExtractionBatch(owner);
+        ExperienceDuplicateGroup ownerGroup =
+                new ExperienceDuplicateGroup(ownerExperience);
+        ownerGroup.addDraft(draft("소유자 Draft"));
+        ownerBatch.addGroup(ownerGroup);
+        batchRepository.saveAndFlush(ownerBatch);
+
+        UserExperience otherExperience = experienceRepository.findByUserOrderByCreatedAtDesc(other)
+                .get(0);
+        ExperienceExtractionBatch otherBatch =
+                new ExperienceExtractionBatch(other);
+        ExperienceDuplicateGroup otherGroup =
+                new ExperienceDuplicateGroup(otherExperience);
+        otherGroup.addDraft(draft("타 사용자 Draft"));
+        otherBatch.addGroup(otherGroup);
+        batchRepository.saveAndFlush(otherBatch);
+
+        mockMvc.perform(get("/internal/experience-extraction-test/state")
+                        .cookie(accessToken(owner)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userEmail").value(OWNER_EMAIL))
+                .andExpect(jsonPath("$.experiences", hasSize(1)))
+                .andExpect(jsonPath("$.experiences[*].title",
+                        hasItem("소유자 프로젝트")))
+                .andExpect(jsonPath("$.temps", hasSize(1)))
+                .andExpect(jsonPath("$.temps[0].experienceName")
+                        .value("소유자 Temp"))
+                .andExpect(jsonPath("$.batches", hasSize(1)))
+                .andExpect(jsonPath("$.batches[0].duplicateGroups", hasSize(1)))
+                .andExpect(jsonPath(
+                        "$.batches[0].duplicateGroups[0].existingExperience.title"
+                ).value("소유자 프로젝트"))
+                .andExpect(jsonPath(
+                        "$.batches[0].duplicateGroups[0].drafts[0].title"
+                ).value("소유자 Draft"))
+                .andExpect(content().string(
+                        org.hamcrest.Matchers.not(
+                                org.hamcrest.Matchers.containsString("타 사용자")
+                        )
+                ));
+    }
+
+    private UserExperience experience(User user, String title) {
+        return UserExperience.builder()
+                .user(user)
+                .title(title)
+                .experienceType(ExperienceType.PROJECT)
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .status(Status.COMPLETED)
+                .documentContent(title + " 본문")
+                .attributes(Map.of("project_name", title))
+                .keywords(List.of("문제 해결"))
+                .build();
+    }
+
+    private ExperienceTemp temp(User user, String name) {
+        return ExperienceTemp.builder()
+                .user(user)
+                .experienceName(name)
+                .experienceGroup("상세 서술형")
+                .experienceType("프로젝트")
+                .resumeUrl("https://cdn.example.com/" + name + ".pdf")
+                .build();
+    }
+
+    private ExperienceExtractionDraft draft(String title) {
+        return ExperienceExtractionDraft.builder()
+                .title(title)
+                .experienceType(ExperienceType.PROJECT)
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .status(Status.COMPLETED)
+                .documentContent(title + " 본문")
+                .attributes(Map.of("project_name", title))
+                .keywords(List.of("협업"))
+                .resumeUrl("https://cdn.example.com/resume.pdf")
+                .similarity(0.91)
+                .build();
+    }
+
+    private Cookie accessToken(User user) {
+        String token = jwtTokenProvider.createToken(
+                user.getEmail(),
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        return new Cookie("accessToken", token);
+    }
+
+    private void clearDatabase() {
+        batchRepository.deleteAll();
+        batchRepository.flush();
+        tempRepository.deleteAll();
+        tempRepository.flush();
+        experienceRepository.deleteAll();
+        experienceRepository.flush();
+        userRepository.deleteAll();
+        userRepository.flush();
+    }
+}

--- a/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestProfileTest.java
+++ b/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestProfileTest.java
@@ -1,0 +1,38 @@
+package back.pickd.experience.controller;
+
+import back.pickd.experience.service.ExperienceExtractionTestService;
+import back.pickd.experience.support.PresetRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ExperienceExtractionTestProfileTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withBean(PresetRegistry.class)
+                    .withBean(ObjectMapper.class)
+                    .withBean(
+                            ExperienceExtractionTestService.class,
+                            () -> mock(ExperienceExtractionTestService.class)
+                    )
+                    .withUserConfiguration(TestConfiguration.class);
+
+    @Test
+    void controllerIsNotCreatedOutsideLocalProfile() {
+        contextRunner
+                .withPropertyValues("spring.profiles.active=prod")
+                .run(context -> assertThat(context)
+                        .doesNotHaveBean(ExperienceExtractionTestController.class));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Import(ExperienceExtractionTestController.class)
+    static class TestConfiguration {
+    }
+}

--- a/src/test/java/back/pickd/user/service/OnboardingServiceIntegrationTest.java
+++ b/src/test/java/back/pickd/user/service/OnboardingServiceIntegrationTest.java
@@ -1,0 +1,165 @@
+package back.pickd.user.service;
+
+import back.pickd.experience.entity.ExperienceDuplicateGroup;
+import back.pickd.experience.entity.ExperienceExtractionBatch;
+import back.pickd.experience.entity.ExperienceExtractionDraft;
+import back.pickd.experience.entity.ExperienceFile;
+import back.pickd.experience.entity.UserExperience;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.Status;
+import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
+import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.global.infra.ai.AiClient;
+import back.pickd.global.infra.s3.S3Service;
+import back.pickd.user.dto.onboarding.OnboardingRequest;
+import back.pickd.user.entity.User;
+import back.pickd.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@SpringBootTest
+class OnboardingServiceIntegrationTest {
+
+    @Autowired
+    private OnboardingService onboardingService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserExperienceRepository experienceRepository;
+
+    @Autowired
+    private ExperienceExtractionBatchRepository batchRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private S3Service s3Service;
+
+    @MockitoBean
+    private AiClient aiClient;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        clearDatabase();
+        user = userRepository.save(User.builder()
+                .email("onboarding@example.com")
+                .name("온보딩 사용자")
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    @Test
+    void replacingOnboardingExperiencesDeletesFilesAndPendingDraftsFirst()
+            throws Exception {
+        UserExperience existing = UserExperience.builder()
+                .user(user)
+                .title("기존 경험")
+                .experienceType(ExperienceType.PROJECT)
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .status(Status.COMPLETED)
+                .documentContent("기존 본문")
+                .attributes(Map.of("project_name", "기존 경험"))
+                .keywords(List.of("기존"))
+                .build();
+        existing.updateFiles(List.of(ExperienceFile.builder()
+                .originalFilename("resume.pdf")
+                .fileType("application/pdf")
+                .fileSize(100L)
+                .filePath("https://cdn.example.com/resume.pdf")
+                .source("RESUME_ORIGINAL")
+                .build()));
+        existing = experienceRepository.saveAndFlush(existing);
+
+        ExperienceExtractionBatch batch = new ExperienceExtractionBatch(user);
+        ExperienceDuplicateGroup group = new ExperienceDuplicateGroup(existing);
+        group.addDraft(ExperienceExtractionDraft.builder()
+                .title("중복 Draft")
+                .experienceType(ExperienceType.PROJECT)
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .status(Status.COMPLETED)
+                .documentContent("Draft 본문")
+                .attributes(Map.of("project_name", "중복 Draft"))
+                .keywords(List.of("중복"))
+                .resumeUrl("https://cdn.example.com/resume.pdf")
+                .similarity(0.92)
+                .build());
+        batch.addGroup(group);
+        batchRepository.saveAndFlush(batch);
+
+        String existingId = existing.getId();
+        OnboardingRequest request = objectMapper.readValue("""
+                {
+                  "targetPeriod": "2026 하반기",
+                  "currentStage": "서류 준비",
+                  "focusItems": ["자기소개서"],
+                  "hasResume": true,
+                  "hasBaseEssay": false,
+                  "hasPortfolio": false,
+                  "experiences": [
+                    {
+                      "type": "PROJECT",
+                      "title": "새 온보딩 경험",
+                      "startDate": "2026-01",
+                      "endDate": "2026-03"
+                    }
+                  ]
+                }
+                """, OnboardingRequest.class);
+
+        onboardingService.updateOnboarding(user.getEmail(), request);
+
+        assertFalse(experienceRepository.findById(existingId).isPresent());
+        assertEquals(0, count("experience_files"));
+        assertEquals(0, count("experience_extraction_batches"));
+        assertEquals(0, count("experience_duplicate_groups"));
+        assertEquals(0, count("experience_extraction_drafts"));
+        assertEquals(
+                List.of("새 온보딩 경험"),
+                experienceRepository.findByUserOrderByCreatedAtDesc(user).stream()
+                        .map(UserExperience::getTitle)
+                        .toList()
+        );
+    }
+
+    private int count(String tableName) {
+        Integer count = jdbcTemplate.queryForObject(
+                "select count(*) from " + tableName,
+                Integer.class
+        );
+        return count != null ? count : 0;
+    }
+
+    private void clearDatabase() {
+        batchRepository.deleteAll();
+        batchRepository.flush();
+        experienceRepository.deleteAll();
+        experienceRepository.flush();
+        userRepository.deleteAll();
+        userRepository.flush();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #59

## 작업 내용

### Application 도메인
- `Application` 엔티티 User FK 추가 (`nullable = false`)
- `ApplicationStatus` enum 도입 (String status 제거), `@JsonValue`/`@JsonCreator`로 Korean label 직렬화
- `findByIdAndUser` 소유권 검증, `findAllByUserOrderByIdDesc` 추가
- delete / update 소유권 검증 강화
- `createdAt` / `updatedAt` audit 필드 추가
- `@Setter` 제거, 도메인 메서드 도입 (`update`, `assignApplyEventId` 등)
- `ApplicationResponse` DTO 신규 추가 (엔티티 직접 노출 제거)
- Controller에서 Repository 직접 의존 제거

### Document 도메인
- `Document` 엔티티 User FK 추가 (`nullable = false`, application FK는 nullable 유지)
- `DocumentType` / `DocumentStatus` enum 도입
- `findByIdAndUser`, `findAllByApplicationIdAndUser`, `findAllByUserOrderByIdDesc` 추가
- delete / update 소유권 검증 강화
- addDocument 시 Application 소유권도 함께 검증
- `createdAt` / `updatedAt` audit 필드 추가, PUT(수정) 엔드포인트 신규 추가

### Notice 도메인
- `user_id` `nullable = false` 제약 추가
- `findByIdAndUser`, `findAllByUserOrderByIdDesc` 추가
- 미사용 필드 제거 (`opportunities`, `threats` — AI가 반환하지 않는 dead field)

### Todo 도메인
- `Todo` 엔티티 User FK 추가 (`nullable = false`)
- `createdAt` / `updatedAt` audit 필드 추가
- `@Setter` 제거, `toggleCompleted()` / `assignCalendarEventId()` 도메인 메서드 도입
- 전체 CRUD 소유권 검증 추가 (GET 포함)
- `findByApplicationIdAndUser`, `findByIdAndUser` 추가

### CoverLetterItem 도메인 (신규)
- `CoverLetterItem` 엔티티 추가 — Notice 또는 Application에 연결되는 자소서 문항
- `notice_id` / `application_id` nullable FK (둘 중 하나만 사용)
- User FK `nullable = false`, `createdAt` / `updatedAt` audit 필드
- `orderIndex` 문항 순서, `maxLength` 글자수 제한 지원
- Repository, Service, Controller 추가
- `GET /api/cover-letter?noticeId={id}` / `?applicationId={id}`
- `POST` / `PUT /{id}` / `DELETE /{id}`
- Notice, Application에 `coverLetterItems` @OneToMany 관계 추가

## 변경 공통 패턴
- 모든 엔티티에 User FK (`nullable = false`) 추가 → 소유권 기반 조회/수정/삭제
- String → Enum 교체로 타입 안전성 확보
- `@PrePersist` / `@PreUpdate` 기반 audit 필드 일관 적용
- `@Setter` 제거 후 도메인 메서드로 상태 변경 캡슐화