### PR TITLE
feat : 파일 업로드 링크 저장 및 조회 API 구현

### DIFF
--- a/src/main/java/back/pickd/global/infra/s3/FileController.java
+++ b/src/main/java/back/pickd/global/infra/s3/FileController.java
@@ -1,50 +1,44 @@
 package back.pickd.global.infra.s3;
 
-import back.pickd.user.entity.User;
-import back.pickd.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/files")
 @RequiredArgsConstructor
 public class FileController {
 
-    private final S3Service s3Service;
-    private final UserService userService;
+    private final FileService fileService;
 
     /**
      * S3 파일 업로드 API
      * (이력서, 자격증, 수료증 등을 업로드한 후 CloudFront URL을 반환받습니다)
      */
     @PostMapping("/upload")
-    public ResponseEntity<Map<String, String>> uploadFile(
+    public ResponseEntity<UploadedFileResponse> uploadFile(
             Authentication authentication,
             @RequestParam("file") MultipartFile file,
             @RequestParam("type") FileUploadType type) {
-        
         if (authentication == null) {
             return ResponseEntity.status(401).build();
         }
 
-        // 1. 현재 로그인된 사용자 정보 조회
-        User user = userService.findByEmail(authentication.getName());
-        
-        // 2. S3Service를 호출하여 S3에 저장하고 CloudFront CDN URL 획득
-        String fileUrl = s3Service.uploadFile(file, type, user.getId());
+        return ResponseEntity.ok(fileService.uploadFile(authentication.getName(), file, type));
+    }
 
-        // 3. 응답 맵 구성
-        Map<String, String> response = new HashMap<>();
-        response.put("fileUrl", fileUrl);
-        response.put("fileName", file.getOriginalFilename());
-        response.put("uploadType", type.name());
+    @GetMapping
+    public ResponseEntity<List<UploadedFileResponse>> getFiles(
+            Authentication authentication,
+            @RequestParam(required = false) FileUploadType type) {
+        if (authentication == null) {
+            return ResponseEntity.status(401).build();
+        }
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(fileService.getFiles(authentication.getName(), type));
     }
 }

--- a/src/main/java/back/pickd/global/infra/s3/FileService.java
+++ b/src/main/java/back/pickd/global/infra/s3/FileService.java
@@ -1,0 +1,53 @@
+package back.pickd.global.infra.s3;
+
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FileService {
+
+    private final S3Service s3Service;
+    private final UserService userService;
+    private final UploadedFileRepository uploadedFileRepository;
+
+    @Transactional
+    public UploadedFileResponse uploadFile(String email, MultipartFile file, FileUploadType type) {
+        User user = userService.findByEmail(email);
+        String fileUrl = s3Service.uploadFile(file, type, user.getId());
+
+        UploadedFile uploadedFile = UploadedFile.builder()
+                .user(user)
+                .fileName(resolveFileName(file))
+                .fileUrl(fileUrl)
+                .uploadType(type)
+                .fileSize(file.getSize())
+                .contentType(file.getContentType())
+                .build();
+
+        return new UploadedFileResponse(uploadedFileRepository.save(uploadedFile));
+    }
+
+    public List<UploadedFileResponse> getFiles(String email, FileUploadType type) {
+        User user = userService.findByEmail(email);
+        List<UploadedFile> files = type == null
+                ? uploadedFileRepository.findByUserOrderByCreatedAtDesc(user)
+                : uploadedFileRepository.findByUserAndUploadTypeOrderByCreatedAtDesc(user, type);
+
+        return files.stream()
+                .map(UploadedFileResponse::new)
+                .toList();
+    }
+
+    private String resolveFileName(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        return (originalFilename == null || originalFilename.isBlank()) ? "unknown" : originalFilename;
+    }
+}

--- a/src/main/java/back/pickd/global/infra/s3/UploadedFile.java
+++ b/src/main/java/back/pickd/global/infra/s3/UploadedFile.java
@@ -1,0 +1,42 @@
+package back.pickd.global.infra.s3;
+
+import back.pickd.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UploadedFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String fileUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private FileUploadType uploadType;
+
+    private Long fileSize;
+    private String contentType;
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/back/pickd/global/infra/s3/UploadedFileRepository.java
+++ b/src/main/java/back/pickd/global/infra/s3/UploadedFileRepository.java
@@ -1,0 +1,13 @@
+package back.pickd.global.infra.s3;
+
+import back.pickd.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UploadedFileRepository extends JpaRepository<UploadedFile, Long> {
+
+    List<UploadedFile> findByUserOrderByCreatedAtDesc(User user);
+
+    List<UploadedFile> findByUserAndUploadTypeOrderByCreatedAtDesc(User user, FileUploadType uploadType);
+}

--- a/src/main/java/back/pickd/global/infra/s3/UploadedFileResponse.java
+++ b/src/main/java/back/pickd/global/infra/s3/UploadedFileResponse.java
@@ -1,0 +1,26 @@
+package back.pickd.global.infra.s3;
+
+import java.time.LocalDateTime;
+
+public record UploadedFileResponse(
+        Long id,
+        String fileName,
+        String fileUrl,
+        FileUploadType uploadType,
+        Long fileSize,
+        String contentType,
+        LocalDateTime createdAt
+) {
+
+    public UploadedFileResponse(UploadedFile file) {
+        this(
+                file.getId(),
+                file.getFileName(),
+                file.getFileUrl(),
+                file.getUploadType(),
+                file.getFileSize(),
+                file.getContentType(),
+                file.getCreatedAt()
+        );
+    }
+}

--- a/src/test/java/back/pickd/global/infra/s3/FileServiceTest.java
+++ b/src/test/java/back/pickd/global/infra/s3/FileServiceTest.java
@@ -1,0 +1,100 @@
+package back.pickd.global.infra.s3;
+
+import back.pickd.user.entity.User;
+import back.pickd.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceTest {
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UploadedFileRepository uploadedFileRepository;
+
+    @InjectMocks
+    private FileService fileService;
+
+    @Test
+    void uploadFileStoresUploadedFileLink() {
+        User user = createUser();
+        MultipartFile file = createFile();
+        String fileUrl = "https://cdn.pickd.com/temp/resume/resume.pdf";
+
+        when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(s3Service.uploadFile(file, FileUploadType.TEMP_RESUME, user.getId())).thenReturn(fileUrl);
+        when(uploadedFileRepository.save(any(UploadedFile.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UploadedFileResponse response =
+                fileService.uploadFile("user@example.com", file, FileUploadType.TEMP_RESUME);
+
+        ArgumentCaptor<UploadedFile> captor = ArgumentCaptor.forClass(UploadedFile.class);
+        verify(uploadedFileRepository).save(captor.capture());
+        UploadedFile saved = captor.getValue();
+
+        assertEquals(user, saved.getUser());
+        assertEquals("resume.pdf", saved.getFileName());
+        assertEquals(fileUrl, saved.getFileUrl());
+        assertEquals(FileUploadType.TEMP_RESUME, saved.getUploadType());
+        assertEquals(file.getSize(), saved.getFileSize());
+        assertEquals("application/pdf", saved.getContentType());
+        assertEquals(fileUrl, response.fileUrl());
+    }
+
+    @Test
+    void getFilesReturnsLinksFilteredByType() {
+        User user = createUser();
+        UploadedFile uploadedFile = UploadedFile.builder()
+                .id(1L)
+                .user(user)
+                .fileName("resume.pdf")
+                .fileUrl("https://cdn.pickd.com/temp/resume/resume.pdf")
+                .uploadType(FileUploadType.TEMP_RESUME)
+                .fileSize(100L)
+                .contentType("application/pdf")
+                .build();
+
+        when(userService.findByEmail("user@example.com")).thenReturn(user);
+        when(uploadedFileRepository.findByUserAndUploadTypeOrderByCreatedAtDesc(
+                user,
+                FileUploadType.TEMP_RESUME
+        )).thenReturn(List.of(uploadedFile));
+
+        List<UploadedFileResponse> responses =
+                fileService.getFiles("user@example.com", FileUploadType.TEMP_RESUME);
+
+        assertEquals(1, responses.size());
+        assertEquals("resume.pdf", responses.get(0).fileName());
+        assertEquals(FileUploadType.TEMP_RESUME, responses.get(0).uploadType());
+    }
+
+    private User createUser() {
+        return User.builder()
+                .email("user@example.com")
+                .name("테스트")
+                .build();
+    }
+
+    private MultipartFile createFile() {
+        return new MockMultipartFile("file", "resume.pdf", "application/pdf", "pdf".getBytes());
+    }
+}


### PR DESCRIPTION
# 변경점 👍
- 공용 파일 업로드 API에서 S3 업로드 링크를 DB에 저장
- 로그인 사용자가 업로드한 파일 링크 목록을 조회할 수 있는 API 추가
- `type` 쿼리 파라미터로 업로드 파일 저장 경로 및 조회 대상을 구분

# Response
[
  {
    "id": 1,
    "fileName": "resume.pdf",
    "fileUrl": "https://cdn.pickd.com/temp/resume/1/uuid.pdf",
    "uploadType": "TEMP_RESUME",
    "fileSize": 12345,
    "contentType": "application/pdf",
    "createdAt": "2026-06-24T12:30:00"
  }
]

# 테스트(FileServiceTest)
-파일 업로드 시 S3 업로드 결과 URL이 UploadedFile로 저장되는지 확인
-파일 조회 시 type 조건에 맞는 업로드 파일 링크 목록이 응답 DTO로 변환되는지 확인