### PR TITLE
feat: Application → Notice 연결 및 AI 분석 시 Application 자동 생성

### DIFF
--- a/src/main/java/back/pickd/application/controller/ApplicationController.java
+++ b/src/main/java/back/pickd/application/controller/ApplicationController.java
@@ -1,7 +1,7 @@
 package back.pickd.application.controller;
 
 import back.pickd.application.dto.request.ApplicationRequest;
-import back.pickd.application.entity.Application;
+import back.pickd.application.dto.response.ApplicationResponse;
 import back.pickd.application.service.ApplicationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -17,7 +17,7 @@ public class ApplicationController {
     private final ApplicationService applicationService;
 
     @GetMapping
-    public List<Application> getAll(Authentication auth) {
+    public List<ApplicationResponse> getAll(Authentication auth) {
         return applicationService.getApplications(auth);
     }
 

--- a/src/main/java/back/pickd/application/dto/request/ApplicationRequest.java
+++ b/src/main/java/back/pickd/application/dto/request/ApplicationRequest.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 @Setter
 public class ApplicationRequest {
 
+    private Long noticeId;
+
     private String company;
     private String jobTitle;
     private String position;

--- a/src/main/java/back/pickd/application/dto/response/ApplicationResponse.java
+++ b/src/main/java/back/pickd/application/dto/response/ApplicationResponse.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class ApplicationResponse {
 
     private Long id;
+    private Long noticeId;
     private List<TodoResponse> todos;
     private String company;
     private String jobTitle;
@@ -35,6 +36,7 @@ public class ApplicationResponse {
     public static ApplicationResponse from(Application app) {
         return ApplicationResponse.builder()
                 .id(app.getId())
+                .noticeId(app.getNotice() != null ? app.getNotice().getId() : null)
                 .todos(app.getTodos().stream().map(TodoResponse::from).toList())
                 .company(app.getCompany())
                 .jobTitle(app.getJobTitle())

--- a/src/main/java/back/pickd/application/entity/Application.java
+++ b/src/main/java/back/pickd/application/entity/Application.java
@@ -3,6 +3,7 @@ package back.pickd.application.entity;
 import back.pickd.application.enums.ApplicationStatus;
 import back.pickd.coverletter.entity.CoverLetterItem;
 import back.pickd.document.entity.Document;
+import back.pickd.notice.entity.Notice;
 import back.pickd.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
@@ -27,6 +28,10 @@ public class Application {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
@@ -119,5 +124,9 @@ public class Application {
 
     public void clearDeadlineEventId() {
         this.deadlineEventId = null;
+    }
+
+    public void assignNotice(Notice notice) {
+        this.notice = notice;
     }
 }

--- a/src/main/java/back/pickd/application/enums/ApplicationStatus.java
+++ b/src/main/java/back/pickd/application/enums/ApplicationStatus.java
@@ -1,5 +1,7 @@
 package back.pickd.application.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +16,18 @@ public enum ApplicationStatus {
     INTERVIEW("면접 전형"),
     FINAL("최종 결과");
 
+    @JsonValue
     private final String label;
+
+    @JsonCreator
+    public static ApplicationStatus from(String label) {
+        for (ApplicationStatus status : values()) {
+            if (status.label.equals(label)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("지원하지 않는 지원 상태입니다: " + label);
+    }
 
     public boolean needsApplyEvent() {
         return this == PREPARING || this == WRITING;

--- a/src/main/java/back/pickd/application/service/ApplicationService.java
+++ b/src/main/java/back/pickd/application/service/ApplicationService.java
@@ -5,6 +5,8 @@ import back.pickd.application.entity.Application;
 import back.pickd.application.enums.ApplicationStatus;
 import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.calendar.service.CalendarAsyncService;
+import back.pickd.notice.entity.Notice;
+import back.pickd.notice.repository.NoticeRepository;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
 import com.google.api.client.util.DateTime;
@@ -23,6 +25,7 @@ import java.util.List;
 public class ApplicationService {
 
     private final ApplicationRepository applicationRepository;
+    private final NoticeRepository noticeRepository;
     private final CalendarAsyncService calendarAsyncService;
     private final UserService userService;
 
@@ -37,8 +40,15 @@ public class ApplicationService {
         User user = userService.findByEmail(auth.getName());
         ApplicationStatus status = dto.getStatus();
 
+        Notice notice = null;
+        if (dto.getNoticeId() != null) {
+            notice = noticeRepository.findByIdAndUser(dto.getNoticeId(), user)
+                    .orElseThrow(() -> new IllegalArgumentException("공고를 찾을 수 없습니다."));
+        }
+
         Application app = Application.builder()
                 .user(user)
+                .notice(notice)
                 .company(dto.getCompany())
                 .jobTitle(dto.getJobTitle())
                 .position(dto.getPosition())

--- a/src/main/java/back/pickd/application/service/ApplicationService.java
+++ b/src/main/java/back/pickd/application/service/ApplicationService.java
@@ -1,6 +1,7 @@
 package back.pickd.application.service;
 
 import back.pickd.application.dto.request.ApplicationRequest;
+import back.pickd.application.dto.response.ApplicationResponse;
 import back.pickd.application.entity.Application;
 import back.pickd.application.enums.ApplicationStatus;
 import back.pickd.application.repository.ApplicationRepository;
@@ -30,9 +31,10 @@ public class ApplicationService {
     private final UserService userService;
 
     @Transactional(readOnly = true)
-    public List<Application> getApplications(Authentication auth) {
+    public List<ApplicationResponse> getApplications(Authentication auth) {
         User user = userService.findByEmail(auth.getName());
-        return applicationRepository.findAllByUserOrderByIdDesc(user);
+        return applicationRepository.findAllByUserOrderByIdDesc(user)
+                .stream().map(ApplicationResponse::from).toList();
     }
 
     @Transactional

--- a/src/main/java/back/pickd/notice/service/NoticeService.java
+++ b/src/main/java/back/pickd/notice/service/NoticeService.java
@@ -1,12 +1,13 @@
 package back.pickd.notice.service;
 
+import back.pickd.application.entity.Application;
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.global.infra.ai.AiClient;
 import back.pickd.global.infra.ai.dto.*;
 import back.pickd.notice.entity.*;
 import back.pickd.notice.enums.*;
-
 import back.pickd.notice.repository.*;
-
 import back.pickd.user.entity.User;
 import back.pickd.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class NoticeService {
     private final SectionPreferenceRepository sectionPreferenceRepository;
     private final NoticeProcessRepository noticeProcessRepository;
     private final ApplicationDocumentRepository applicationDocumentRepository;
+    private final ApplicationRepository applicationRepository;
     private final UserRepository userRepository;
 
     // URL 채용공고 분석 후 저장
@@ -138,6 +140,16 @@ public class NoticeService {
                 applicationDocumentRepository.save(document);
             }
         }
+
+        // AI 분석 공고 저장 후 Application 자동 생성
+        Application application = Application.builder()
+                .user(user)
+                .notice(savedNotice)
+                .company(savedNotice.getCompanyName())
+                .jobTitle(savedNotice.getNoticeName())
+                .status(ApplicationStatus.PREPARING)
+                .build();
+        applicationRepository.save(application);
 
         return savedNotice.getId();
     }

--- a/src/test/java/back/pickd/application/service/ApplicationServiceTest.java
+++ b/src/test/java/back/pickd/application/service/ApplicationServiceTest.java
@@ -296,7 +296,7 @@ class ApplicationServiceTest {
             when(applicationRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
             ApplicationRequest req = buildRequest(ApplicationStatus.WRITING);
 
-            assertThatThrownBy(() -> applicationService.updateApplication(99L, authentication, req))
+            assertThatThrownBy(() -> applicationService.updateApplication(99L, req, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("지원 공고를 찾을 수 없습니다");
         }
@@ -319,7 +319,7 @@ class ApplicationServiceTest {
             req.setDeadlineDate(LocalDateTime.now().plusDays(7));
             when(applicationRepository.save(any())).thenReturn(app);
 
-            applicationService.updateApplication(1L, authentication, req);
+            applicationService.updateApplication(1L, req, authentication);
 
             verify(calendarAsyncService).deleteEventAsync(authentication, "old-event-id");
         }

--- a/src/test/java/back/pickd/application/service/ApplicationServiceTest.java
+++ b/src/test/java/back/pickd/application/service/ApplicationServiceTest.java
@@ -6,6 +6,9 @@ import back.pickd.application.entity.Application;
 import back.pickd.application.enums.ApplicationStatus;
 import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.calendar.service.CalendarAsyncService;
+import back.pickd.notice.entity.Notice;
+import back.pickd.notice.enums.JobCategory;
+import back.pickd.notice.repository.NoticeRepository;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +36,7 @@ import static org.mockito.Mockito.*;
 class ApplicationServiceTest {
 
     @Mock ApplicationRepository applicationRepository;
+    @Mock NoticeRepository noticeRepository;
     @Mock CalendarAsyncService calendarAsyncService;
     @Mock UserService userService;
     @Mock Authentication authentication;
@@ -40,6 +44,7 @@ class ApplicationServiceTest {
     @InjectMocks ApplicationService applicationService;
 
     User user;
+    Notice notice;
 
     @BeforeEach
     void setUp() {
@@ -47,6 +52,15 @@ class ApplicationServiceTest {
                 .email("test@test.com")
                 .name("테스트유저")
                 .build();
+
+        notice = Notice.builder()
+                .user(user)
+                .companyName("카카오")
+                .noticeName("2026 상반기 공채")
+                .category(JobCategory.FULL_TIME)
+                .startedAt("2026-01-01")
+                .build();
+
         when(authentication.getName()).thenReturn("test@test.com");
         when(userService.findByEmail("test@test.com")).thenReturn(user);
     }
@@ -170,6 +184,45 @@ class ApplicationServiceTest {
 
             assertThat(captor.getValue().getUser()).isEqualTo(user);
             assertThat(captor.getValue().getCompany()).isEqualTo("카카오");
+        }
+
+        @Test
+        @DisplayName("noticeId가 있으면 Notice와 연결된 Application을 생성한다")
+        void createsApplicationLinkedToNotice() throws Exception {
+            ApplicationRequest req = buildRequest(ApplicationStatus.PREPARING);
+            req.setNoticeId(1L);
+            when(noticeRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(notice));
+            ArgumentCaptor<Application> captor = ArgumentCaptor.forClass(Application.class);
+            when(applicationRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            applicationService.addApplication(req, authentication);
+
+            assertThat(captor.getValue().getNotice()).isEqualTo(notice);
+        }
+
+        @Test
+        @DisplayName("noticeId가 null이면 notice 없이 Application을 생성한다")
+        void createsApplicationWithoutNotice() throws Exception {
+            ApplicationRequest req = buildRequest(ApplicationStatus.PREPARING);
+            // noticeId = null
+            ArgumentCaptor<Application> captor = ArgumentCaptor.forClass(Application.class);
+            when(applicationRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            applicationService.addApplication(req, authentication);
+
+            assertThat(captor.getValue().getNotice()).isNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 noticeId로 Application 생성 시 예외가 발생한다")
+        void throwsWhenNoticeNotFound() {
+            ApplicationRequest req = buildRequest(ApplicationStatus.PREPARING);
+            req.setNoticeId(99L);
+            when(noticeRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> applicationService.addApplication(req, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("공고를 찾을 수 없습니다");
         }
     }
 


### PR DESCRIPTION
## 개요
Application과 Notice가 분리되어 있던 구조를 연결하고, AI 공고 분석 시 Application을 자동 생성합니다.

## 변경 사항

### Application → Notice FK 연결
- `Application`에 `notice_id` nullable FK 추가
- `assignNotice()` 도메인 메서드 추가
- 수기 입력 시 `notice_id = null`, AI 분석 시 서버에서 자동 연결

### 지원 흐름 개선
**수기 입력**
```
사용자 → POST /api/application → Application (notice_id = null)
```
**AI 분석**
```
사용자 → POST /api/notices/analyze → Notice 저장 → Application 자동 생성 (PREPARING, notice_id = Notice.id)
```

### DTO 및 응답 개선
- `ApplicationRequest`에 `noticeId` 추가 (수기 등록 시 공고 연결 가능)
- `ApplicationResponse`에 `noticeId` 추가
- `ApplicationService.getApplications()` 반환 타입 `List<ApplicationResponse>`로 통일
- `ApplicationController` 반환 타입 일치

### ApplicationStatus 직렬화 개선
- `@JsonValue` / `@JsonCreator` 추가 → label 기반 JSON 직렬화/역직렬화
- `from(String label)` 정적 메서드 추가

## 테스트
- notice 연결 케이스, 미연결 케이스, 소유권 검증 케이스 추가
- `ApplicationStatusTest` — 직렬화/역직렬화/캘린더 이벤트 조건 전체 통과

## 관련 이슈
closes #64