### PR TITLE
feat: DocumentType COVER_LETTER 제거 및 CoverLetterItem @PrePersist 검증 추가

### DIFF
--- a/src/main/java/back/pickd/coverletter/entity/CoverLetterItem.java
+++ b/src/main/java/back/pickd/coverletter/entity/CoverLetterItem.java
@@ -57,6 +57,9 @@ public class CoverLetterItem {
 
     @PrePersist
     protected void onCreate() {
+        if (this.notice == null && this.application == null) {
+            throw new IllegalStateException("CoverLetterItem은 Notice 또는 Application 중 하나에 반드시 연결되어야 합니다.");
+        }
         this.createdAt = LocalDateTime.now();
         this.updatedAt = this.createdAt;
     }

--- a/src/main/java/back/pickd/document/dto/DocumentRequest.java
+++ b/src/main/java/back/pickd/document/dto/DocumentRequest.java
@@ -14,7 +14,7 @@ public class DocumentRequest {
     private String company;
 
     @NotNull
-    private DocumentType type;      // RESUME, PORTFOLIO, COVER_LETTER, ETC
+    private DocumentType type;      // RESUME, PORTFOLIO, ETC
 
     private DocumentStatus status;  // nullable
 

--- a/src/main/java/back/pickd/document/enums/DocumentType.java
+++ b/src/main/java/back/pickd/document/enums/DocumentType.java
@@ -9,7 +9,6 @@ public enum DocumentType {
 
     RESUME("이력서"),
     PORTFOLIO("포트폴리오"),
-    COVER_LETTER("자기소개서"),
     ETC("기타");
 
     private final String label;

--- a/src/test/java/back/pickd/coverletter/entity/CoverLetterItemTest.java
+++ b/src/test/java/back/pickd/coverletter/entity/CoverLetterItemTest.java
@@ -1,0 +1,90 @@
+package back.pickd.coverletter.entity;
+
+import back.pickd.application.entity.Application;
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.notice.entity.Notice;
+import back.pickd.notice.enums.JobCategory;
+import back.pickd.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("CoverLetterItem 엔티티 단위 테스트")
+class CoverLetterItemTest {
+
+    User user;
+    Notice notice;
+    Application application;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().email("test@test.com").name("테스터").build();
+
+        notice = Notice.builder()
+                .user(user)
+                .companyName("카카오")
+                .noticeName("2026 상반기 공채")
+                .category(JobCategory.FULL_TIME)
+                .startedAt("2026-01-01")
+                .build();
+
+        application = Application.builder()
+                .user(user).company("카카오").jobTitle("백엔드")
+                .status(ApplicationStatus.WRITING).important(false).build();
+    }
+
+    // @PrePersist onCreate() 메서드를 리플렉션으로 직접 호출
+    private void invokeOnCreate(CoverLetterItem item) throws Exception {
+        Method method = CoverLetterItem.class.getDeclaredMethod("onCreate");
+        method.setAccessible(true);
+        try {
+            method.invoke(item);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException re) throw re;
+            throw new RuntimeException(cause);
+        }
+    }
+
+    @Nested
+    @DisplayName("@PrePersist 검증")
+    class PrePersistValidation {
+
+        @Test
+        @DisplayName("notice만 있으면 정상 저장된다")
+        void passesWhenNoticeIsSet() throws Exception {
+            CoverLetterItem item = CoverLetterItem.builder()
+                    .user(user).notice(notice).question("q").orderIndex(0).build();
+
+            assertThatCode(() -> invokeOnCreate(item)).doesNotThrowAnyException();
+            assertThat(item.getCreatedAt()).isNotNull();
+            assertThat(item.getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("application만 있으면 정상 저장된다")
+        void passesWhenApplicationIsSet() throws Exception {
+            CoverLetterItem item = CoverLetterItem.builder()
+                    .user(user).application(application).question("q").orderIndex(0).build();
+
+            assertThatCode(() -> invokeOnCreate(item)).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("notice와 application 모두 null이면 IllegalStateException이 발생한다")
+        void throwsWhenBothNotiiceAndApplicationAreNull() throws Exception {
+            CoverLetterItem item = CoverLetterItem.builder()
+                    .user(user).question("q").orderIndex(0).build();
+
+            assertThatThrownBy(() -> invokeOnCreate(item))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Notice 또는 Application 중 하나에 반드시 연결되어야 합니다");
+        }
+    }
+}

--- a/src/test/java/back/pickd/document/service/DocumentServiceTest.java
+++ b/src/test/java/back/pickd/document/service/DocumentServiceTest.java
@@ -57,7 +57,7 @@ class DocumentServiceTest {
         DocumentRequest req = new DocumentRequest();
         req.setTitle("자기소개서");
         req.setCompany("카카오");
-        req.setType(DocumentType.COVER_LETTER);
+        req.setType(DocumentType.RESUME);
         req.setStatus(DocumentStatus.DRAFT);
         req.setProgress(30);
         req.setContent("내용...");
@@ -70,7 +70,7 @@ class DocumentServiceTest {
                 .application(application)
                 .title("자기소개서")
                 .company("카카오")
-                .type(DocumentType.COVER_LETTER)
+                .type(DocumentType.RESUME)
                 .status(DocumentStatus.DRAFT)
                 .progress(30)
                 .content("내용...")
@@ -134,7 +134,7 @@ class DocumentServiceTest {
             Document saved = captor.getValue();
             assertThat(saved.getUser()).isEqualTo(user);
             assertThat(saved.getApplication()).isEqualTo(application);
-            assertThat(saved.getType()).isEqualTo(DocumentType.COVER_LETTER);
+            assertThat(saved.getType()).isEqualTo(DocumentType.RESUME);
         }
 
         @Test


### PR DESCRIPTION
## 변경 사항

closes #66

### DocumentType.COVER_LETTER 제거
- `DocumentType` enum에서 `COVER_LETTER("자기소개서")` 값 제거
- 자기소개서는 `CoverLetterItem` 엔티티가 전담하므로 Document 타입으로 불필요
- `DocumentRequest.java` 주석 업데이트
- `DocumentServiceTest.java` 테스트 픽스처를 `DocumentType.RESUME`으로 교체

### CoverLetterItem @PrePersist 검증 추가
- `notice`와 `application` 모두 null인 채로 저장 시도 시 `IllegalStateException` 발생
- DB 제약이 아닌 JPA 엔티티 레벨 방어 (DB 미연결 상태 대응)
- `CoverLetterItemTest` 추가: notice 연결, application 연결, 둘 다 null 3가지 케이스 검증