### PR TITLE
feat: AiStrategy 중복 user FK 제거

### DIFF
--- a/src/main/java/back/pickd/notice/entity/AiStrategy.java
+++ b/src/main/java/back/pickd/notice/entity/AiStrategy.java
@@ -2,7 +2,6 @@ package back.pickd.notice.entity;
 
 import back.pickd.coverletter.entity.CoverLetterItem;
 import back.pickd.experience.entity.UserExperience;
-import back.pickd.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,10 +14,6 @@ public class AiStrategy {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cover_letter_item_id", nullable = false)
@@ -49,10 +44,9 @@ public class AiStrategy {
     }
 
     @Builder
-    public AiStrategy(User user, CoverLetterItem coverLetterItem, UserExperience matchedExperience,
+    public AiStrategy(CoverLetterItem coverLetterItem, UserExperience matchedExperience,
                       SwotStrategy strategy, String jdTargeting,
                       String dynamicFraming, String strategyDerivation, String writingGuide) {
-        this.user = user;
         this.coverLetterItem = coverLetterItem;
         this.matchedExperience = matchedExperience;
         this.strategy = strategy;


### PR DESCRIPTION
## 변경 사항

closes #67

### 문제
`AiStrategy`에 `user_id` FK가 직접 존재했으나, `coverLetterItem → user`로 이미 User에 접근 가능하여 중복

### 변경
- `AiStrategy.user` 필드 및 `@ManyToOne` 관계 제거
- `@Builder` 생성자에서 `User user` 파라미터 제거
- `import back.pickd.user.entity.User` 제거