### PR TITLE
feat: ExperienceTemp experienceGroup/experienceType String → Enum 통일

### DIFF
--- a/src/main/java/back/pickd/experience/entity/ExperienceTemp.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceTemp.java
@@ -1,5 +1,7 @@
 package back.pickd.experience.entity;
 
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
 import back.pickd.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -25,11 +27,13 @@ public class ExperienceTemp {
     @Column(nullable = false)
     private String experienceName;
 
-    @Column(nullable = false)
-    private String experienceGroup; // 예: "상세 서술형", "스펙·증빙형"
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ExperienceGroup experienceGroup;
 
-    @Column(nullable = false)
-    private String experienceType;  // 예: "프로젝트", "어학", "인턴"
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private ExperienceType experienceType;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String resumeUrl; // 1차 업로드 시 S3에 임시 저장된 자소서 원본 CloudFront URL
@@ -37,7 +41,7 @@ public class ExperienceTemp {
     private LocalDateTime createdAt;
 
     @Builder
-    public ExperienceTemp(User user, String experienceName, String experienceGroup, String experienceType, String resumeUrl) {
+    public ExperienceTemp(User user, String experienceName, ExperienceGroup experienceGroup, ExperienceType experienceType, String resumeUrl) {
         this.user = user;
         this.experienceName = experienceName;
         this.experienceGroup = experienceGroup;

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
@@ -70,8 +70,8 @@ public class ExperienceExtractionService {
                 ExperienceTemp temp = ExperienceTemp.builder()
                         .user(user)
                         .experienceName(summary.getExperience_name())
-                        .experienceGroup(toKoreanGroup(group))
-                        .experienceType(type.getKoreanName())
+                        .experienceGroup(group)
+                        .experienceType(type)
                         .resumeUrl(resumeUrl)
                         .build();
                 temps.add(tempRepository.save(temp));
@@ -104,8 +104,8 @@ public class ExperienceExtractionService {
         List<AiStep1Response.ExperienceSummaryDto> selectedSummaries = temps.stream()
                 .map(t -> new AiStep1Response.ExperienceSummaryDto(
                         t.getExperienceName(),
-                        t.getExperienceGroup(),
-                        t.getExperienceType()
+                        toKoreanGroup(t.getExperienceGroup()),
+                        t.getExperienceType().getKoreanName()
                 ))
                 .collect(Collectors.toList());
 

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
@@ -292,8 +292,8 @@ public class ExperienceExtractionV2Service {
     }
 
     private SelectedExperience toSelectedExperience(ExperienceTemp temp) {
-        ExperienceType type = convertType(temp.getExperienceType());
-        ExperienceGroup group = convertGroup(temp.getExperienceGroup());
+        ExperienceType type = temp.getExperienceType();
+        ExperienceGroup group = temp.getExperienceGroup();
         validateGroupType(group, type);
         return new SelectedExperience(temp, type, group);
     }

--- a/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestControllerIntegrationTest.java
+++ b/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestControllerIntegrationTest.java
@@ -197,8 +197,8 @@ class ExperienceExtractionTestControllerIntegrationTest {
         return ExperienceTemp.builder()
                 .user(user)
                 .experienceName(name)
-                .experienceGroup("상세 서술형")
-                .experienceType("프로젝트")
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .experienceType(ExperienceType.PROJECT)
                 .resumeUrl("https://cdn.example.com/" + name + ".pdf")
                 .build();
     }


### PR DESCRIPTION
## 변경 사항

closes #68

### 문제
`ExperienceTemp.experienceGroup`, `experienceType`이 `String`으로 저장되어 있어
`UserExperience`의 Enum 타입과 불일치. 저장 시 한국어 문자열로 변환, 조회 시 다시 파싱하는 불필요한 왕복 발생

### 변경
- `ExperienceTemp.experienceGroup`: `String` → `ExperienceGroup`
- `ExperienceTemp.experienceType`: `String` → `ExperienceType`
- `ExperienceExtractionService.extractStep1()`: builder에 enum 직접 전달 (`toKoreanGroup()` 변환 제거)
- `ExperienceExtractionService.extractStep2()`: AI 요청 DTO 생성 시 enum → Korean String 역변환 추가
- `ExperienceExtractionV2Service.toSelectedExperience()`: `convertType()`/`convertGroup()` 파싱 제거, enum 직접 사용
- 통합 테스트 픽스처 String 리터럴 → Enum 상수로 교체