### PR TITLE
fix: 엔티티 및 Enum 소규모 정합성 수정

### DIFF
--- a/src/main/java/back/pickd/document/enums/DocumentStatus.java
+++ b/src/main/java/back/pickd/document/enums/DocumentStatus.java
@@ -1,5 +1,7 @@
 package back.pickd.document.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,5 +12,14 @@ public enum DocumentStatus {
     DRAFT("작성중"),
     COMPLETED("완료");
 
+    @JsonValue
     private final String label;
+
+    @JsonCreator
+    public static DocumentStatus from(String label) {
+        for (DocumentStatus s : values()) {
+            if (s.label.equals(label)) return s;
+        }
+        throw new IllegalArgumentException("지원하지 않는 서류 상태입니다: " + label);
+    }
 }

--- a/src/main/java/back/pickd/document/enums/DocumentType.java
+++ b/src/main/java/back/pickd/document/enums/DocumentType.java
@@ -1,5 +1,7 @@
 package back.pickd.document.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,5 +13,14 @@ public enum DocumentType {
     PORTFOLIO("포트폴리오"),
     ETC("기타");
 
+    @JsonValue
     private final String label;
+
+    @JsonCreator
+    public static DocumentType from(String label) {
+        for (DocumentType t : values()) {
+            if (t.label.equals(label)) return t;
+        }
+        throw new IllegalArgumentException("지원하지 않는 서류 유형입니다: " + label);
+    }
 }

--- a/src/main/java/back/pickd/experience/entity/ExperienceTemp.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceTemp.java
@@ -38,6 +38,7 @@ public class ExperienceTemp {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String resumeUrl; // 1차 업로드 시 S3에 임시 저장된 자소서 원본 CloudFront URL
 
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Builder

--- a/src/main/java/back/pickd/experience/entity/ExperienceTemp.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceTemp.java
@@ -1,5 +1,7 @@
 package back.pickd.experience.entity;
 
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
 import back.pickd.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -25,11 +27,13 @@ public class ExperienceTemp {
     @Column(nullable = false)
     private String experienceName;
 
-    @Column(nullable = false)
-    private String experienceGroup; // 예: "상세 서술형", "스펙·증빙형"
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ExperienceGroup experienceGroup;
 
-    @Column(nullable = false)
-    private String experienceType;  // 예: "프로젝트", "어학", "인턴"
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private ExperienceType experienceType;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String resumeUrl; // 1차 업로드 시 S3에 임시 저장된 자소서 원본 CloudFront URL
@@ -37,7 +41,7 @@ public class ExperienceTemp {
     private LocalDateTime createdAt;
 
     @Builder
-    public ExperienceTemp(User user, String experienceName, String experienceGroup, String experienceType, String resumeUrl) {
+    public ExperienceTemp(User user, String experienceName, ExperienceGroup experienceGroup, ExperienceType experienceType, String resumeUrl) {
         this.user = user;
         this.experienceName = experienceName;
         this.experienceGroup = experienceGroup;

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
@@ -70,8 +70,8 @@ public class ExperienceExtractionService {
                 ExperienceTemp temp = ExperienceTemp.builder()
                         .user(user)
                         .experienceName(summary.getExperience_name())
-                        .experienceGroup(toKoreanGroup(group))
-                        .experienceType(type.getKoreanName())
+                        .experienceGroup(group)
+                        .experienceType(type)
                         .resumeUrl(resumeUrl)
                         .build();
                 temps.add(tempRepository.save(temp));
@@ -104,8 +104,8 @@ public class ExperienceExtractionService {
         List<AiStep1Response.ExperienceSummaryDto> selectedSummaries = temps.stream()
                 .map(t -> new AiStep1Response.ExperienceSummaryDto(
                         t.getExperienceName(),
-                        t.getExperienceGroup(),
-                        t.getExperienceType()
+                        toKoreanGroup(t.getExperienceGroup()),
+                        t.getExperienceType().getKoreanName()
                 ))
                 .collect(Collectors.toList());
 

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
@@ -292,8 +292,8 @@ public class ExperienceExtractionV2Service {
     }
 
     private SelectedExperience toSelectedExperience(ExperienceTemp temp) {
-        ExperienceType type = convertType(temp.getExperienceType());
-        ExperienceGroup group = convertGroup(temp.getExperienceGroup());
+        ExperienceType type = temp.getExperienceType();
+        ExperienceGroup group = temp.getExperienceGroup();
         validateGroupType(group, type);
         return new SelectedExperience(temp, type, group);
     }

--- a/src/main/java/back/pickd/user/entity/UserCertification.java
+++ b/src/main/java/back/pickd/user/entity/UserCertification.java
@@ -16,7 +16,7 @@ public class UserCertification {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/back/pickd/user/entity/UserEducation.java
+++ b/src/main/java/back/pickd/user/entity/UserEducation.java
@@ -17,7 +17,7 @@ public class UserEducation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/back/pickd/user/entity/UserInterest.java
+++ b/src/main/java/back/pickd/user/entity/UserInterest.java
@@ -18,7 +18,7 @@ public class UserInterest {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/back/pickd/user/entity/UserLocation.java
+++ b/src/main/java/back/pickd/user/entity/UserLocation.java
@@ -18,7 +18,7 @@ public class UserLocation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/back/pickd/user/entity/UserPrepStatus.java
+++ b/src/main/java/back/pickd/user/entity/UserPrepStatus.java
@@ -18,7 +18,7 @@ public class UserPrepStatus {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestControllerIntegrationTest.java
+++ b/src/test/java/back/pickd/experience/controller/ExperienceExtractionTestControllerIntegrationTest.java
@@ -197,8 +197,8 @@ class ExperienceExtractionTestControllerIntegrationTest {
         return ExperienceTemp.builder()
                 .user(user)
                 .experienceName(name)
-                .experienceGroup("상세 서술형")
-                .experienceType("프로젝트")
+                .experienceGroup(ExperienceGroup.NARRATIVE)
+                .experienceType(ExperienceType.PROJECT)
                 .resumeUrl("https://cdn.example.com/" + name + ".pdf")
                 .build();
     }


### PR DESCRIPTION
## 변경 사항

closes #72

### UserCertification
- `user_id` FK `nullable = false` 추가

### UserEducation / UserLocation / UserInterest / UserPrepStatus
- `@OneToOne` `FetchType.LAZY` 명시 (기본 EAGER → LAZY)

### ExperienceTemp
- `createdAt`: `@Column(nullable = false, updatable = false)` 추가

### DocumentStatus / DocumentType
- `@JsonValue` / `@JsonCreator` 추가 — ApplicationStatus와 동일한 패턴으로 통일