### PR TITLE
fix: AI 응답 DTO snake_case 필드에 @JsonProperty 명시

### DIFF
--- a/src/main/java/back/pickd/global/infra/ai/dto/AiStep1Response.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiStep1Response.java
@@ -1,5 +1,6 @@
 package back.pickd.global.infra.ai.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,8 +15,13 @@ public class AiStep1Response {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ExperienceSummaryDto {
+        @JsonProperty("experience_name")
         private String experience_name;
+
+        @JsonProperty("experience_group")
         private String experience_group;
+
+        @JsonProperty("experience_type")
         private String experience_type;
     }
 }

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiStep2Response.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiStep2Response.java
@@ -1,5 +1,6 @@
 package back.pickd.global.infra.ai.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.util.List;
@@ -13,28 +14,62 @@ public class AiStep2Response {
     @Getter
     @NoArgsConstructor
     public static class Step2ExperienceDto {
+        @JsonProperty("experience_name")
         private String experience_name;
+
+        @JsonProperty("experience_group")
         private String experience_group;
+
+        @JsonProperty("experience_type")
         private String experience_type;
+
         private List<String> keywords;
+
+        @JsonProperty("is_important")
         private boolean is_important;
+
+        @JsonProperty("progress_status")
         private String progress_status;
+
+        @JsonProperty("needs_merge")
         private boolean needs_merge;
+
         private boolean unanswered;
+
+        @JsonProperty("has_ai_questions")
         private boolean has_ai_questions;
-        
+
         // 11가지 소분류 유형에 따라 유동적인 필드는 Map으로 통째 파싱
+        @JsonProperty("basic_info")
         private Map<String, Object> basic_info;
-        
+
+        @JsonProperty("experience_content")
         private String experience_content;
+
+        @JsonProperty("tagged_body_text")
         private List<TaggedSentenceDto> tagged_body_text;
+
+        @JsonProperty("document_editor_content")
         private String document_editor_content;
+
+        @JsonProperty("related_links")
         private List<String> related_links;
+
         private List<String> attachments;
+
+        @JsonProperty("ai_questions")
         private List<String> ai_questions;
+
+        @JsonProperty("ai_sentence_cards")
         private List<String> ai_sentence_cards;
+
+        @JsonProperty("merge_candidate_id")
         private String merge_candidate_id;
+
+        @JsonProperty("merge_similarity")
         private Double merge_similarity;
+
+        @JsonProperty("writing_status")
         private String writing_status;
     }
 


### PR DESCRIPTION
## 변경 사항

closes #74

`AiExperienceMergeCheckResponse`는 이미 `@JsonProperty` 사용 중이었으나 `AiStep1Response`, `AiStep2Response`에는 누락되어 있던 것을 통일.

특히 `boolean is_important`의 경우 Lombok이 `isIs_important()`를 생성하므로 명시적 `@JsonProperty`가 필수.