### PR TITLE
refactor: Experience 변환 유틸 메서드 공통 클래스로 추출

### DIFF
--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionService.java
@@ -21,6 +21,7 @@ import back.pickd.experience.enums.ExperienceType;
 import back.pickd.experience.enums.Status;
 import back.pickd.experience.repository.ExperienceTempRepository;
 import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.experience.support.ExperienceConversionUtils;
 import back.pickd.experience.support.PresetRegistry;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
@@ -44,6 +45,7 @@ public class ExperienceExtractionService {
     private final UserService userService;
     private final ExperienceMergeService experienceMergeService;
     private final PresetRegistry presetRegistry;
+    private final ExperienceConversionUtils conversionUtils;
 
     /**
      * 1차 경험 후보 추출 및 임시 캐싱
@@ -64,9 +66,9 @@ public class ExperienceExtractionService {
         List<ExperienceTemp> temps = new ArrayList<>();
         if (aiResponse.getExperiences() != null) {
             for (AiStep1Response.ExperienceSummaryDto summary : aiResponse.getExperiences()) {
-                ExperienceType type = convertType(summary.getExperience_type());
-                ExperienceGroup group = convertGroup(summary.getExperience_group());
-                validateGroupType(group, type);
+                ExperienceType type = conversionUtils.convertType(summary.getExperience_type());
+                ExperienceGroup group = conversionUtils.convertGroup(summary.getExperience_group());
+                conversionUtils.validateGroupType(group, type);
                 ExperienceTemp temp = ExperienceTemp.builder()
                         .user(user)
                         .experienceName(summary.getExperience_name())
@@ -104,7 +106,7 @@ public class ExperienceExtractionService {
         List<AiStep1Response.ExperienceSummaryDto> selectedSummaries = temps.stream()
                 .map(t -> new AiStep1Response.ExperienceSummaryDto(
                         t.getExperienceName(),
-                        toKoreanGroup(t.getExperienceGroup()),
+                        conversionUtils.toKoreanGroup(t.getExperienceGroup()),
                         t.getExperienceType().getKoreanName()
                 ))
                 .collect(Collectors.toList());
@@ -120,8 +122,8 @@ public class ExperienceExtractionService {
         List<Conflict> mergeCandidates = new ArrayList<>();
         if (aiResponse.getExperiences() != null) {
             for (AiStep2Response.Step2ExperienceDto dto : aiResponse.getExperiences()) {
-                ExperienceGroup group = convertGroup(dto.getExperience_group());
-                ExperienceType type = convertType(dto.getExperience_type());
+                ExperienceGroup group = conversionUtils.convertGroup(dto.getExperience_group());
+                ExperienceType type = conversionUtils.convertType(dto.getExperience_type());
 
                 experienceMergeService.buildStep2MergeCandidate(user, dto, type, group)
                         .ifPresent(mergeCandidates::add);
@@ -198,29 +200,4 @@ public class ExperienceExtractionService {
         return new Step3Response(savedExperiences, skippedCount);
     }
 
-    private ExperienceGroup convertGroup(String koreanGroup) {
-        return switch (koreanGroup) {
-            case "상세 서술형" -> ExperienceGroup.NARRATIVE;
-            case "스펙·증빙형" -> ExperienceGroup.SPEC;
-            default -> throw new IllegalArgumentException(
-                    "지원하지 않는 경험 그룹입니다: " + koreanGroup
-            );
-        };
-    }
-
-    private ExperienceType convertType(String koreanType) {
-        return ExperienceType.fromKoreanName(koreanType);
-    }
-
-    private void validateGroupType(ExperienceGroup group, ExperienceType type) {
-        if (presetRegistry.getExperienceGroup(type) != group) {
-            throw new IllegalArgumentException(
-                    "경험 그룹과 유형이 일치하지 않습니다: " + type.getKoreanName()
-            );
-        }
-    }
-
-    private String toKoreanGroup(ExperienceGroup group) {
-        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
-    }
 }

--- a/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceExtractionV2Service.java
@@ -16,6 +16,7 @@ import back.pickd.experience.enums.Status;
 import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
 import back.pickd.experience.repository.ExperienceTempRepository;
 import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.experience.support.ExperienceConversionUtils;
 import back.pickd.experience.support.PresetRegistry;
 import back.pickd.global.infra.ai.AiClient;
 import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
@@ -44,6 +45,7 @@ public class ExperienceExtractionV2Service {
     private final UserService userService;
     private final ExperienceMergeService experienceMergeService;
     private final PresetRegistry presetRegistry;
+    private final ExperienceConversionUtils conversionUtils;
 
     @Transactional
     public Step2Response extractStep2(String email, List<Long> selectedTempIds) {
@@ -58,7 +60,7 @@ public class ExperienceExtractionV2Service {
         List<AiStep1Response.ExperienceSummaryDto> summaries = selectedExperiences.stream()
                 .map(selected -> new AiStep1Response.ExperienceSummaryDto(
                         selected.temp().getExperienceName(),
-                        toKoreanGroup(selected.group()),
+                        conversionUtils.toKoreanGroup(selected.group()),
                         selected.type().getKoreanName()
                 ))
                 .toList();
@@ -294,7 +296,7 @@ public class ExperienceExtractionV2Service {
     private SelectedExperience toSelectedExperience(ExperienceTemp temp) {
         ExperienceType type = temp.getExperienceType();
         ExperienceGroup group = temp.getExperienceGroup();
-        validateGroupType(group, type);
+        conversionUtils.validateGroupType(group, type);
         return new SelectedExperience(temp, type, group);
     }
 
@@ -310,8 +312,8 @@ public class ExperienceExtractionV2Service {
         }
         for (int index = 0; index < response.getExperiences().size(); index++) {
             AiStep2Response.Step2ExperienceDto dto = response.getExperiences().get(index);
-            ExperienceType responseType = convertType(dto.getExperience_type());
-            ExperienceGroup responseGroup = convertGroup(dto.getExperience_group());
+            ExperienceType responseType = conversionUtils.convertType(dto.getExperience_type());
+            ExperienceGroup responseGroup = conversionUtils.convertGroup(dto.getExperience_group());
             SelectedExperience selected = selectedExperiences.get(index);
             if (responseType != selected.type() || responseGroup != selected.group()) {
                 throw new IllegalStateException("AI 2차 경험 유형이 선택한 1차 경험과 일치하지 않습니다.");
@@ -416,32 +418,6 @@ public class ExperienceExtractionV2Service {
             }
         }
         return indexed;
-    }
-
-    private ExperienceGroup convertGroup(String koreanGroup) {
-        return switch (koreanGroup) {
-            case "상세 서술형" -> ExperienceGroup.NARRATIVE;
-            case "스펙·증빙형" -> ExperienceGroup.SPEC;
-            default -> throw new IllegalArgumentException(
-                    "지원하지 않는 경험 그룹입니다: " + koreanGroup
-            );
-        };
-    }
-
-    private ExperienceType convertType(String koreanType) {
-        return ExperienceType.fromKoreanName(koreanType);
-    }
-
-    private void validateGroupType(ExperienceGroup group, ExperienceType type) {
-        if (presetRegistry.getExperienceGroup(type) != group) {
-            throw new IllegalArgumentException(
-                    "경험 그룹과 유형이 일치하지 않습니다: " + type.getKoreanName()
-            );
-        }
-    }
-
-    private String toKoreanGroup(ExperienceGroup group) {
-        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
     }
 
     private record SelectedExperience(

--- a/src/main/java/back/pickd/experience/service/ExperienceMergeService.java
+++ b/src/main/java/back/pickd/experience/service/ExperienceMergeService.java
@@ -8,6 +8,7 @@ import back.pickd.experience.dto.ExperienceCreateDto.Request;
 import back.pickd.experience.dto.ExperienceMergeDto.Candidate;
 import back.pickd.experience.dto.ExperienceMergeDto.Conflict;
 import back.pickd.experience.dto.ExperienceMergeDto.Draft;
+import back.pickd.experience.support.ExperienceConversionUtils;
 import back.pickd.user.entity.User;
 import back.pickd.experience.entity.UserExperience;
 import back.pickd.experience.enums.ExperienceGroup;
@@ -30,6 +31,7 @@ public class ExperienceMergeService {
 
     private final AiClient aiClient;
     private final UserExperienceRepository userExperienceRepository;
+    private final ExperienceConversionUtils conversionUtils;
 
     public List<AiExperienceMergeCheckRequest.ExperiencePayload> buildExistingExperiencePayloads(User user) {
         return userExperienceRepository.findByUserOrderByCreatedAtDesc(user)
@@ -133,8 +135,8 @@ public class ExperienceMergeService {
                 .id(experience.getId())
                 .title(experience.getTitle())
                 .experienceName(experience.getTitle())
-                .experienceGroup(toKoreanGroup(experience.getExperienceGroup()))
-                .experienceType(toKoreanType(experience.getExperienceType()))
+                .experienceGroup(conversionUtils.toKoreanGroup(experience.getExperienceGroup()))
+                .experienceType(conversionUtils.toKoreanType(experience.getExperienceType()))
                 .keywords(experience.getKeywords() != null ? experience.getKeywords() : new ArrayList<>())
                 .attributes(experience.getAttributes() != null ? experience.getAttributes() : new HashMap<>())
                 .documentContent(experience.getDocumentContent())
@@ -145,22 +147,12 @@ public class ExperienceMergeService {
         return AiExperienceMergeCheckRequest.ExperiencePayload.builder()
                 .title(request.getTitle())
                 .experienceName(request.getTitle())
-                .experienceGroup(toKoreanGroup(request.getExperienceGroup()))
-                .experienceType(toKoreanType(request.getExperienceType()))
+                .experienceGroup(conversionUtils.toKoreanGroup(request.getExperienceGroup()))
+                .experienceType(conversionUtils.toKoreanType(request.getExperienceType()))
                 .keywords(request.getKeywords() != null ? request.getKeywords() : new ArrayList<>())
                 .attributes(request.getAttributes() != null ? request.getAttributes() : new HashMap<>())
                 .documentContent(request.getDocumentContent())
                 .build();
     }
 
-    private String toKoreanGroup(ExperienceGroup group) {
-        if (group == null) {
-            return null;
-        }
-        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
-    }
-
-    private String toKoreanType(ExperienceType type) {
-        return type != null ? type.getKoreanName() : null;
-    }
 }

--- a/src/main/java/back/pickd/experience/support/ExperienceConversionUtils.java
+++ b/src/main/java/back/pickd/experience/support/ExperienceConversionUtils.java
@@ -1,0 +1,44 @@
+package back.pickd.experience.support;
+
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Experience 도메인에서 반복 사용되는 Enum ↔ 한국어 변환 유틸리티.
+ * ExperienceExtractionService, ExperienceExtractionV2Service, ExperienceMergeService에서 중복 제거.
+ */
+@Component
+@RequiredArgsConstructor
+public class ExperienceConversionUtils {
+
+    private final PresetRegistry presetRegistry;
+
+    public ExperienceGroup convertGroup(String koreanGroup) {
+        return switch (koreanGroup) {
+            case "상세 서술형" -> ExperienceGroup.NARRATIVE;
+            case "스펙·증빙형" -> ExperienceGroup.SPEC;
+            default -> throw new IllegalArgumentException("지원하지 않는 경험 그룹입니다: " + koreanGroup);
+        };
+    }
+
+    public ExperienceType convertType(String koreanType) {
+        return ExperienceType.fromKoreanName(koreanType);
+    }
+
+    public String toKoreanGroup(ExperienceGroup group) {
+        if (group == null) return null;
+        return group == ExperienceGroup.NARRATIVE ? "상세 서술형" : "스펙·증빙형";
+    }
+
+    public String toKoreanType(ExperienceType type) {
+        return type != null ? type.getKoreanName() : null;
+    }
+
+    public void validateGroupType(ExperienceGroup group, ExperienceType type) {
+        if (presetRegistry.getExperienceGroup(type) != group) {
+            throw new IllegalArgumentException("경험 그룹과 유형이 일치하지 않습니다: " + type.getKoreanName());
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항

closes #76

### 문제
`convertGroup()`, `convertType()`, `toKoreanGroup()`, `validateGroupType()` 4개 메서드가
`ExperienceExtractionService`, `ExperienceExtractionV2Service`, `ExperienceMergeService` 3곳에 완전히 동일하게 중복

### 변경
- `experience/support/ExperienceConversionUtils` 신규 `@Component` 생성
- 3개 서비스에서 중복 메서드 제거 후 `conversionUtils` 위임으로 교체
- `toKoreanType()`도 `MergeService`에서 추출하여 유틸에 통합