### PR TITLE
test: ExperienceConversionUtils mock stubbing 추가 (#78)

### DIFF
--- a/src/test/java/back/pickd/experience/service/ExperienceExtractionServiceTest.java
+++ b/src/test/java/back/pickd/experience/service/ExperienceExtractionServiceTest.java
@@ -8,6 +8,7 @@ import back.pickd.experience.enums.ExperienceType;
 import back.pickd.experience.enums.Status;
 import back.pickd.experience.repository.ExperienceTempRepository;
 import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.experience.support.ExperienceConversionUtils;
 import back.pickd.experience.support.PresetRegistry;
 import back.pickd.global.infra.ai.AiClient;
 import back.pickd.global.infra.ai.dto.AiStep1Response;
@@ -58,6 +59,9 @@ class ExperienceExtractionServiceTest {
     @Mock
     private PresetRegistry presetRegistry;
 
+    @Mock
+    private ExperienceConversionUtils conversionUtils;
+
     @InjectMocks
     private ExperienceExtractionService experienceExtractionService;
 
@@ -91,6 +95,8 @@ class ExperienceExtractionServiceTest {
         when(s3Service.uploadFile(file, FileUploadType.TEMP_RESUME, null))
                 .thenReturn("https://cdn/resume.pdf");
         when(aiClient.extractStep1(file)).thenReturn(aiResponse);
+        when(conversionUtils.convertType("창업"))
+                .thenThrow(new IllegalArgumentException("지원하지 않는 경험 유형입니다: 창업"));
 
         assertThrows(
                 IllegalArgumentException.class,

--- a/src/test/java/back/pickd/experience/service/ExperienceMergeServiceTest.java
+++ b/src/test/java/back/pickd/experience/service/ExperienceMergeServiceTest.java
@@ -5,6 +5,8 @@ import back.pickd.experience.enums.ExperienceGroup;
 import back.pickd.experience.enums.ExperienceType;
 import back.pickd.experience.enums.Status;
 import back.pickd.experience.repository.UserExperienceRepository;
+import back.pickd.experience.support.ExperienceConversionUtils;
+import back.pickd.experience.support.PresetRegistry;
 import back.pickd.global.infra.ai.AiClient;
 import back.pickd.global.infra.ai.dto.AiExperienceMergeCheckRequest;
 import back.pickd.user.entity.User;
@@ -29,6 +31,12 @@ class ExperienceMergeServiceTest {
     @Mock
     private UserExperienceRepository userExperienceRepository;
 
+    @Mock
+    private PresetRegistry presetRegistry;
+
+    @Mock
+    private ExperienceConversionUtils conversionUtils;
+
     @InjectMocks
     private ExperienceMergeService experienceMergeService;
 
@@ -50,6 +58,8 @@ class ExperienceMergeServiceTest {
                 .keywords(List.of("문제 해결"))
                 .build();
         when(userExperienceRepository.findByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(experience));
+        when(conversionUtils.toKoreanGroup(ExperienceGroup.NARRATIVE)).thenReturn("상세 서술형");
+        when(conversionUtils.toKoreanType(ExperienceType.PROJECT)).thenReturn("프로젝트");
 
         List<AiExperienceMergeCheckRequest.ExperiencePayload> payloads =
                 experienceMergeService.buildExistingExperiencePayloads(user);


### PR DESCRIPTION
### 변경 사항

- ExperienceExtractionServiceTest: convertType("창업") → IllegalArgumentException throw stub 추가
- ExperienceMergeServiceTest: toKoreanGroup / toKoreanType 반환값 stub 추가

### 원인
- #76에서 ExperienceConversionUtils를 @Component로 추출한 후, 테스트에서 mock은 주입했지만 메서드 stub이 누락되어 NPE/assertion 실패 발생