### PR TITLE
refactor : ifelse 체이닝 제거 

### DIFF
--- a/src/main/java/back/pickd/experience/dto/ExperienceExtractionDto.java
+++ b/src/main/java/back/pickd/experience/dto/ExperienceExtractionDto.java
@@ -38,8 +38,8 @@ public final class ExperienceExtractionDto {
             this.id = temp.getId();
             this.userId = temp.getUser().getId();
             this.experienceName = temp.getExperienceName();
-            this.experienceGroup = temp.getExperienceGroup();
-            this.experienceType = temp.getExperienceType();
+            this.experienceGroup = temp.getExperienceGroup() != null ? temp.getExperienceGroup().name() : null;
+            this.experienceType = temp.getExperienceType() != null ? temp.getExperienceType().name() : null;
             this.createdAt = temp.getCreatedAt();
         }
     }

--- a/src/main/java/back/pickd/experience/dto/ExperienceExtractionTestDto.java
+++ b/src/main/java/back/pickd/experience/dto/ExperienceExtractionTestDto.java
@@ -43,8 +43,8 @@ public final class ExperienceExtractionTestDto {
             return new TempState(
                     temp.getId(),
                     temp.getExperienceName(),
-                    temp.getExperienceGroup(),
-                    temp.getExperienceType(),
+                    temp.getExperienceGroup() != null ? temp.getExperienceGroup().name() : null,
+                    temp.getExperienceType() != null ? temp.getExperienceType().name() : null,
                     temp.getResumeUrl(),
                     temp.getCreatedAt()
             );

--- a/src/main/java/back/pickd/experience/enums/ExperienceType.java
+++ b/src/main/java/back/pickd/experience/enums/ExperienceType.java
@@ -1,5 +1,7 @@
 package back.pickd.experience.enums;
 
+import java.util.Map;
+
 public enum ExperienceType {
     PROJECT("프로젝트"),
     ACTIVITY("대외활동"),
@@ -32,5 +34,29 @@ public enum ExperienceType {
             }
         }
         throw new IllegalArgumentException("지원하지 않는 경험 유형입니다: " + koreanName);
+    }
+
+    /**
+     * 이 경험 유형의 기본 그룹을 반환한다.
+     * 스펙·증빙 계열(AWARD, LICENSE, LANGUAGE, COURSE, EXCHANGE)은 SPEC,
+     * 나머지는 NARRATIVE.
+     */
+    public ExperienceGroup defaultGroup() {
+        return switch (this) {
+            case AWARD, LICENSE, LANGUAGE, COURSE, EXCHANGE -> ExperienceGroup.SPEC;
+            default -> ExperienceGroup.NARRATIVE;
+        };
+    }
+
+    /**
+     * 이 경험 유형에 맞는 attributes 맵을 생성한다.
+     * AWARD는 award_date 키, 나머지는 period 키를 사용한다.
+     */
+    public Map<String, Object> buildAttributes(String startDate, String endDate) {
+        if (this == AWARD) {
+            return Map.of("award_date", endDate != null ? endDate : "");
+        }
+        String period = (startDate != null ? startDate : "") + " ~ " + (endDate != null ? endDate : "");
+        return Map.of("period", period);
     }
 }

--- a/src/main/java/back/pickd/user/dto/onboarding/OnboardingRequest.java
+++ b/src/main/java/back/pickd/user/dto/onboarding/OnboardingRequest.java
@@ -2,6 +2,7 @@ package back.pickd.user.dto.onboarding;
 
 import back.pickd.user.entity.enums.DegreeType;
 import back.pickd.user.entity.enums.EnrollmentStatus;
+import back.pickd.user.entity.enums.OnboardingStep;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -59,6 +60,20 @@ public class OnboardingRequest {
     private Boolean hasPortfolio;
     private List<ExperienceDto> experiences;
     private List<CertificationDto> certifications;
+
+    /**
+     * 요청에 포함된 필드를 기반으로 현재 온보딩 단계를 판별한다.
+     * 각 단계를 나타내는 대표 필드가 null이 아니면 해당 단계로 판단한다.
+     */
+    public OnboardingStep detectStep() {
+        if (targetPeriod != null)  return OnboardingStep.COMPLETED;
+        if (industries != null)    return OnboardingStep.INTERESTS;
+        if (schoolName != null)    return OnboardingStep.EDUCATION;
+        if (nickname != null)      return OnboardingStep.BASIC;
+        if (name != null)          return OnboardingStep.VERIFICATION;
+        if (serviceAgreed != null) return OnboardingStep.TERMS;
+        return null;
+    }
 
     @Getter @NoArgsConstructor
     public static class ExperienceDto {

--- a/src/main/java/back/pickd/user/service/OnboardingService.java
+++ b/src/main/java/back/pickd/user/service/OnboardingService.java
@@ -2,15 +2,14 @@ package back.pickd.user.service;
 
 import back.pickd.user.dto.onboarding.OnboardingRequest;
 import back.pickd.experience.entity.UserExperience;
-import back.pickd.experience.enums.ExperienceGroup;
 import back.pickd.experience.enums.ExperienceType;
 import back.pickd.experience.enums.Status;
 import back.pickd.experience.repository.ExperienceExtractionBatchRepository;
 import back.pickd.experience.repository.UserExperienceRepository;
 import back.pickd.user.entity.*;
 import back.pickd.user.entity.enums.*;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import back.pickd.user.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -79,75 +78,45 @@ public class OnboardingService {
     }
 
     private void updateCurrentStep(User user, OnboardingRequest dto) {
-        if (dto.getTargetPeriod() != null) user.updateOnboardingStep(OnboardingStep.COMPLETED);
-        else if (dto.getIndustries() != null) user.updateOnboardingStep(OnboardingStep.INTERESTS);
-        else if (dto.getSchoolName() != null) user.updateOnboardingStep(OnboardingStep.EDUCATION);
-        else if (dto.getNickname() != null) user.updateOnboardingStep(OnboardingStep.BASIC);
-        else if (dto.getName() != null) user.updateOnboardingStep(OnboardingStep.VERIFICATION);
-        else if (dto.getServiceAgreed() != null) user.updateOnboardingStep(OnboardingStep.TERMS);
+        OnboardingStep step = dto.detectStep();
+        if (step != null) user.updateOnboardingStep(step);
     }
 
     private void updateListInfos(User user, OnboardingRequest dto) {
         if (dto.getExperiences() != null) {
             deleteExistingExperiences(user);
-            dto.getExperiences().forEach(e -> {
-                ExperienceType expType = ExperienceType.PROJECT;
-                ExperienceGroup expGroup = ExperienceGroup.NARRATIVE;
-                
-                String rawType = e.getType();
-                if ("AWARD".equals(rawType)) {
-                    expType = ExperienceType.AWARD;
-                    expGroup = ExperienceGroup.SPEC;
-                } else if ("INTERN".equals(rawType)) {
-                    expType = ExperienceType.INTERN;
-                    expGroup = ExperienceGroup.NARRATIVE;
-                } else if ("ACTIVITY".equals(rawType)) {
-                    expType = ExperienceType.ACTIVITY;
-                    expGroup = ExperienceGroup.NARRATIVE;
-                } else if ("PROJECT".equals(rawType)) {
-                    expType = ExperienceType.PROJECT;
-                    expGroup = ExperienceGroup.NARRATIVE;
-                }
-
-                Map<String, Object> attributes = new HashMap<>();
-                String periodVal = (e.getStartDate() != null ? e.getStartDate() : "") 
-                        + " ~ " 
-                        + (e.getEndDate() != null ? e.getEndDate() : "");
-                
-                if (expType == ExperienceType.AWARD) {
-                    attributes.put("award_date", e.getEndDate());
-                } else if (expType == ExperienceType.INTERN) {
-                    attributes.put("period", periodVal);
-                } else if (expType == ExperienceType.ACTIVITY) {
-                    attributes.put("period", periodVal);
-                } else {
-                    attributes.put("period", periodVal);
-                }
-
-                experienceRepository.save(
+            List<UserExperience> experiences = new ArrayList<>();
+            for (OnboardingRequest.ExperienceDto e : dto.getExperiences()) {
+                ExperienceType expType = ExperienceType.valueOf(e.getType());
+                experiences.add(
                     UserExperience.builder()
                         .user(user)
                         .title(e.getTitle())
                         .experienceType(expType)
-                        .experienceGroup(expGroup)
+                        .experienceGroup(expType.defaultGroup())
                         .status(Status.COMPLETED)
-                        .attributes(attributes)
+                        .attributes(expType.buildAttributes(e.getStartDate(), e.getEndDate()))
                         .documentContent("")
                         .build()
                 );
-            });
+            }
+            experienceRepository.saveAll(experiences);
         }
         if (dto.getCertifications() != null) {
             certificationRepository.deleteByUser(user);
-            dto.getCertifications().forEach(c -> certificationRepository.save(
-                UserCertification.builder()
-                    .user(user)
-                    .type("LICENSE")
-                    .name(c.getName())
-                    .score(c.getScore())
-                    .acquisitionDate(c.getAcquisitionDate())
-                    .build()
-            ));
+            List<UserCertification> certifications = new ArrayList<>();
+            for (OnboardingRequest.CertificationDto c : dto.getCertifications()) {
+                certifications.add(
+                    UserCertification.builder()
+                        .user(user)
+                        .type("LICENSE")
+                        .name(c.getName())
+                        .score(c.getScore())
+                        .acquisitionDate(c.getAcquisitionDate())
+                        .build()
+                );
+            }
+            certificationRepository.saveAll(certifications);
         }
     }
 


### PR DESCRIPTION
## 개요
OnboardingService의 if/else 체인을 제거하고 각 책임을 적절한 위치로 이동.

## 변경 사항
- **ExperienceType.java**: `defaultGroup()`, `buildAttributes()` 메서드 추가 — 타입별 그룹/attributes 결정 로직을 enum이 직접 보유
- **OnboardingRequest.java**: `detectStep()` 추가 — 온보딩 단계 판별 로직을 서비스가 아닌 DTO가 담당
- **OnboardingService.java**: if/else 4단계 → `valueOf` + enum 위임, if/else 6단계 → `detectStep()` 1줄, 루프 내 `save()` 반복 → `saveAll()` 교체

## 관련 이슈
Closes #84

## 테스트
- [ ] `./gradlew test`