### PR TITLE
refactor : 직접 엔티티 반환하던 것을 Dto로 매핑

### DIFF
--- a/src/main/java/back/pickd/document/controller/DocumentController.java
+++ b/src/main/java/back/pickd/document/controller/DocumentController.java
@@ -1,7 +1,7 @@
 package back.pickd.document.controller;
 
 import back.pickd.document.dto.DocumentRequest;
-import back.pickd.document.entity.Document;
+import back.pickd.document.dto.DocumentResponse;
 import back.pickd.document.service.DocumentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -17,26 +17,26 @@ public class DocumentController {
     private final DocumentService documentService;
 
     @GetMapping
-    public List<Document> getAllDocuments(Authentication auth) {
+    public List<DocumentResponse> getAllDocuments(Authentication auth) {
         return documentService.getAllDocuments(auth);
     }
 
     @GetMapping("/{applicationId}")
-    public List<Document> getDocuments(@PathVariable Long applicationId, Authentication auth) {
+    public List<DocumentResponse> getDocuments(@PathVariable Long applicationId, Authentication auth) {
         return documentService.getDocuments(applicationId, auth);
     }
 
     @PostMapping("/{applicationId}")
-    public Document addDocument(@PathVariable Long applicationId,
-                                @RequestBody DocumentRequest request,
-                                Authentication auth) {
+    public DocumentResponse addDocument(@PathVariable Long applicationId,
+                                        @RequestBody DocumentRequest request,
+                                        Authentication auth) {
         return documentService.addDocument(applicationId, request, auth);
     }
 
     @PutMapping("/{id}")
-    public Document updateDocument(@PathVariable Long id,
-                                   @RequestBody DocumentRequest request,
-                                   Authentication auth) {
+    public DocumentResponse updateDocument(@PathVariable Long id,
+                                           @RequestBody DocumentRequest request,
+                                           Authentication auth) {
         return documentService.updateDocument(id, request, auth);
     }
 

--- a/src/main/java/back/pickd/document/dto/DocumentResponse.java
+++ b/src/main/java/back/pickd/document/dto/DocumentResponse.java
@@ -1,0 +1,36 @@
+package back.pickd.document.dto;
+
+import back.pickd.document.entity.Document;
+import back.pickd.document.enums.DocumentStatus;
+import back.pickd.document.enums.DocumentType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class DocumentResponse {
+
+    private final Long id;
+    private final Long applicationId;
+    private final String title;
+    private final String company;
+    private final DocumentType type;
+    private final DocumentStatus status;
+    private final Integer progress;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public DocumentResponse(Document document) {
+        this.id = document.getId();
+        this.applicationId = document.getApplication() != null ? document.getApplication().getId() : null;
+        this.title = document.getTitle();
+        this.company = document.getCompany();
+        this.type = document.getType();
+        this.status = document.getStatus();
+        this.progress = document.getProgress();
+        this.content = document.getContent();
+        this.createdAt = document.getCreatedAt();
+        this.updatedAt = document.getUpdatedAt();
+    }
+}

--- a/src/main/java/back/pickd/document/service/DocumentService.java
+++ b/src/main/java/back/pickd/document/service/DocumentService.java
@@ -3,6 +3,7 @@ package back.pickd.document.service;
 import back.pickd.application.entity.Application;
 import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.document.dto.DocumentRequest;
+import back.pickd.document.dto.DocumentResponse;
 import back.pickd.document.entity.Document;
 import back.pickd.document.repository.DocumentRepository;
 import back.pickd.user.entity.User;
@@ -23,19 +24,21 @@ public class DocumentService {
     private final UserService userService;
 
     @Transactional(readOnly = true)
-    public List<Document> getDocuments(Long applicationId, Authentication auth) {
+    public List<DocumentResponse> getDocuments(Long applicationId, Authentication auth) {
         User user = userService.findByEmail(auth.getName());
-        return documentRepository.findAllByApplicationIdAndUser(applicationId, user);
+        return documentRepository.findAllByApplicationIdAndUser(applicationId, user)
+                .stream().map(DocumentResponse::new).toList();
     }
 
     @Transactional(readOnly = true)
-    public List<Document> getAllDocuments(Authentication auth) {
+    public List<DocumentResponse> getAllDocuments(Authentication auth) {
         User user = userService.findByEmail(auth.getName());
-        return documentRepository.findAllByUserOrderByIdDesc(user);
+        return documentRepository.findAllByUserOrderByIdDesc(user)
+                .stream().map(DocumentResponse::new).toList();
     }
 
     @Transactional
-    public Document addDocument(Long applicationId, DocumentRequest request, Authentication auth) {
+    public DocumentResponse addDocument(Long applicationId, DocumentRequest request, Authentication auth) {
         User user = userService.findByEmail(auth.getName());
         Application application = applicationRepository.findByIdAndUser(applicationId, user)
                 .orElseThrow(() -> new IllegalArgumentException("지원 공고를 찾을 수 없습니다."));
@@ -51,11 +54,11 @@ public class DocumentService {
                 .content(request.getContent())
                 .build();
 
-        return documentRepository.save(document);
+        return new DocumentResponse(documentRepository.save(document));
     }
 
     @Transactional
-    public Document updateDocument(Long id, DocumentRequest request, Authentication auth) {
+    public DocumentResponse updateDocument(Long id, DocumentRequest request, Authentication auth) {
         User user = userService.findByEmail(auth.getName());
         Document document = documentRepository.findByIdAndUser(id, user)
                 .orElseThrow(() -> new IllegalArgumentException("서류를 찾을 수 없습니다."));
@@ -68,7 +71,7 @@ public class DocumentService {
                 request.getProgress(),
                 request.getContent()
         );
-        return documentRepository.save(document);
+        return new DocumentResponse(document);
     }
 
     @Transactional

--- a/src/test/java/back/pickd/document/service/DocumentServiceTest.java
+++ b/src/test/java/back/pickd/document/service/DocumentServiceTest.java
@@ -4,6 +4,7 @@ import back.pickd.application.entity.Application;
 import back.pickd.application.enums.ApplicationStatus;
 import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.document.dto.DocumentRequest;
+import back.pickd.document.dto.DocumentResponse;
 import back.pickd.document.entity.Document;
 import back.pickd.document.enums.DocumentStatus;
 import back.pickd.document.enums.DocumentType;
@@ -90,7 +91,7 @@ class DocumentServiceTest {
             Document doc2 = buildDocument();
             when(documentRepository.findAllByUserOrderByIdDesc(user)).thenReturn(List.of(doc2, doc1));
 
-            List<Document> result = documentService.getAllDocuments(authentication);
+            List<DocumentResponse> result = documentService.getAllDocuments(authentication);
 
             assertThat(result).hasSize(2);
             verify(documentRepository).findAllByUserOrderByIdDesc(user);
@@ -109,7 +110,7 @@ class DocumentServiceTest {
             when(documentRepository.findAllByApplicationIdAndUser(1L, user))
                     .thenReturn(List.of(buildDocument()));
 
-            List<Document> result = documentService.getDocuments(1L, authentication);
+            List<DocumentResponse> result = documentService.getDocuments(1L, authentication);
 
             assertThat(result).hasSize(1);
             verify(documentRepository).findAllByApplicationIdAndUser(1L, user);
@@ -173,7 +174,6 @@ class DocumentServiceTest {
         void updatesDocumentContent() {
             Document doc = buildDocument();
             when(documentRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(doc));
-            when(documentRepository.save(doc)).thenReturn(doc);
 
             DocumentRequest req = buildRequest();
             req.setTitle("수정된 자소서");


### PR DESCRIPTION
## 개요
DocumentController의 4개 엔드포인트가 Document 엔티티를 직접 반환하던 것을 DocumentResponse DTO로 교체.

## 변경 사항
- **DocumentResponse.java**: 신규 생성. id, applicationId, title, company, type, status, progress, content, createdAt, updatedAt 포함. user 정보 미노출.
- **DocumentService.java**: 반환 타입 `Document` → `DocumentResponse`, updateDocument 불필요한 save() 제거
- **DocumentController.java**: 반환 타입 교체
- **DocumentServiceTest.java**: 반환 타입 및 불필요 stub 수정
- **ExperienceExtractionDto/TestDto**: ExperienceTemp Enum 전환 후 String 변환 누락 수정

## 관련 이슈
Closes #85

## 테스트
- [x] `./gradlew test` 110 tests passed