### PR TITLE
fix: 값 검증 및 예외 처리 강화 (closes #90)

### DIFF
--- a/src/main/java/back/pickd/application/controller/ApplicationController.java
+++ b/src/main/java/back/pickd/application/controller/ApplicationController.java
@@ -3,6 +3,7 @@ package back.pickd.application.controller;
 import back.pickd.application.dto.request.ApplicationRequest;
 import back.pickd.application.dto.response.ApplicationResponse;
 import back.pickd.application.service.ApplicationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +23,7 @@ public class ApplicationController {
     }
 
     @PostMapping
-    public void add(@RequestBody ApplicationRequest dto, Authentication auth) throws Exception {
+    public void add(@RequestBody @Valid ApplicationRequest dto, Authentication auth) throws Exception {
         applicationService.addApplication(dto, auth);
     }
 
@@ -33,7 +34,7 @@ public class ApplicationController {
 
     @PutMapping("/{id}")
     public void update(@PathVariable Long id,
-                       @RequestBody ApplicationRequest dto,
+                       @RequestBody @Valid ApplicationRequest dto,
                        Authentication auth) throws Exception {
         applicationService.updateApplication(id, dto, auth);
     }

--- a/src/main/java/back/pickd/application/controller/ApplicationController.java
+++ b/src/main/java/back/pickd/application/controller/ApplicationController.java
@@ -3,6 +3,16 @@ package back.pickd.application.controller;
 import back.pickd.application.dto.request.ApplicationRequest;
 import back.pickd.application.dto.response.ApplicationResponse;
 import back.pickd.application.service.ApplicationService;
+import back.pickd.global.config.OpenApiConfig;
+import back.pickd.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -13,29 +23,62 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/application")
+@Tag(name = "Application", description = "지원 공고 관리 API")
+@SecurityRequirement(name = OpenApiConfig.COOKIE_AUTH)
 public class ApplicationController {
 
     private final ApplicationService applicationService;
 
     @GetMapping
-    public List<ApplicationResponse> getAll(Authentication auth) {
+    @Operation(summary = "지원 공고 목록 조회", description = "로그인 사용자의 전체 지원 공고를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ApplicationResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public List<ApplicationResponse> getAll(@Parameter(hidden = true) Authentication auth) {
         return applicationService.getApplications(auth);
     }
 
     @PostMapping
-    public void add(@RequestBody @Valid ApplicationRequest dto, Authentication auth) throws Exception {
+    @Operation(summary = "지원 공고 추가", description = "새 지원 공고를 등록합니다. noticeId가 있으면 채용공고와 연결됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "추가 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 유효성 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public void add(@RequestBody @Valid ApplicationRequest dto, @Parameter(hidden = true) Authentication auth) throws Exception {
         applicationService.addApplication(dto, auth);
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id, Authentication auth) throws Exception {
+    @Operation(summary = "지원 공고 삭제", description = "본인 소유의 지원 공고를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "소유권 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public void delete(@PathVariable Long id, @Parameter(hidden = true) Authentication auth) throws Exception {
         applicationService.deleteApplication(id, auth);
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "지원 공고 수정", description = "지원 공고 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "소유권 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public void update(@PathVariable Long id,
                        @RequestBody @Valid ApplicationRequest dto,
-                       Authentication auth) throws Exception {
+                       @Parameter(hidden = true) Authentication auth) throws Exception {
         applicationService.updateApplication(id, dto, auth);
     }
 }

--- a/src/main/java/back/pickd/calendar/controller/CalendarRestController.java
+++ b/src/main/java/back/pickd/calendar/controller/CalendarRestController.java
@@ -2,9 +2,19 @@ package back.pickd.calendar.controller;
 
 import back.pickd.calendar.dto.CalendarEventRequest;
 import back.pickd.calendar.service.CalendarService;
+import back.pickd.global.config.OpenApiConfig;
+import back.pickd.global.error.ErrorResponse;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventDateTime;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -17,17 +27,26 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/calendar")
 @RequiredArgsConstructor
+@Tag(name = "Calendar", description = "Google Calendar 연동 일정 관리 API")
+@SecurityRequirement(name = OpenApiConfig.COOKIE_AUTH)
 public class CalendarRestController {
 
     private final CalendarService calendarService;
 
-    /**
-     * 일정 목록 조회
-     */
     @GetMapping("/events")
-    public List<Event> getEvents(Authentication authentication,
-                                @RequestParam(required = false) String timeMin,
-                                @RequestParam(required = false) String timeMax)
+    @Operation(
+            summary = "일정 목록 조회",
+            description = "현재 시점 기준 1년 전 ~ 1년 후 범위의 Google Calendar 일정을 반환합니다. timeMin/timeMax 파라미터는 현재 미적용(서버 내부 범위 고정)입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public List<Event> getEvents(
+            @Parameter(hidden = true) Authentication authentication,
+            @Parameter(description = "조회 시작 시각 (현재 미적용)") @RequestParam(required = false) String timeMin,
+            @Parameter(description = "조회 종료 시각 (현재 미적용)") @RequestParam(required = false) String timeMax)
             throws IOException, GeneralSecurityException {
 
         java.util.TimeZone tz = java.util.TimeZone.getTimeZone("Asia/Seoul");
@@ -42,11 +61,16 @@ public class CalendarRestController {
         return calendarService.getEvents(authentication, min, max);
     }
 
-    /**
-     * 일정 등록
-     */
     @PostMapping("/events")
-    public Event createEvent(Authentication authentication, @RequestBody @Valid CalendarEventRequest requestDto) throws IOException, GeneralSecurityException {
+    @Operation(summary = "일정 등록", description = "Google Calendar에 새 일정을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public Event createEvent(
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody @Valid CalendarEventRequest requestDto) throws IOException, GeneralSecurityException {
         Event event = new Event()
                 .setSummary(requestDto.getSummary())
                 .setLocation(requestDto.getLocation())
@@ -67,33 +91,44 @@ public class CalendarRestController {
         return calendarService.createEvent(authentication, event);
     }
 
-    /**
-     * 일정 수정 (부분 업데이트 지원)
-     */
     @PutMapping("/events/{eventId}")
-    public Event updateEvent(Authentication authentication, 
-                            @PathVariable String eventId, 
-                            @RequestBody @Valid CalendarEventRequest requestDto) throws IOException, GeneralSecurityException {
-        
+    @Operation(summary = "일정 수정", description = "기존 일정을 부분 업데이트합니다. null 필드는 변경되지 않습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public Event updateEvent(
+            @Parameter(hidden = true) Authentication authentication,
+            @PathVariable String eventId,
+            @RequestBody @Valid CalendarEventRequest requestDto) throws IOException, GeneralSecurityException {
+
         Event existingEvent = calendarService.getEvent(authentication, eventId);
-        
+
         if (requestDto.getSummary() != null) existingEvent.setSummary(requestDto.getSummary());
         if (requestDto.getLocation() != null) existingEvent.setLocation(requestDto.getLocation());
         if (requestDto.getDescription() != null) existingEvent.setDescription(requestDto.getDescription());
-        
+
         return calendarService.updateEvent(authentication, eventId, existingEvent);
     }
 
-    /**
-     * 일정 삭제
-     */
     @DeleteMapping("/events/{eventId}")
-    public void deleteEvent(Authentication authentication, @PathVariable String eventId) throws IOException, GeneralSecurityException {
+    @Operation(summary = "일정 삭제", description = "Google Calendar에서 일정을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public void deleteEvent(
+            @Parameter(hidden = true) Authentication authentication,
+            @PathVariable String eventId) throws IOException, GeneralSecurityException {
         calendarService.deleteEvent(authentication, eventId);
     }
 
     @GetMapping("/me")
-    public String me(Authentication authentication) {
+    @Operation(summary = "인증 사용자 이메일 확인", description = "현재 인증된 사용자의 이메일을 반환합니다. (디버그용)")
+    @ApiResponse(responseCode = "200", description = "이메일 반환")
+    public String me(@Parameter(hidden = true) Authentication authentication) {
         if (authentication == null) return null;
         return authentication.getName();
     }

--- a/src/main/java/back/pickd/calendar/controller/CalendarRestController.java
+++ b/src/main/java/back/pickd/calendar/controller/CalendarRestController.java
@@ -5,6 +5,7 @@ import back.pickd.calendar.service.CalendarService;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventDateTime;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -45,7 +46,7 @@ public class CalendarRestController {
      * 일정 등록
      */
     @PostMapping("/events")
-    public Event createEvent(Authentication authentication, @RequestBody CalendarEventRequest requestDto) throws IOException, GeneralSecurityException {
+    public Event createEvent(Authentication authentication, @RequestBody @Valid CalendarEventRequest requestDto) throws IOException, GeneralSecurityException {
         Event event = new Event()
                 .setSummary(requestDto.getSummary())
                 .setLocation(requestDto.getLocation())
@@ -72,7 +73,7 @@ public class CalendarRestController {
     @PutMapping("/events/{eventId}")
     public Event updateEvent(Authentication authentication, 
                             @PathVariable String eventId, 
-                            @RequestBody CalendarEventRequest requestDto) throws IOException, GeneralSecurityException {
+                            @RequestBody @Valid CalendarEventRequest requestDto) throws IOException, GeneralSecurityException {
         
         Event existingEvent = calendarService.getEvent(authentication, eventId);
         

--- a/src/main/java/back/pickd/calendar/service/CalendarService.java
+++ b/src/main/java/back/pickd/calendar/service/CalendarService.java
@@ -1,6 +1,7 @@
 package back.pickd.calendar.service;
 
 import back.pickd.application.entity.Todo;
+import back.pickd.global.error.ApiException;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
@@ -32,11 +33,11 @@ public class CalendarService {
     private static final ZoneId SEOUL_ZONE = ZoneId.of(TIME_ZONE);
 
     private Calendar getCalendarClient(Authentication authentication) throws IOException, GeneralSecurityException {
-        if (authentication == null) throw new RuntimeException("로그인 필요");
+        if (authentication == null) throw ApiException.unauthorized("로그인이 필요합니다.");
         OAuth2AuthorizedClient client =
                 authorizedClientService.loadAuthorizedClient("google", authentication.getName());
 
-        if (client == null) throw new RuntimeException("구글 연동 필요");
+        if (client == null) throw ApiException.unauthorized("Google 계정 연동이 필요합니다.");
         String token = client.getAccessToken().getTokenValue();
         GoogleCredentials credentials = GoogleCredentials.create(new AccessToken(token, null));
         NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();

--- a/src/main/java/back/pickd/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/back/pickd/global/error/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -14,6 +15,7 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 
 /**
  * 전역 예외 처리기 (Global Exception Handler)
@@ -25,6 +27,21 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e, HttpServletRequest request) {
         return buildErrorResponse(HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다: " + e.getResourcePath(), request);
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(ApiException e, HttpServletRequest request) {
+        log.warn("ApiException [{}]: {}", e.getStatus(), e.getMessage());
+        return buildErrorResponse(e.getStatus(), e.getMessage(), request);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("Validation failed: {}", message);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, message, request);
     }
 
     @ExceptionHandler({IOException.class, GeneralSecurityException.class})
@@ -39,12 +56,12 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({OAuth2AuthenticationException.class, RuntimeException.class})
-    public ResponseEntity<ErrorResponse> handleAuthException(Exception e, HttpServletRequest request) {
-        log.error("Authentication/Runtime Exception: {}", e.getMessage());
-        
-        HttpStatus status = e.getMessage().contains("로그인") || e.getMessage().contains("인증") 
+    public ResponseEntity<ErrorResponse> handleRuntimeException(Exception e, HttpServletRequest request) {
+        log.error("Runtime Exception: {}", e.getMessage());
+        String message = e.getMessage() != null ? e.getMessage() : "처리 중 오류가 발생했습니다.";
+        HttpStatus status = message.contains("로그인") || message.contains("인증")
                 ? HttpStatus.UNAUTHORIZED : HttpStatus.BAD_REQUEST;
-        return buildErrorResponse(status, e.getMessage(), request);
+        return buildErrorResponse(status, message, request);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 개요
값 검증 누락 및 예외 처리 불일치 문제를 수정합니다.

closes #90

## 변경 사항

### 값 검증 (`@Valid` 추가)
- `ApplicationController.add()`, `update()` — `@Valid` 누락으로 `ApplicationRequest.status`의 `@NotNull` 검증이 실행되지 않던 문제 수정
- `CalendarRestController.createEvent()`, `updateEvent()` — 향후 제약 조건 추가에 대비한 `@Valid` 추가

### 예외 처리

**`GlobalExceptionHandler`**
- `ApiException` 전용 핸들러 추가
  - 기존: `RuntimeException` 핸들러에서 처리되어 `ApiException`의 `status` 필드가 무시되고 항상 400 반환
  - 이후: `e.getStatus()`를 사용하여 의도한 HTTP 상태 코드 반환
- `MethodArgumentNotValidException` 핸들러 추가
  - `@Valid` 검증 실패 시 500 대신 400 반환, 실패한 필드명과 메시지를 응답에 포함
- `handleRuntimeException()` NPE 방지
  - `e.getMessage().contains()` → `null` 메시지 예외에서 NPE 발생 가능 → null 체크 후 기본 메시지 fallback 처리

**`CalendarService`**
- `getCalendarClient()` 내 `RuntimeException` → `ApiException.unauthorized()` 교체
  - 미로그인, Google 미연동 시 기존 400 → 401 반환

## 영향 범위
- 런타임 동작 변경: `ApiException` 발생 시 HTTP 상태 코드가 정확하게 반환됨
- Breaking 없음: 기존 정상 흐름은 변경 없음