### PR TITLE
fix: DB 무결성 및 성능 개선 (closes #93)

### DIFF
--- a/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
@@ -1,6 +1,8 @@
 package back.pickd.experience.entity;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,6 +27,7 @@ public class ExperienceDuplicateGroup {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "existing_experience_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private UserExperience existingExperience;
 
     @OneToMany(mappedBy = "duplicateGroup", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
@@ -1,8 +1,10 @@
 package back.pickd.experience.entity;
 
 import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.global.error.ApiException;
 import back.pickd.user.entity.User;
 import jakarta.persistence.*;
+import org.springframework.http.HttpStatus;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -52,6 +54,9 @@ public class ExperienceExtractionBatch {
     }
 
     public void complete() {
+        if (this.status != ExtractionBatchStatus.PENDING) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "이미 처리된 배치입니다.");
+        }
         this.status = ExtractionBatchStatus.COMPLETED;
         this.processedAt = OffsetDateTime.now();
         this.groups.clear();

--- a/src/main/java/back/pickd/experience/entity/UserExperience.java
+++ b/src/main/java/back/pickd/experience/entity/UserExperience.java
@@ -6,6 +6,7 @@ import back.pickd.experience.enums.Status;
 import back.pickd.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -60,10 +61,12 @@ public class UserExperience {
     @Builder.Default
     private List<String> keywords = new ArrayList<>();
 
+    @BatchSize(size = 30)
     @OneToMany(mappedBy = "userExperience", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<ExperienceLink> links = new ArrayList<>();
 
+    @BatchSize(size = 30)
     @OneToMany(mappedBy = "userExperience", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<ExperienceFile> files = new ArrayList<>();

--- a/src/main/java/back/pickd/user/dto/onboarding/OnboardingRequest.java
+++ b/src/main/java/back/pickd/user/dto/onboarding/OnboardingRequest.java
@@ -5,6 +5,7 @@ import back.pickd.user.entity.enums.EnrollmentStatus;
 import back.pickd.user.entity.enums.OnboardingStep;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,7 @@ public class OnboardingRequest {
 
     // Step 1.5: Verification
     private String name;
+    @Pattern(regexp = "^\\d{8}$", message = "생년월일 형식은 YYYYMMDD여야 합니다.")
     private String birthDate;
     private String phone;
 
@@ -38,6 +40,7 @@ public class OnboardingRequest {
     private String minor;
     private DegreeType degreeType;
     private EnrollmentStatus enrollmentStatus;
+    @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "졸업년월 형식은 YYYY-MM이어야 합니다.")
     private String graduationDate;
     private Double gpa;
     private String campus;
@@ -87,6 +90,7 @@ public class OnboardingRequest {
     public static class CertificationDto {
         private String name;
         private String score;
+        @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "취득년월 형식은 YYYY-MM이어야 합니다.")
         private String acquisitionDate;
     }
 }

--- a/src/main/java/back/pickd/user/entity/UserInterest.java
+++ b/src/main/java/back/pickd/user/entity/UserInterest.java
@@ -23,12 +23,16 @@ public class UserInterest {
     private User user;
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_industries", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_industries",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_industries", columnList = "user_interest_id"))
     @Column(name = "industry")
     private List<String> industries = new ArrayList<>();
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_job_groups", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_job_groups",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_job_groups", columnList = "user_interest_id"))
     @Column(name = "job_group")
     private List<String> jobGroups = new ArrayList<>();
 
@@ -36,12 +40,16 @@ public class UserInterest {
     private String employmentType; // e.g., "FULL_TIME", "INTERN"
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_company_types", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_company_types",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_company_types", columnList = "user_interest_id"))
     @Column(name = "company_type")
     private List<String> companyTypes = new ArrayList<>();
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_keywords", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_keywords",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_keywords", columnList = "user_interest_id"))
     @Column(name = "keyword")
     private List<String> keywords = new ArrayList<>();
 
@@ -64,7 +72,9 @@ public class UserInterest {
     private String workType;
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_apply_types", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_apply_types",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_apply_types", columnList = "user_interest_id"))
     @Column(name = "apply_type")
     private List<String> applyTypes = new ArrayList<>();
 

--- a/src/main/java/back/pickd/user/entity/UserLocation.java
+++ b/src/main/java/back/pickd/user/entity/UserLocation.java
@@ -26,7 +26,9 @@ public class UserLocation {
     private String currentResidence;
 
     @ElementCollection
-    @CollectionTable(name = "user_desired_locations", joinColumns = @JoinColumn(name = "user_location_id"))
+    @CollectionTable(name = "user_desired_locations",
+            joinColumns = @JoinColumn(name = "user_location_id"),
+            indexes = @Index(name = "idx_user_desired_locations", columnList = "user_location_id"))
     @Column(name = "location")
     private List<String> desiredLocations = new ArrayList<>();
 

--- a/src/main/java/back/pickd/user/entity/UserPrepStatus.java
+++ b/src/main/java/back/pickd/user/entity/UserPrepStatus.java
@@ -29,7 +29,9 @@ public class UserPrepStatus {
     private String currentStage;
 
     @ElementCollection
-    @CollectionTable(name = "user_focus_items", joinColumns = @JoinColumn(name = "user_prep_status_id"))
+    @CollectionTable(name = "user_focus_items",
+            joinColumns = @JoinColumn(name = "user_prep_status_id"),
+            indexes = @Index(name = "idx_user_focus_items", columnList = "user_prep_status_id"))
     @Column(name = "focus_item")
     private List<String> focusItems = new ArrayList<>();
 
@@ -43,7 +45,9 @@ public class UserPrepStatus {
     private boolean hasPortfolio;
 
     @ElementCollection
-    @CollectionTable(name = "user_preparing_exams", joinColumns = @JoinColumn(name = "user_prep_status_id"))
+    @CollectionTable(name = "user_preparing_exams",
+            joinColumns = @JoinColumn(name = "user_prep_status_id"),
+            indexes = @Index(name = "idx_user_preparing_exams", columnList = "user_prep_status_id"))
     @Column(name = "exam_name")
     private List<String> preparingExams = new ArrayList<>();
 


### PR DESCRIPTION
## 개요
DB 설계 보고서 기반으로 논의된 무결성 및 성능 개선 사항을 적용합니다.
이슈 #93에서 7개 항목을 검토하여 5개 항목을 수정합니다. (2개는 현행 유지 결정)

## 변경 사항

### 1. UserExperience N+1 해소 — `@BatchSize(30)` 적용
`ExperienceResponse`가 목록 조회 시 `files`와 `links`를 함께 반환하여 N+1이 실제로 발생하고 있었습니다.
두 컬렉션이 모두 `List<>`이므로 JOIN FETCH 동시 적용 시 `MultipleBagFetchException` 위험이 있어 `@BatchSize`를 선택했습니다.

- **적용 전**: 경험 N개 조회 시 쿼리 2N+1개
- **적용 후**: 쿼리 3개 고정 (경험 1 + files 1 + links 1)

### 2. `ExperienceDuplicateGroup.existingExperience` — ON DELETE CASCADE
경험 삭제 시 해당 경험을 참조하는 중복 그룹은 의미가 없어지므로 CASCADE로 처리합니다.
중복 그룹은 추출 배치의 검토 단계에서만 쓰이는 임시 데이터입니다.

### 3. 날짜 필드 `@Pattern` 검증 추가
String으로 저장하는 날짜 필드에 형식 검증이 없었습니다.
프론트엔드가 이미 String 형식으로 전송하고 있어 타입 변경 없이 검증만 추가했습니다.

| 필드 | 형식 | 패턴 |
|------|------|------|
| `birthDate` | YYYYMMDD | `^\d{8}$` |
| `graduationDate` | YYYY-MM | `^\d{4}-\d{2}$` |
| `acquisitionDate` | YYYY-MM | `^\d{4}-\d{2}$` |

### 4. 컬렉션 테이블 `@Index` 명시적 추가
JPA 기본 동작에 의존하지 않고 7개 컬렉션 테이블에 FK 컬럼 기준 인덱스를 명시적으로 선언합니다.

- `user_interest_industries`, `user_interest_job_groups`, `user_interest_company_types`
- `user_interest_keywords`, `user_interest_apply_types`
- `user_desired_locations`
- `user_focus_items`, `user_preparing_exams`

### 5. `ExperienceExtractionBatch.complete()` — 상태 전이 가드 추가
기존 `complete()` 메서드에 중복 호출 방지 로직이 없었습니다.
`PENDING` 상태가 아닌 배치에 `complete()`를 호출하면 `ApiException(400)`을 반환합니다.

## 현행 유지 결정 항목
- **지원 상태 전이 강제**: 취업 준비 특성상 유연한 상태 변경이 필요 → 현행 유지
- **PostgreSQL GIN 인덱스**: JSON 필드 기반 검색 API 미존재, AI 서버는 worker 역할로만 동작 → 추후 검색 기능 추가 시 재검토

## 수정 파일
- `experience/entity/UserExperience.java`
- `experience/entity/ExperienceDuplicateGroup.java`
- `experience/entity/ExperienceExtractionBatch.java`
- `user/dto/onboarding/OnboardingRequest.java`
- `user/entity/UserInterest.java`
- `user/entity/UserLocation.java`
- `user/entity/UserPrepStatus.java`