### PR TITLE
fix: AI headcount 타입 Integer → String 통일 (closes #95)

### DIFF
--- a/src/main/java/back/pickd/global/infra/ai/dto/AiJobPostingResponse.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiJobPostingResponse.java
@@ -19,7 +19,7 @@ public class AiJobPostingResponse {
     private String startedAt;
     private String endedAt;
     private String noticeUrl;
-    private Integer headcount;
+    private String headcount;
     private String region1depth;
     private String workplaceAddress;
     private List<AiNoticeSectionDto> sections;

--- a/src/main/java/back/pickd/notice/service/NoticeService.java
+++ b/src/main/java/back/pickd/notice/service/NoticeService.java
@@ -62,7 +62,7 @@ public class NoticeService {
                 .startedAt(aiResponse.getStartedAt())
                 .endedAt(aiResponse.getEndedAt())
                 .employmentType(convertEmploymentType(aiResponse.getEmploymentType()))
-                .headcount(aiResponse.getHeadcount() != null ? String.valueOf(aiResponse.getHeadcount()) : "0")
+                .headcount(aiResponse.getHeadcount())
                 .region1depth(aiResponse.getRegion1depth())
                 .workplaceAddress(aiResponse.getWorkplaceAddress())
                 .noticeUrl(url != null ? url : aiResponse.getNoticeUrl())


### PR DESCRIPTION
## 관련 이슈
- #95
- Base: `main`

## 문제
AI 서버가 스크래핑한 채용 인원 데이터는 `"00명 내외"`, `"0명 이상"` 등 문자열 형태로 반환되지만, `AiJobPostingResponse.headcount`가 `Integer`로 선언되어 있어 역직렬화 시 파싱 실패 위험이 있었음.
또한 `NoticeService`에서 `String.valueOf(aiResponse.getHeadcount())`로 변환하는 과정에서 null 처리를 위해 `"0"`을 기본값으로 사용하는 불명확한 로직이 존재했음.

## 작업 내용
- `AiJobPostingResponse.headcount`: `Integer` → `String` 타입 변경
- `NoticeService`: `String.valueOf()` 변환 로직 제거, AI 응답값 직접 사용

## 테스트
- 관련 테스트 코드 없음 (headcount 필드를 직접 검증하는 테스트 미존재)