### PR TITLE
test: 연동 전 API QA 및 단위 & E2E 테스트 진행 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ tokens/
 
 # YAML Secret files
 application-local.yml
+
+# macOS
+.DS_Store
+
+# PR/temp docs
+pr_body_*.md

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -44,6 +45,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
+
+	// AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -62,4 +62,18 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	// 통합 테스트는 기본 test task에서 제외 (Context 전체 로딩으로 느림)
+	exclude '**/*IntegrationTest*'
+	exclude '**/PickdApplicationTests*'
+	// JUnit 5 @Nested inner class는 outer class가 자동 실행 — Gradle 중복 탐지 방지
+	exclude '**/*$*'
+}
+
+// 통합 테스트만 별도 실행: ./gradlew integrationTest
+tasks.register('integrationTest', Test) {
+	useJUnitPlatform()
+	include '**/*IntegrationTest*'
+	include '**/PickdApplicationTests*'
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
 }

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/scripts/FRONTEND_GUIDE.md
+++ b/scripts/FRONTEND_GUIDE.md
@@ -1,0 +1,516 @@
+# PICKD 프론트엔드 연동 가이드
+
+> 작성일: 2026-06-26  
+> 대상: 프론트엔드 팀  
+> 현재 BE 브랜치: `main` / AI 브랜치: `main`
+
+---
+
+## 목차
+
+1. [로컬 서버 기동](#1-로컬-서버-기동)
+2. [인증 방식](#2-인증-방식)
+3. [로컬 테스트 계정 발급](#3-로컬-테스트-계정-발급)
+4. [API 호출 순서 — 경험 추출 플로우](#4-api-호출-순서--경험-추출-플로우)
+5. [요청/응답 샘플 JSON](#5-요청응답-샘플-json)
+6. [에러 케이스 정리](#6-에러-케이스-정리)
+7. [상태 전이 다이어그램](#7-상태-전이-다이어그램)
+8. [검증 완료 / 미완료 범위](#8-검증-완료--미완료-범위)
+9. [로컬 DB seed 방법](#9-로컬-db-seed-방법)
+
+---
+
+## 1. 로컬 서버 기동
+
+### BE (Spring Boot)
+
+```bash
+cd pickd-BE
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+- 주소: `http://localhost:8080`
+- Swagger UI: `http://localhost:8080/swagger-ui/index.html`
+- H2 콘솔: `http://localhost:8080/h2-console`
+  - JDBC URL: `jdbc:h2:mem:pickd` / User: `sa` / Password: (비워둠)
+- 테스트 화면: `http://localhost:8080/experience-extraction-test`
+
+### AI (FastAPI)
+
+```bash
+cd pickd-AI/myeongsung
+source .venv/bin/activate
+uvicorn app.main:app --reload --port 8000
+```
+
+- 주소: `http://localhost:8000`
+- 헬스체크: `GET http://localhost:8000/health` → `{"status":"ok"}`
+- Docs: `http://localhost:8000/docs`
+
+### CORS 허용 origin
+
+BE는 아래 두 origin에서 자격증명(쿠키)을 포함한 요청을 허용합니다:
+
+```
+http://localhost:3000
+http://localhost:5173
+```
+
+---
+
+## 2. 인증 방식
+
+### 운영 / 개발: Google OAuth2
+
+1. 프론트에서 `http://localhost:8080/oauth2/authorization/google` 로 리다이렉트
+2. 구글 로그인 성공 시 BE가 `accessToken` 쿠키를 발급 후 프론트로 리다이렉트
+3. 이후 모든 API 요청에 **쿠키가 자동으로 포함**됨
+
+### 로컬 테스트: 시드 API로 JWT 직접 발급
+
+```
+POST http://localhost:8080/internal/seed/user
+```
+
+응답의 `accessToken`을 쿠키로 설정:
+
+```javascript
+// Axios 설정 예시
+axios.defaults.withCredentials = true;
+
+// 또는 수동 쿠키 설정 (개발 도구 → Application → Cookies)
+// Name: accessToken
+// Value: <응답의 accessToken 값>
+// Domain: localhost
+```
+
+> `withCredentials: true` 또는 `credentials: 'include'` 를 **반드시** 설정해야 쿠키가 전송됩니다.
+
+---
+
+## 3. 로컬 테스트 계정 발급
+
+```bash
+curl -s -X POST http://localhost:8080/internal/seed/user \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@pickd.local","name":"테스트유저"}' | python3 -m json.tool
+```
+
+응답:
+
+```json
+{
+  "id": 1,
+  "email": "test@pickd.local",
+  "name": "테스트유저",
+  "accessToken": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+발급받은 `accessToken`을 브라우저 쿠키로 설정하면 로그인 상태가 됩니다.
+
+---
+
+## 4. API 호출 순서 — 경험 추출 플로우
+
+### 전체 플로우 개요
+
+```
+[사용자] 자소서 PDF 업로드
+        ↓
+Step1: POST /api/experiences/extract/step1
+        → ExperienceTemp 목록 반환 (후보 리스트)
+        ↓
+[사용자] 원하는 경험 선택 (checkbox)
+        ↓
+Step2 V2: POST /api/v2/experiences/extract/step2
+        → savedExperiences: 즉시 저장된 경험
+        → duplicateBatchId: 중복 있을 경우 non-null
+        → duplicateGroups:  중복 후보 그룹 목록
+        ↓
+    ┌───────────────────────────────────┐
+    │ duplicateBatchId == null?         │
+    │  YES → 플로우 종료 (모두 저장됨)  │
+    │  NO  → Step3로 진행               │
+    └───────────────────────────────────┘
+        ↓ (중복 있을 경우)
+[사용자] 각 그룹에서 남길 경험 선택
+        ↓
+Step3 V2: POST /api/v2/experiences/extract/step3
+        → 선택된 경험 최종 저장, 나머지 삭제
+        ↓
+완료
+```
+
+### 앱 재시작 / 화면 새로고침 시 미처리 중복 복원
+
+```
+GET /api/v2/experiences/extract/duplicates/pending
+→ 처리되지 않은 batch 목록 반환
+→ 각 batch를 Step3에 전달하여 선택 화면 복원
+```
+
+### 엔드포인트 요약
+
+| 순서 | Method | Path | 설명 |
+|------|--------|------|------|
+| 1 | POST | `/api/experiences/extract/step1` | PDF 업로드 → temp 경험 후보 추출 |
+| 2 | POST | `/api/v2/experiences/extract/step2` | 선택 temp ID → 상세 추출 + 중복 판정 |
+| 2.5 | GET | `/api/v2/experiences/extract/duplicates/pending` | 미처리 중복 batch 복원 |
+| 3 | POST | `/api/v2/experiences/extract/step3` | 중복 그룹 최종 선택 반영 |
+
+---
+
+## 5. 요청/응답 샘플 JSON
+
+### Step1 — 경험 후보 1차 추출
+
+**Request** (`multipart/form-data`)
+
+```
+POST /api/experiences/extract/step1
+Content-Type: multipart/form-data
+
+file: <PDF 파일 바이너리>
+```
+
+**Response** `200`
+
+```json
+[
+  {
+    "id": 101,
+    "userId": 1,
+    "experienceName": "금융 AI Agent 프로젝트",
+    "experienceGroup": "NARRATIVE",
+    "experienceType": "PROJECT",
+    "createdAt": "2024-09-01T09:00:00"
+  },
+  {
+    "id": 102,
+    "userId": 1,
+    "experienceName": "TOEIC 930점",
+    "experienceGroup": "SPEC",
+    "experienceType": "LANGUAGE",
+    "createdAt": "2024-09-01T09:00:00"
+  }
+]
+```
+
+> 반환된 `id`를 Step2의 `selectedTempIds`에 사용하세요.
+
+---
+
+### Step2 V2 — 선택 경험 상세 추출
+
+**Request**
+
+```json
+POST /api/v2/experiences/extract/step2
+
+{
+  "selectedTempIds": [101, 102]
+}
+```
+
+**Response** `200` — 중복 없는 경우
+
+```json
+{
+  "savedExperiences": [
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "title": "금융 AI Agent 프로젝트",
+      "experienceType": "PROJECT",
+      "experienceGroup": "NARRATIVE",
+      "status": "COMPLETED",
+      "documentContent": "추천 모델 개선을 담당했습니다.",
+      "attributes": { "project_name": "금융 AI Agent", "role": "백엔드 개발" },
+      "keywords": ["문제 해결", "실행력"],
+      "files": [],
+      "links": []
+    }
+  ],
+  "duplicateBatchId": null,
+  "duplicateGroups": []
+}
+```
+
+**Response** `200` — 중복 있는 경우
+
+```json
+{
+  "savedExperiences": [],
+  "duplicateBatchId": "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+  "duplicateGroups": [
+    {
+      "groupId": "9f83540e-5d78-4a08-a284-78cecfdf2e3d",
+      "items": [
+        {
+          "itemId": "aaaaaaaa-0001-0001-0001-000000000001",
+          "source": "EXISTING",
+          "similarity": null,
+          "experience": {
+            "title": "금융 AI Agent 프로젝트",
+            "experienceType": "PROJECT",
+            "experienceGroup": "NARRATIVE",
+            "status": "COMPLETED",
+            "documentContent": "추천 모델 개선을 담당했습니다.",
+            "attributes": { "project_name": "금융 AI Agent" },
+            "keywords": ["문제 해결"]
+          }
+        },
+        {
+          "itemId": "dddddddd-draft-0001-0001-000000000001",
+          "source": "EXTRACTED",
+          "similarity": 0.91,
+          "experience": {
+            "title": "금융 AI Agent 프로젝트 (재추출)",
+            "experienceType": "PROJECT",
+            "experienceGroup": "NARRATIVE",
+            "status": "COMPLETED",
+            "documentContent": "추천 시스템 개선을 통해 정확도를 15% 향상시킨 경험입니다.",
+            "attributes": { "project_name": "금융 AI Agent" },
+            "keywords": ["문제 해결", "실행력"]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+> **`duplicateBatchId`가 non-null이면 Step3 화면을 보여주세요.**  
+> `source: "EXISTING"` = 기존에 저장된 경험 / `source: "EXTRACTED"` = 이번에 추출한 후보
+
+---
+
+### pending duplicates — 미처리 중복 batch 복원
+
+**Request**
+
+```
+GET /api/v2/experiences/extract/duplicates/pending
+```
+
+**Response** `200`
+
+```json
+{
+  "batches": [
+    {
+      "duplicateBatchId": "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+      "createdAt": "2024-09-01T09:00:00+09:00",
+      "duplicateGroups": [ /* Step2와 동일한 구조 */ ]
+    }
+  ]
+}
+```
+
+> `batches`가 비어 있으면 처리할 중복 없음.
+
+---
+
+### Step3 V2 — 중복 최종 선택 반영
+
+**Request**
+
+```json
+POST /api/v2/experiences/extract/step3
+
+{
+  "duplicateBatchId": "f128a54c-0525-4d89-96bb-ce8f7eb602b3",
+  "groups": [
+    {
+      "groupId": "9f83540e-5d78-4a08-a284-78cecfdf2e3d",
+      "selectedItemIds": ["dddddddd-draft-0001-0001-000000000001"]
+    }
+  ]
+}
+```
+
+> - `selectedItemIds`: 남길 경험의 `itemId` 목록
+> - 기존 경험과 추출 draft를 함께 선택할 수 있음
+> - **모든 그룹에 대해 선택을 제공해야 합니다** (그룹 누락 시 400)
+
+**Response** `200`
+
+```json
+{
+  "selectedExperiences": [
+    {
+      "id": "dddddddd-draft-0001-0001-000000000001",
+      "title": "금융 AI Agent 프로젝트 (재추출)",
+      "experienceType": "PROJECT",
+      "experienceGroup": "NARRATIVE",
+      "status": "COMPLETED"
+    }
+  ],
+  "deletedExperienceIds": ["aaaaaaaa-0001-0001-0001-000000000001"]
+}
+```
+
+---
+
+## 6. 에러 케이스 정리
+
+| HTTP | 발생 조건 | 응답 예시 |
+|------|-----------|-----------|
+| `401` | 쿠키 없음 또는 JWT 만료 | `{"status":401,"message":"인증이 필요합니다."}` |
+| `400` | `selectedTempIds` 비어 있음 | `{"status":400,"message":"처리할 임시 경험이 없습니다."}` |
+| `400` | 다른 사용자 소유의 temp ID 포함 | `{"status":400,"message":"해당 임시 경험에 접근 권한이 없습니다."}` |
+| `400` | 이미 처리된 batch ID로 Step3 요청 | `{"status":400,"message":"이미 처리된 batch입니다."}` |
+| `400` | Step3에서 그룹 일부 누락 | `{"status":400,"message":"모든 중복 그룹에 대한 선택이 필요합니다."}` |
+| `400` | Step3의 `selectedItemIds`가 비어 있음 | `{"status":400,"message":"그룹마다 하나 이상의 경험을 선택해야 합니다."}` |
+| `500` | AI 서버 미응답 / OpenAI quota 초과 | `{"status":500,"message":"AI 서버 호출 실패"}` |
+
+---
+
+## 7. 상태 전이 다이어그램
+
+### ExperienceExtractionBatch 상태
+
+```
+Step2 호출 (중복 감지)
+        ↓
+    PENDING
+        ↓ Step3 호출 (선택 완료)
+    COMPLETED
+```
+
+### 경험 추출 전체 화면 전이
+
+```
+[홈 / 경험 목록]
+        ↓ "자소서로 경험 추출" 버튼
+[Step1: PDF 업로드]
+        ↓ 후보 목록 반환
+[Step2: 경험 선택 화면] — 체크박스로 원하는 경험 선택
+        ↓ Step2 API 호출
+    ┌─────────────────────────────────────────┐
+    │ duplicateBatchId == null?               │
+    │  YES → [경험 목록]으로 이동 (저장 완료) │
+    │  NO  ↓                                  │
+    └──────[Step3: 중복 선택 화면]────────────┘
+                ↓ 각 그룹에서 선택
+            Step3 API 호출
+                ↓
+        [경험 목록]으로 이동
+```
+
+### 앱 재시작 시 중복 복원
+
+```
+앱 로드 시 GET /duplicates/pending 자동 호출
+        ↓
+    batches.length > 0?
+      YES → [Step3: 중복 선택 화면] 표시
+      NO  → 정상 흐름 진행
+```
+
+---
+
+## 8. 검증 완료 / 미완료 범위
+
+### ✅ 검증 완료
+
+| 항목 | 검증 방법 |
+|------|-----------|
+| BE 자동 테스트 34개 | `./gradlew test` 전부 통과 |
+| AI 자동 테스트 34개 | `pytest -q tests` 전부 통과 |
+| AI Step1 경험 후보 추출 | 실제 더미 PDF로 검증 |
+| AI Step2 V2 상세 경험 추출 | 실제 더미 데이터로 검증 |
+| AI merge-check 중복 판정 | 동일 경험 재추출로 중복 batch 생성 확인 |
+| BE Step2 V2 전체 경로 (BE→AI→OpenAI→DB 저장) | 더미 temp 주입 후 API 호출로 검증 |
+| BE Step3 V2 기존 경험 선택 처리 | 중복 batch 생성 후 Step3 호출 검증 |
+| pending duplicate 조회 | batch 생성 후 pending API 확인 |
+| BE OpenAPI 경로 등록 | Swagger UI에서 전 경로 확인 |
+| 수기 경험 저장 API | POST /api/experiences 직접 호출 |
+
+### ⚠️ 미완료 / 주의 사항
+
+| 항목 | 현황 | 권고 |
+|------|------|------|
+| BE Step1 실제 S3 업로드 포함 전체 경로 | S3를 우회하여 temp 직접 주입으로 Step2/3 검증만 완료 | 로컬 S3(LocalStack) 또는 실제 버킷으로 Step1 E2E 필요 |
+| Gemini vision 이미지 분석 | quota 429로 실패 → GPT 텍스트 fallback으로 성공 | Gemini quota 확인 후 재검증 |
+| 실제 프론트 브라우저 클릭 플로우 | 미검증 | 프론트 연동 후 E2E 브라우저 테스트 필요 |
+| 운영 DB seed | H2 인메모리 전용 seed만 준비됨 | PostgreSQL 운영 DB용 seed 별도 준비 필요 |
+
+---
+
+## 9. 로컬 DB seed 방법
+
+### 방법 A: API로 seed (권장)
+
+```bash
+# 1. 테스트 유저 생성 + JWT 발급
+TOKEN=$(curl -s -X POST http://localhost:8080/internal/seed/user \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@pickd.local","name":"테스트유저"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])")
+
+# 2. 수기 경험 3개 저장
+curl -s -X POST http://localhost:8080/api/experiences \
+  -H "Content-Type: application/json" -H "Cookie: accessToken=$TOKEN" \
+  -d '{"title":"금융 AI Agent 프로젝트","experienceType":"PROJECT","experienceGroup":"NARRATIVE","status":"COMPLETED","documentContent":"추천 정확도 15% 향상","attributes":{"project_name":"금융 AI Agent","role":"백엔드"},"keywords":["문제 해결"],"forceCreate":true}' | python3 -m json.tool
+
+# 3. temp 주입 (Step1 대체)
+curl -s -X POST http://localhost:8080/internal/seed/temp \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@pickd.local","experiences":[{"name":"금융 AI Agent 프로젝트","type":"PROJECT","group":"NARRATIVE"},{"name":"TOEIC 930점","type":"LANGUAGE","group":"SPEC"}]}' | python3 -m json.tool
+
+# 4. E2E 전체 자동 실행 (위 단계 모두 포함)
+python3 scripts/e2e_test.py
+```
+
+### 방법 B: H2 콘솔에서 SQL 직접 실행
+
+1. `http://localhost:8080/h2-console` 접속
+2. JDBC URL: `jdbc:h2:mem:pickd` / User: `sa`
+3. `scripts/seed_h2.sql` 파일 내용을 붙여넣고 실행
+
+### 방법 C: E2E 스크립트 일괄 실행
+
+```bash
+# BE + AI 서버가 모두 기동된 상태에서
+cd pickd-BE
+python3 scripts/e2e_test.py
+```
+
+스크립트가 자동으로:
+1. 서버 헬스 확인
+2. 테스트 유저 생성 + JWT 발급
+3. 수기 경험 3개 seed
+4. temp experience 주입 (Step1 대체)
+5. Step2 V2 호출 + 결과 검증
+6. 중복 batch 생성 검증
+7. pending duplicates 조회
+8. Step3 선택 처리
+9. 최종 DB 상태 검증
+
+실행 결과:
+
+```
+==================================================
+  PICKD 로컬 E2E 테스트
+==================================================
+
+[STEP 1 — 서버 헬스 체크]
+  ✓ AI 서버 응답
+  ✓ BE 서버 응답
+
+[STEP 2 — 테스트 유저 생성 + JWT 획득]
+  ✓ POST /internal/seed/user → 200
+  ...
+
+[STEP 10 — 최종 DB 상태 검증]
+  ✓ temp 0개 (모두 처리됨)
+  ✓ 완료된 batch 존재
+
+==================================================
+  PASSED: 18
+==================================================
+```
+
+---
+
+*문의: 명성 (dreamkms2014@pusan.ac.kr)*

--- a/scripts/TEST_SCENARIOS.md
+++ b/scripts/TEST_SCENARIOS.md
@@ -1,0 +1,1282 @@
+# PICKD API 수동 테스트 시나리오
+
+> 작성일: 2026-06-26  
+> 테스트 환경: 로컬 (BE `localhost:8080` / AI `localhost:8000`)  
+> 도구: Swagger UI, curl, 또는 Postman
+
+---
+
+## 사전 준비
+
+### 1. 서버 기동
+
+```bash
+# 터미널 1 — BE
+cd pickd-BE
+./gradlew bootRun --args='--spring.profiles.active=local'
+
+# 터미널 2 — AI
+cd pickd-AI/myeongsung
+source .venv/bin/activate
+uvicorn app.main:app --reload --port 8000
+```
+
+### 2. 테스트 계정 + JWT 발급
+
+```bash
+curl -s -X POST http://localhost:8080/internal/seed/user \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@pickd.local","name":"테스트유저"}'
+```
+
+응답에서 `accessToken` 복사 → 브라우저 쿠키에 수동 설정
+
+```
+이름:  accessToken
+값:    eyJhbGciOi...  (복사한 토큰)
+도메인: localhost
+경로:  /
+```
+
+> Swagger UI 사용 시: `http://localhost:8080/swagger-ui/index.html` → 우상단 **Authorize** → `accessToken` 쿠키 값 붙여넣기
+
+### 3. 변수 메모 공간 (테스트 진행하며 채워나가기)
+
+```
+JWT_TOKEN      = 
+NOTICE_ID      = 
+APPLICATION_ID = 
+TODO_ID        = 
+DOCUMENT_ID    = 
+COVER_LETTER_ID = 
+EXPERIENCE_ID_1 =
+EXPERIENCE_ID_2 =
+EXPERIENCE_ID_3 =
+FILE_ID        =
+CALENDAR_EVENT_ID =
+TEMP_ID_1      =
+TEMP_ID_2      =
+DUPLICATE_BATCH_ID =
+DUPLICATE_GROUP_ID =
+```
+
+---
+
+## 도메인 1 — User
+
+### T-01 내 프로필 조회
+
+```
+GET /api/user
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `email: "test@pickd.local"` 확인
+- [ ] `onboardingStep: "COMPLETED"` 확인 (seed로 생성했으므로)
+
+---
+
+### T-02 프로필 이미지 업로드
+
+```
+POST /api/user/profile-image
+Content-Type: multipart/form-data
+
+file: (아무 JPG/PNG 파일)
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] 응답에 `profileImageUrl` 포함
+- [ ] URL이 `https://` 로 시작
+
+---
+
+### T-03 프로필 이미지 조회
+
+```
+GET /api/user/profile-image
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] T-02에서 업로드한 URL과 동일
+
+---
+
+## 도메인 2 — Onboarding
+
+### T-04 온보딩 상태 조회
+
+```
+GET /api/onboarding/status
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `onboardingStep` 값 확인 (seed: `COMPLETED`)
+
+---
+
+### T-05 온보딩 초기화
+
+```
+POST /api/onboarding/reset
+```
+
+**확인 포인트**
+- [ ] 200 반환, `"Reset complete"` 응답
+
+---
+
+### T-06 온보딩 Step1 — 약관 동의
+
+```json
+POST /api/onboarding
+
+{
+  "serviceAgreed": true,
+  "privacyAgreed": true,
+  "marketingAgreed": false,
+  "pushAgreed": true
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `onboardingStep: "TERMS"` 또는 다음 단계 확인
+
+---
+
+### T-07 온보딩 Step3 — 기본 정보
+
+```json
+POST /api/onboarding
+
+{
+  "nickname": "명성",
+  "intro": "백엔드 개발을 공부하는 부산대학교 4학년입니다.",
+  "currentResidence": "부산",
+  "desiredLocations": ["서울", "부산"],
+  "detailedAddress": "부산광역시 금정구"
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `nickname: "명성"` 확인
+- [ ] `onboardingStep` 진행됨
+
+---
+
+### T-08 온보딩 Step4 — 학력
+
+```json
+POST /api/onboarding
+
+{
+  "schoolName": "부산대학교",
+  "department": "정보컴퓨터공학부",
+  "degreeType": "BACHELOR",
+  "enrollmentStatus": "GRADUATED",
+  "graduationDate": "2026-02",
+  "gpa": 3.9,
+  "campus": "부산 캠퍼스"
+}
+```
+
+---
+
+### T-09 온보딩 Step5 — 관심 분야
+
+```json
+POST /api/onboarding
+
+{
+  "industries": ["IT/소프트웨어", "핀테크"],
+  "jobGroups": ["백엔드 개발", "서버 개발"],
+  "employmentType": "정규직",
+  "companyTypes": ["대기업", "스타트업"],
+  "keywords": ["Spring Boot", "Java", "MSA"],
+  "targetCompany": "카카오",
+  "salaryRange": "4000만원 이상"
+}
+```
+
+---
+
+### T-10 온보딩 Step6 — 준비 현황 (COMPLETED)
+
+```json
+POST /api/onboarding
+
+{
+  "targetPeriod": "2026 하반기",
+  "currentStage": "서류 준비",
+  "focusItems": ["자기소개서", "포트폴리오"],
+  "hasResume": true,
+  "hasBaseEssay": true,
+  "hasPortfolio": false,
+  "experiences": [
+    { "type": "인턴", "title": "카카오 서버 인턴", "startDate": "2025-07", "endDate": "2025-08" }
+  ],
+  "certifications": [
+    { "name": "정보처리기사", "score": null, "acquisitionDate": "2025-11" }
+  ]
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `onboardingStep: "COMPLETED"`
+
+---
+
+## 도메인 3 — Notice (채용공고 분석)
+
+> **주의**: 이 API는 BE → AI → OpenAI 호출로 20~40초 소요됩니다.
+
+### T-11 URL 기반 채용공고 분석
+
+```json
+POST /api/notices/analyze/url
+
+{
+  "url": "여기에_찾은_채용공고_URL_입력"
+}
+```
+
+**추천 사이트 (공고 URL 직접 복사)**
+- 사람인: https://www.saramin.co.kr → 공고 클릭 → URL 복사
+- 잡코리아: https://www.jobkorea.co.kr → 공고 클릭 → URL 복사
+- 카카오 채용: https://careers.kakao.com/jobs
+- 원티드: https://www.wanted.co.kr/jobsfeed
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] 응답에 `noticeId` 포함 → **NOTICE_ID 메모**
+- [ ] Application이 자동 생성되었는지 GET /api/application 으로 확인
+
+---
+
+### T-12 PDF 기반 채용공고 분석
+
+```
+POST /api/notices/analyze/pdf
+Content-Type: multipart/form-data
+
+file: (채용공고 PDF 파일)
+```
+
+> 채용공고 인쇄 → PDF 저장 또는 채용 사이트에서 공고 PDF 다운로드
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] 새로운 `noticeId` 반환
+
+---
+
+## 도메인 4 — Application (지원 공고)
+
+> T-11/T-12에서 공고 분석 시 Application이 자동 생성됩니다.  
+> 아래는 **추가** 수기 입력 테스트입니다.
+
+### T-13 수기 지원 공고 추가
+
+```json
+POST /api/application
+
+{
+  "company": "네이버",
+  "jobTitle": "2026 상반기 서버 개발자 신입공채",
+  "position": "백엔드 개발",
+  "industry": "IT/소프트웨어",
+  "status": "PREPARING",
+  "memo": "네이버 클라우드 팀 관심 있음",
+  "deadlineDate": "2026-07-31T23:59:59",
+  "important": true
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] 응답에서 `id` 확인 → **APPLICATION_ID 메모**
+- [ ] `status`가 한국어로 직렬화되는지 확인 (예: `"서류 준비"`)
+
+---
+
+### T-14 지원 공고 목록 조회
+
+```
+GET /api/application
+```
+
+**확인 포인트**
+- [ ] 200 반환, 배열 반환
+- [ ] T-11/T-12 자동 생성 + T-13 수기 입력 포함 확인
+- [ ] `todos`, `documents` 배열 확인
+
+---
+
+### T-15 지원 공고 수정
+
+```json
+PUT /api/application/{APPLICATION_ID}
+
+{
+  "status": "APPLIED",
+  "memo": "서류 제출 완료 (2026-06-27)",
+  "applyDate": "2026-06-27T10:00:00",
+  "important": true
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `status` 변경 확인
+- [ ] `updatedAt` 변경 확인
+
+---
+
+### T-16 지원 공고 삭제
+
+> 새로 추가 공고 하나 더 만들고 삭제 테스트
+
+```json
+POST /api/application
+{
+  "company": "삭제테스트회사",
+  "jobTitle": "삭제용 공고",
+  "status": "PREPARING"
+}
+```
+
+```
+DELETE /api/application/{삭제용_APPLICATION_ID}
+```
+
+**확인 포인트**
+- [ ] 204 반환
+- [ ] GET /api/application 재조회 시 해당 항목 없어짐
+
+---
+
+## 도메인 5 — Todo
+
+### T-17 할 일 추가 (공고 연결)
+
+```json
+POST /api/todo
+
+{
+  "title": "네이버 자기소개서 1차 작성",
+  "dueDateTime": "2026-07-10T23:59:59",
+  "memo": "직무 역량 키워드 중심으로 작성",
+  "applicationId": {APPLICATION_ID},
+  "company": "네이버",
+  "jobTitle": "2026 상반기 서버 개발자 신입공채"
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `id` 확인 → **TODO_ID 메모**
+- [ ] `calendarEventId` 값 확인 (Google Calendar 연동 시 non-null)
+
+---
+
+### T-18 할 일 두 번째 추가
+
+```json
+POST /api/todo
+
+{
+  "title": "포트폴리오 PDF 변환",
+  "dueDateTime": "2026-07-05T18:00:00",
+  "memo": "Notion → PDF 내보내기",
+  "applicationId": {APPLICATION_ID},
+  "company": "네이버",
+  "jobTitle": "2026 상반기 서버 개발자 신입공채"
+}
+```
+
+---
+
+### T-19 전체 할 일 목록 조회
+
+```
+GET /api/todo
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] T-17, T-18 포함 확인
+
+---
+
+### T-20 공고별 할 일 조회
+
+```
+GET /api/todo/application/{APPLICATION_ID}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] 해당 공고의 할 일만 반환
+
+---
+
+### T-21 할 일 수정
+
+```json
+PUT /api/todo/{TODO_ID}
+
+{
+  "title": "네이버 자기소개서 1차 완료",
+  "dueDateTime": "2026-07-12T23:59:59",
+  "memo": "멘토 피드백 반영 예정"
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `title` 변경 확인
+
+---
+
+### T-22 할 일 삭제
+
+```
+DELETE /api/todo/{TODO_ID_2번}
+```
+
+**확인 포인트**
+- [ ] 204 반환
+- [ ] GET /api/todo 재조회 시 없어짐
+
+---
+
+## 도메인 6 — Document (서류)
+
+### T-23 서류 작성
+
+```json
+POST /api/document/{APPLICATION_ID}
+
+{
+  "title": "네이버 2026 상반기 이력서",
+  "company": "네이버",
+  "type": "RESUME",
+  "status": "IN_PROGRESS",
+  "progress": 20,
+  "content": "# 이력서\n\n## 인적사항\n- 이름: 홍길동\n- 학교: 부산대학교 정보컴퓨터공학부\n\n## 경력\n- 카카오 서버 인턴 (2025.07 ~ 2025.08)\n"
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `id` 확인 → **DOCUMENT_ID 메모**
+- [ ] `type`, `status` 확인
+
+---
+
+### T-24 포트폴리오 서류 추가
+
+```json
+POST /api/document/{APPLICATION_ID}
+
+{
+  "title": "포트폴리오 v1",
+  "company": "네이버",
+  "type": "PORTFOLIO",
+  "status": "IN_PROGRESS",
+  "progress": 0,
+  "content": "# 포트폴리오\n\n준비 중...\n"
+}
+```
+
+---
+
+### T-25 공고별 서류 조회
+
+```
+GET /api/document/{APPLICATION_ID}
+```
+
+**확인 포인트**
+- [ ] T-23, T-24 둘 다 반환
+
+---
+
+### T-26 전체 서류 조회
+
+```
+GET /api/document
+```
+
+---
+
+### T-27 서류 수정
+
+```json
+PUT /api/document/{DOCUMENT_ID}
+
+{
+  "title": "네이버 2026 상반기 이력서 v2",
+  "type": "RESUME",
+  "status": "COMPLETED",
+  "progress": 90,
+  "content": "# 이력서\n\n## 인적사항\n- 이름: 홍길동\n- 학교: 부산대학교 정보컴퓨터공학부 4학년\n\n## 경력\n- 카카오 서버 인턴 (2025.07 ~ 2025.08)\n  - Spring Boot REST API 개발\n  - 코드 리뷰 문화 경험\n"
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `status: "COMPLETED"`, `progress: 90` 확인
+
+---
+
+### T-28 서류 삭제
+
+> T-24에서 만든 포트폴리오 서류 삭제
+
+```
+DELETE /api/document/{PORTFOLIO_DOCUMENT_ID}
+```
+
+**확인 포인트**
+- [ ] 204 반환
+
+---
+
+## 도메인 7 — CoverLetter (자기소개서)
+
+### T-29 자기소개서 문항 생성
+
+```json
+POST /api/cover-letter
+
+{
+  "question": "지원 동기 및 입사 후 목표를 서술하세요.",
+  "answer": "저는 대규모 트래픽을 처리하는 백엔드 시스템에 관심이 많습니다. 네이버의 기술력을 배우며 성장하고 싶습니다.",
+  "maxLength": 500,
+  "orderIndex": 1,
+  "aiGenerated": false,
+  "applicationId": {APPLICATION_ID}
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `id` 확인 → **COVER_LETTER_ID 메모**
+
+---
+
+### T-30 자기소개서 두 번째 문항
+
+```json
+POST /api/cover-letter
+
+{
+  "question": "본인의 강점과 이를 발휘한 경험을 서술하세요.",
+  "answer": "저의 강점은 문제 해결 능력입니다. 캡스톤 프로젝트에서 추천 시스템 정확도를 15% 향상시킨 경험이 있습니다.",
+  "maxLength": 800,
+  "orderIndex": 2,
+  "aiGenerated": false,
+  "applicationId": {APPLICATION_ID}
+}
+```
+
+---
+
+### T-31 자기소개서 문항 조회
+
+```
+GET /api/cover-letter
+```
+
+**확인 포인트**
+- [ ] T-29, T-30 둘 다 반환
+
+---
+
+### T-32 자기소개서 수정
+
+```json
+PUT /api/cover-letter/{COVER_LETTER_ID}
+
+{
+  "question": "지원 동기 및 입사 후 목표를 서술하세요.",
+  "answer": "저는 대규모 트래픽을 처리하는 백엔드 시스템에 깊은 관심이 있습니다. 네이버의 검색 인프라와 클라우드 기술을 배우며, 5년 내 시스템 아키텍트로 성장하고 싶습니다.",
+  "maxLength": 500,
+  "orderIndex": 1,
+  "aiGenerated": false
+}
+```
+
+---
+
+### T-33 자기소개서 문항 삭제
+
+```
+DELETE /api/cover-letter/{COVER_LETTER_ID_2번}
+```
+
+**확인 포인트**
+- [ ] 204 반환
+
+---
+
+## 도메인 8 — File
+
+### T-34 파일 업로드
+
+```
+POST /api/files/upload
+Content-Type: multipart/form-data
+
+file: (이력서 PDF 파일)
+type: RESUME
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `id`, `fileName`, `fileUrl`, `uploadType: "RESUME"` 확인 → **FILE_ID 메모**
+- [ ] `fileUrl`이 CDN URL인지 확인
+
+---
+
+### T-35 파일 목록 조회 (전체)
+
+```
+GET /api/files
+```
+
+---
+
+### T-36 파일 목록 조회 (타입 필터)
+
+```
+GET /api/files?type=RESUME
+```
+
+**확인 포인트**
+- [ ] RESUME 타입만 반환
+
+---
+
+## 도메인 9 — Calendar
+
+> Google Calendar가 연동된 계정이어야 실제 동작합니다.  
+> 로컬 테스트 계정(test@pickd.local)은 Google OAuth가 없으므로 **401 또는 500 예상**.  
+> 실제 Google 로그인 계정으로 테스트하거나 오류 응답 코드만 확인합니다.
+
+### T-37 내 캘린더 이메일 확인
+
+```
+GET /api/calendar/me
+```
+
+**확인 포인트**
+- [ ] Google OAuth 미연동 시: 500 또는 오류
+- [ ] 연동 시: 이메일 문자열 반환
+
+---
+
+### T-38 일정 등록
+
+```json
+POST /api/calendar/events
+
+{
+  "summary": "네이버 서류 마감",
+  "location": "온라인 지원",
+  "description": "네이버 2026 상반기 서버 개발자 신입공채 서류 마감",
+  "start": {
+    "dateTime": "2026-07-31T23:59:59",
+    "timeZone": "Asia/Seoul"
+  },
+  "end": {
+    "dateTime": "2026-07-31T23:59:59",
+    "timeZone": "Asia/Seoul"
+  }
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환 (Google OAuth 연동 시)
+- [ ] `id` 확인 → **CALENDAR_EVENT_ID 메모**
+
+---
+
+### T-39 일정 목록 조회
+
+```
+GET /api/calendar/events
+```
+
+---
+
+### T-40 일정 수정
+
+```json
+PUT /api/calendar/events/{CALENDAR_EVENT_ID}
+
+{
+  "summary": "네이버 서류 마감 ⚠️",
+  "description": "마감 하루 전 재확인 필요"
+}
+```
+
+---
+
+### T-41 일정 삭제
+
+```
+DELETE /api/calendar/events/{CALENDAR_EVENT_ID}
+```
+
+---
+
+## 도메인 10 — Experience (수기 CRUD)
+
+### T-42 수기 경험 생성 — PROJECT
+
+```json
+POST /api/experiences
+
+{
+  "title": "금융 AI Agent 추천 시스템 프로젝트",
+  "experienceType": "PROJECT",
+  "experienceGroup": "NARRATIVE",
+  "status": "COMPLETED",
+  "documentContent": "LangGraph와 Spring Boot를 활용해 금융 상품 추천 AI Agent를 개발했습니다. 추천 정확도를 15% 향상시켰으며, 팀 내 기술 리드로 API 설계를 담당했습니다.",
+  "attributes": {
+    "project_name": "금융 AI Agent 추천 시스템",
+    "role": "백엔드 개발 및 AI 연동",
+    "period": "2025.03 ~ 2025.08",
+    "organization": "부산대학교 캡스톤 디자인팀",
+    "achievements": "추천 정확도 15% 향상, 4인 팀 기술 리드"
+  },
+  "keywords": ["문제 해결", "실행력", "API 설계", "LangGraph", "Spring Boot"],
+  "links": [
+    {
+      "title": "GitHub 저장소",
+      "url": "https://github.com/example/finance-ai-agent",
+      "materialType": "GITHUB"
+    }
+  ],
+  "forceCreate": false
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `id` 확인 → **EXPERIENCE_ID_1 메모** (UUID 형태)
+- [ ] `attributes`, `keywords`, `links` 저장 확인
+
+---
+
+### T-43 수기 경험 생성 — LANGUAGE
+
+```json
+POST /api/experiences
+
+{
+  "title": "TOEIC 930점",
+  "experienceType": "LANGUAGE",
+  "experienceGroup": "SPEC",
+  "status": "COMPLETED",
+  "documentContent": null,
+  "attributes": {
+    "score": "930",
+    "test_name": "TOEIC",
+    "acquired_date": "2025-06"
+  },
+  "keywords": ["어학", "영어"],
+  "forceCreate": true
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `id` 확인 → **EXPERIENCE_ID_2 메모**
+
+---
+
+### T-44 수기 경험 생성 — INTERN
+
+```json
+POST /api/experiences
+
+{
+  "title": "카카오 서버 개발 인턴십",
+  "experienceType": "INTERN",
+  "experienceGroup": "NARRATIVE",
+  "status": "COMPLETED",
+  "documentContent": "Spring Boot 기반 API 개발 및 유지보수를 담당했습니다. 코드 리뷰 문화를 경험하며 팀워크와 커뮤니케이션 역량을 키웠습니다. 일평균 처리 요청 10만 건 이상의 실서버 환경에서 개발하였습니다.",
+  "attributes": {
+    "company": "카카오",
+    "role": "서버 개발",
+    "period": "2025.07 ~ 2025.08",
+    "department": "카카오 클라우드 팀"
+  },
+  "keywords": ["협업", "코드리뷰", "Spring Boot", "Java", "실서버 경험"],
+  "forceCreate": true
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `id` 확인 → **EXPERIENCE_ID_3 메모**
+
+---
+
+### T-45 경험 목록 조회
+
+```
+GET /api/experiences
+```
+
+**확인 포인트**
+- [ ] 200 반환, 3개 포함
+- [ ] 각 경험의 `attributes`, `keywords` 포함 확인
+
+---
+
+### T-46 경험 단일 조회
+
+```
+GET /api/experiences/{EXPERIENCE_ID_1}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `links` 배열 (GitHub URL) 포함 확인
+- [ ] `files` 배열 확인
+
+---
+
+### T-47 경험 수정
+
+```json
+PUT /api/experiences/{EXPERIENCE_ID_1}
+
+{
+  "title": "금융 AI Agent 추천 시스템 프로젝트 (수정)",
+  "experienceType": "PROJECT",
+  "experienceGroup": "NARRATIVE",
+  "status": "COMPLETED",
+  "documentContent": "LangGraph와 Spring Boot를 활용해 금융 상품 추천 AI Agent를 개발했습니다. 추천 정확도를 15% 향상시키고, REST API 응답 시간을 30% 단축하는 성과를 냈습니다.",
+  "attributes": {
+    "project_name": "금융 AI Agent 추천 시스템",
+    "role": "백엔드 개발 및 AI 연동",
+    "period": "2025.03 ~ 2025.08",
+    "organization": "부산대학교 캡스톤 디자인팀",
+    "achievements": "추천 정확도 15% 향상, 응답시간 30% 단축"
+  },
+  "keywords": ["문제 해결", "실행력", "성능 최적화", "API 설계"]
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `documentContent`, `keywords` 변경 확인
+- [ ] `updatedAt` 변경 확인
+
+---
+
+### T-48 경험 삭제
+
+> 별도로 하나 더 만들어 삭제 테스트
+
+```json
+POST /api/experiences
+{
+  "title": "삭제 테스트용 경험",
+  "experienceType": "ALBA",
+  "experienceGroup": "NARRATIVE",
+  "status": "IN_PROGRESS",
+  "forceCreate": true
+}
+```
+
+```
+DELETE /api/experiences/{삭제용_EXPERIENCE_ID}
+```
+
+**확인 포인트**
+- [ ] 204 반환
+- [ ] GET /api/experiences 재조회 시 없어짐
+
+---
+
+## 도메인 11 — Experience Extraction V1
+
+> **Step1 → Step2 → (Step3)** 순서 필수
+
+### T-49 Step1 — 자소서 PDF 업로드 (경험 후보 추출)
+
+```
+POST /api/experiences/extract/step1
+Content-Type: multipart/form-data
+
+file: (본인 자소서 PDF)
+```
+
+> 소요 시간: 15~30초
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] 경험 후보 배열 반환 (경험명, 유형 확인)
+- [ ] 각 `id` 메모 → **TEMP_ID_1, TEMP_ID_2 메모**
+- [ ] 자소서에 언급한 경험이 올바르게 추출됐는지 내용 검토
+- [ ] `experienceGroup` 이 NARRATIVE/SPEC 으로 올바르게 분류됐는지 확인
+
+---
+
+### T-50 Step2 V1 — 선택 경험 상세 추출
+
+```json
+POST /api/experiences/extract/step2
+
+{
+  "selectedTempIds": [TEMP_ID_1, TEMP_ID_2]
+}
+```
+
+> 소요 시간: 30~60초 (경험 수에 비례)
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `savedExperiences`: 즉시 저장된 경험 확인
+- [ ] `mergeCandidates`: 기존 경험과 중복 여부 확인
+- [ ] 저장된 경험의 `documentContent` 내용이 자소서 내용 반영했는지 확인
+- [ ] `attributes` 필드에 프로젝트명, 역할, 기간 등 추출됐는지 확인
+
+---
+
+### T-51 Step3 V1 — 중복 경험 처리 (mergeCandidates 있을 경우)
+
+> T-50 응답의 `mergeCandidates` 가 비어있으면 스킵
+
+```json
+POST /api/experiences/extract/step3
+
+{
+  "decisions": [
+    {
+      "action": "CREATE_NEW",
+      "draft": {
+        "title": "중복으로 감지된 경험 제목",
+        "experienceType": "PROJECT",
+        "experienceGroup": "NARRATIVE",
+        "status": "COMPLETED",
+        "documentContent": "내용...",
+        "attributes": {},
+        "keywords": []
+      }
+    }
+  ]
+}
+```
+
+> `action`: `CREATE_NEW` (새로 저장) 또는 `SKIP` (건너뜀)
+
+---
+
+## 도메인 12 — Experience Extraction V2 ⭐
+
+> 핵심 플로우. **Step1(V1) → Step2 V2 → Step3 V2** 순서  
+> Step1은 V1과 동일 엔드포인트 사용
+
+### T-52 Step1 — 자소서 PDF 업로드 (기존 temp 초기화 후 재추출)
+
+```
+POST /api/experiences/extract/step1
+Content-Type: multipart/form-data
+
+file: (본인 자소서 PDF)
+```
+
+> **주의**: Step1 호출 시 이전 temp가 초기화됩니다.
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] temp ID 목록 메모
+- [ ] 경험 후보 내용 검토 (V1과 동일하나 V2 step2와 연동할 ID 확인)
+
+---
+
+### T-53 Step2 V2 — 상세 추출 + 중복 판정
+
+```json
+POST /api/v2/experiences/extract/step2
+
+{
+  "selectedTempIds": [TEMP_ID_1, TEMP_ID_2]
+}
+```
+
+> 소요 시간: 30~60초
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `savedExperiences` 확인 (중복 아닌 경험 즉시 저장됨)
+- [ ] `duplicateBatchId` 확인
+  - **null**: 중복 없음 → 플로우 종료
+  - **non-null**: → **DUPLICATE_BATCH_ID 메모**, Step3 진행
+- [ ] `duplicateGroups` 배열 확인
+  - 각 그룹의 `groupId` 메모 → **DUPLICATE_GROUP_ID 메모**
+  - `source: "EXISTING"` 항목 = 기존 저장 경험
+  - `source: "EXTRACTED"` 항목 = 이번 추출 후보
+  - `similarity` 값 확인 (0.8 이상이면 중복 판정)
+
+---
+
+### T-54 pending duplicates 조회 (앱 재시작 복원 시뮬레이션)
+
+```
+GET /api/v2/experiences/extract/duplicates/pending
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] T-53에서 생성된 batch 포함 확인
+- [ ] `duplicateBatchId`, `duplicateGroups` 구조 확인
+
+---
+
+### T-55 Step3 V2 — 중복 최종 선택 (기존 경험 유지)
+
+> 기존 경험(`source: "EXISTING"`)을 선택하는 시나리오
+
+```json
+POST /api/v2/experiences/extract/step3
+
+{
+  "duplicateBatchId": "{DUPLICATE_BATCH_ID}",
+  "groups": [
+    {
+      "groupId": "{DUPLICATE_GROUP_ID}",
+      "selectedItemIds": ["{EXISTING_ITEM_ID}"]
+    }
+  ]
+}
+```
+
+**확인 포인트**
+- [ ] 200 반환
+- [ ] `selectedExperiences`: 선택된 경험 확인
+- [ ] `deletedExperienceIds`: 삭제된 경험 ID 확인
+- [ ] GET /api/experiences 재조회 → 선택된 경험만 남아있는지 확인
+- [ ] GET /api/v2/experiences/extract/duplicates/pending → batch 없어짐 확인
+
+---
+
+### T-56 Step3 V2 — 중복 최종 선택 (추출 후보 사용) — 재테스트
+
+> 이번에는 추출 후보(`source: "EXTRACTED"`)를 선택하는 시나리오  
+> Step1 → Step2를 다시 실행해서 중복 batch 재생성 후 테스트
+
+```json
+POST /api/v2/experiences/extract/step3
+
+{
+  "duplicateBatchId": "{NEW_DUPLICATE_BATCH_ID}",
+  "groups": [
+    {
+      "groupId": "{GROUP_ID}",
+      "selectedItemIds": ["{EXTRACTED_ITEM_ID}"]
+    }
+  ]
+}
+```
+
+**확인 포인트**
+- [ ] 기존 경험이 추출 후보로 교체됐는지 확인
+- [ ] `deletedExperienceIds` 에 기존 경험 ID 포함
+
+---
+
+## 에러 케이스 테스트
+
+### E-01 인증 없이 API 호출
+
+```bash
+curl -s http://localhost:8080/api/user
+```
+
+**기대**: `401 Unauthorized`
+
+---
+
+### E-02 잘못된 JWT
+
+```bash
+curl -s http://localhost:8080/api/user \
+  -H "Cookie: accessToken=invalidtoken123"
+```
+
+**기대**: `401 Unauthorized`
+
+---
+
+### E-03 없는 리소스 조회
+
+```
+GET /api/experiences/00000000-0000-0000-0000-000000000000
+```
+
+**기대**: `400` 또는 `404`
+
+---
+
+### E-04 Step2 — temp ID 없이 호출
+
+```json
+POST /api/v2/experiences/extract/step2
+
+{
+  "selectedTempIds": []
+}
+```
+
+**기대**: `400 Bad Request`
+
+---
+
+### E-05 이미 처리된 batch로 Step3 재호출
+
+> T-55 완료 후 동일한 batchId로 Step3 재호출
+
+```json
+POST /api/v2/experiences/extract/step3
+
+{
+  "duplicateBatchId": "{COMPLETED_BATCH_ID}",
+  "groups": [ ... ]
+}
+```
+
+**기대**: `400 Bad Request` + 에러 메시지 확인
+
+---
+
+### E-06 Notice URL 분석 — 잘못된 URL
+
+```json
+POST /api/notices/analyze/url
+
+{
+  "url": ""
+}
+```
+
+**기대**: `400 Bad Request` (validation)
+
+---
+
+### E-07 Application 필수 필드 누락
+
+```json
+POST /api/application
+
+{
+  "company": "테스트"
+}
+```
+
+> `status` 누락
+
+**기대**: `400 Bad Request`
+
+---
+
+## 테스트 완료 체크리스트
+
+### User / Onboarding
+- [ ] T-01 프로필 조회
+- [ ] T-02 이미지 업로드
+- [ ] T-03 이미지 조회
+- [ ] T-04 온보딩 상태 조회
+- [ ] T-05 온보딩 초기화
+- [ ] T-06~10 온보딩 단계별 저장
+
+### Notice
+- [ ] T-11 URL 분석 _(URL 직접 찾아 입력)_
+- [ ] T-12 PDF 분석
+
+### Application
+- [ ] T-13 수기 추가
+- [ ] T-14 목록 조회
+- [ ] T-15 수정
+- [ ] T-16 삭제
+
+### Todo
+- [ ] T-17~18 추가
+- [ ] T-19~20 조회
+- [ ] T-21 수정
+- [ ] T-22 삭제
+
+### Document
+- [ ] T-23~24 작성
+- [ ] T-25~26 조회
+- [ ] T-27 수정
+- [ ] T-28 삭제
+
+### CoverLetter
+- [ ] T-29~30 생성
+- [ ] T-31 조회
+- [ ] T-32 수정
+- [ ] T-33 삭제
+
+### File
+- [ ] T-34 업로드
+- [ ] T-35~36 조회
+
+### Calendar
+- [ ] T-37~41 _(Google OAuth 연동 필요)_
+
+### Experience CRUD
+- [ ] T-42~44 수기 생성 3개
+- [ ] T-45~46 조회
+- [ ] T-47 수정
+- [ ] T-48 삭제
+
+### Experience Extraction V1
+- [ ] T-49 Step1 (자소서 PDF 업로드)
+- [ ] T-50 Step2
+- [ ] T-51 Step3 _(중복 있을 경우)_
+
+### Experience Extraction V2 ⭐
+- [ ] T-52 Step1 (자소서 PDF 업로드)
+- [ ] T-53 Step2 V2 (중복 판정)
+- [ ] T-54 pending 조회
+- [ ] T-55 Step3 V2 (기존 유지)
+- [ ] T-56 Step3 V2 (추출 후보 선택)
+
+### 에러 케이스
+- [ ] E-01 ~ E-07
+
+---
+
+## 빠른 상태 확인 명령
+
+```bash
+# 내 현재 경험/temp/batch 상태 한번에 확인
+curl -s "http://localhost:8080/internal/experience-extraction-test/state" \
+  -H "Cookie: accessToken={JWT_TOKEN}" | python3 -m json.tool
+```
+
+출력 예시:
+
+```json
+{
+  "email": "test@pickd.local",
+  "experiences": [ ... ],   // 저장된 경험
+  "temps": [ ... ],         // Step1 후보 (처리 전)
+  "batches": [ ... ]        // 중복 batch 목록 + 상태
+}
+```

--- a/scripts/e2e_test.py
+++ b/scripts/e2e_test.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""
+PICKD 로컬 E2E 테스트 스크립트
+=================================
+사전 조건:
+  - BE 서버: http://localhost:8080  (./gradlew bootRun --args='--spring.profiles.active=local')
+  - AI 서버: http://localhost:8000  (uvicorn app.main:app --reload)
+
+실행:
+  python scripts/e2e_test.py
+
+의존 라이브러리 (표준 라이브러리만 사용, 설치 불필요):
+  - urllib.request / urllib.error / json (Python 표준)
+"""
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import urlencode
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 설정
+# ──────────────────────────────────────────────────────────────────────────────
+
+BE = "http://localhost:8080"
+AI = "http://localhost:8000"
+
+TEST_EMAIL   = "test@pickd.local"
+TEST_NAME    = "E2E테스트유저"
+RESUME_URL   = "https://example.com/dummy-resume.pdf"
+
+# 기준 경험 seed (Step2 중복 판정 기준이 될 기존 경험들)
+SEED_EXPERIENCES = [
+    {
+        "title": "금융 AI Agent 프로젝트",
+        "experienceType": "PROJECT",
+        "experienceGroup": "NARRATIVE",
+        "status": "COMPLETED",
+        "documentContent": "추천 모델 개선을 담당했습니다. 추천 정확도 15% 향상.",
+        "attributes": {"project_name": "금융 AI Agent", "role": "백엔드 개발", "period": "2023.03 ~ 2023.08"},
+        "keywords": ["문제 해결", "실행력"],
+        "forceCreate": True,
+    },
+    {
+        "title": "TOEIC 930점",
+        "experienceType": "LANGUAGE",
+        "experienceGroup": "SPEC",
+        "status": "COMPLETED",
+        "documentContent": None,
+        "attributes": {"score": "930", "test_name": "TOEIC"},
+        "keywords": ["어학"],
+        "forceCreate": True,
+    },
+    {
+        "title": "카카오 서버 인턴십",
+        "experienceType": "INTERN",
+        "experienceGroup": "NARRATIVE",
+        "status": "COMPLETED",
+        "documentContent": "Spring Boot 기반 API 개발 및 유지보수를 담당했습니다.",
+        "attributes": {"company": "카카오", "role": "서버 개발", "period": "2023.07 ~ 2023.08"},
+        "keywords": ["Spring", "Java", "협업"],
+        "forceCreate": True,
+    },
+]
+
+# Step1 → Step2 대상 temp experiences
+TEMP_EXPERIENCES = [
+    {"name": "금융 AI Agent 프로젝트",  "type": "PROJECT",  "group": "NARRATIVE"},
+    {"name": "TOEIC 930점",            "type": "LANGUAGE", "group": "SPEC"},
+]
+
+# 중복 판정 재현용 temp (기존 경험과 동일한 제목 재주입)
+DUPLICATE_TEMP_EXPERIENCES = [
+    {"name": "금융 AI Agent 프로젝트",  "type": "PROJECT",  "group": "NARRATIVE"},
+]
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 유틸
+# ──────────────────────────────────────────────────────────────────────────────
+
+PASSED = []
+FAILED = []
+
+def _color(text, code): return f"\033[{code}m{text}\033[0m"
+def ok(msg):   print(_color(f"  ✓ {msg}", "32"))
+def fail(msg): print(_color(f"  ✗ {msg}", "31"))
+def info(msg): print(_color(f"  · {msg}", "36"))
+def section(title): print(_color(f"\n[{title}]", "1;33"))
+
+
+def request(method, url, data=None, headers=None, cookie=None):
+    """간단한 HTTP 요청 헬퍼. JSON body + 쿠키 지원."""
+    req_headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if headers:
+        req_headers.update(headers)
+    if cookie:
+        req_headers["Cookie"] = f"accessToken={cookie}"
+
+    body = json.dumps(data).encode() if data is not None else None
+    req = urllib.request.Request(url, data=body, headers=req_headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode()
+            return resp.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            return e.code, json.loads(raw)
+        except Exception:
+            return e.code, raw
+
+
+def check(label, condition, detail=""):
+    if condition:
+        ok(label)
+        PASSED.append(label)
+    else:
+        fail(f"{label}  {detail}")
+        FAILED.append(label)
+
+
+def abort(msg):
+    fail(f"ABORT: {msg}")
+    summary()
+    sys.exit(1)
+
+
+def summary():
+    print(_color(f"\n{'='*50}", "1"))
+    print(_color(f"  PASSED: {len(PASSED)}", "32"))
+    if FAILED:
+        print(_color(f"  FAILED: {len(FAILED)}", "31"))
+        for f in FAILED:
+            print(_color(f"    - {f}", "31"))
+    print(_color(f"{'='*50}", "1"))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 테스트 단계
+# ──────────────────────────────────────────────────────────────────────────────
+
+def step1_health():
+    section("STEP 1 — 서버 헬스 체크")
+
+    status, body = request("GET", f"{AI}/health")
+    check("AI 서버 응답", status == 200, f"status={status}")
+    if status != 200:
+        abort("AI 서버가 응답하지 않습니다. 먼저 AI 서버를 실행하세요.")
+
+    status, body = request("GET", f"{BE}/swagger-ui/index.html")
+    check("BE 서버 응답", status == 200, f"status={status}")
+    if status != 200:
+        abort("BE 서버가 응답하지 않습니다. 먼저 BE 서버를 실행하세요.")
+
+
+def step2_seed_user():
+    section("STEP 2 — 테스트 유저 생성 + JWT 획득")
+
+    status, body = request("POST", f"{BE}/internal/seed/user", {
+        "email": TEST_EMAIL,
+        "name":  TEST_NAME,
+    })
+    check("POST /internal/seed/user → 200", status == 200, f"status={status} body={body}")
+    if status != 200:
+        abort("seed/user 실패. BE가 local 프로파일로 실행 중인지 확인하세요.")
+
+    token = body["accessToken"]
+    info(f"유저 ID={body['id']}  email={body['email']}")
+    info(f"JWT={token[:40]}...")
+    return token
+
+
+def step3_seed_experiences(token):
+    section("STEP 3 — 수기 경험 seed (3개)")
+
+    ids = []
+    for exp in SEED_EXPERIENCES:
+        status, body = request("POST", f"{BE}/api/experiences", exp, cookie=token)
+        check(f"POST /api/experiences [{exp['title'][:20]}]", status == 200, f"status={status}")
+        if status == 200 and isinstance(body, dict):
+            ids.append(body.get("id"))
+
+    status, body = request("GET", f"{BE}/api/experiences", cookie=token)
+    check("GET /api/experiences → 3개", status == 200 and isinstance(body, list) and len(body) >= 3,
+          f"count={len(body) if isinstance(body, list) else '?'}")
+    info(f"저장된 경험 수: {len(body) if isinstance(body, list) else '?'}")
+    return ids
+
+
+def step4_seed_temps(token):
+    section("STEP 4 — ExperienceTemp 주입 (Step1 대체)")
+
+    status, body = request("POST", f"{BE}/internal/seed/temp", {
+        "email":       TEST_EMAIL,
+        "resumeUrl":   RESUME_URL,
+        "experiences": TEMP_EXPERIENCES,
+    })
+    check("POST /internal/seed/temp → 200", status == 200, f"status={status} body={body}")
+    if status != 200:
+        abort("temp seed 실패")
+
+    temp_ids = body["tempIds"]
+    info(f"주입된 temp IDs: {temp_ids}")
+    return temp_ids
+
+
+def step5_extract_step2(token, temp_ids):
+    section("STEP 5 — BE Step2 V2 호출 (AI 연동)")
+
+    info("AI 경험 추출 중... (10~30초 소요)")
+    status, body = request("POST", f"{BE}/api/v2/experiences/extract/step2",
+                           {"selectedTempIds": temp_ids}, cookie=token)
+    check("POST /api/v2/experiences/extract/step2 → 200", status == 200, f"status={status}")
+    if status != 200:
+        info(f"응답: {json.dumps(body, ensure_ascii=False)[:300]}")
+        abort("Step2 실패")
+
+    saved = body.get("savedExperiences", [])
+    batch_id = body.get("duplicateBatchId")
+    dup_groups = body.get("duplicateGroups", [])
+
+    check("savedExperiences 존재", len(saved) > 0, f"count={len(saved)}")
+    info(f"저장된 경험: {[e.get('title') for e in saved]}")
+    info(f"중복 batchId: {batch_id}")
+    info(f"중복 그룹 수: {len(dup_groups)}")
+    return body
+
+
+def step6_verify_state(token, step2_result):
+    section("STEP 6 — DB 상태 검증")
+
+    status, body = request("GET", f"{BE}/internal/experience-extraction-test/state", cookie=token)
+    check("GET /internal/experience-extraction-test/state → 200", status == 200, f"status={status}")
+    if status != 200:
+        return
+
+    exp_count  = len(body.get("experiences", []))
+    temp_count = len(body.get("temps", []))
+    batch_count = len(body.get("batches", []))
+    info(f"experiences={exp_count}  temps={temp_count}  batches={batch_count}")
+
+    check("temp가 처리되어 0개", temp_count == 0, f"남은 temp={temp_count}")
+    check("experience 3개 이상", exp_count >= 3, f"count={exp_count}")
+
+    batch_id = step2_result.get("duplicateBatchId")
+    if batch_id:
+        batches = body.get("batches", [])
+        pending = [b for b in batches if b.get("status") == "PENDING"]
+        check("PENDING batch 존재", len(pending) > 0, f"pending={len(pending)}")
+
+
+def step7_duplicate_batch(token):
+    section("STEP 7 — 중복 batch 생성 검증 (동일 temp 재주입)")
+
+    # 동일 경험 재주입
+    status, body = request("POST", f"{BE}/internal/seed/temp", {
+        "email":       TEST_EMAIL,
+        "resumeUrl":   RESUME_URL,
+        "experiences": DUPLICATE_TEMP_EXPERIENCES,
+    })
+    check("중복 temp 재주입 → 200", status == 200, f"status={status}")
+    if status != 200:
+        return None
+
+    temp_ids = body["tempIds"]
+    info(f"재주입 temp IDs: {temp_ids}")
+
+    info("Step2 재호출 (중복 판정 예상)...")
+    status, body = request("POST", f"{BE}/api/v2/experiences/extract/step2",
+                           {"selectedTempIds": temp_ids}, cookie=token)
+    check("Step2 재호출 → 200", status == 200, f"status={status}")
+    if status != 200:
+        return None
+
+    batch_id = body.get("duplicateBatchId")
+    dup_groups = body.get("duplicateGroups", [])
+    check("중복 batchId 생성됨", batch_id is not None, "batchId=None → 중복 미감지")
+    info(f"중복 batchId: {batch_id}  groups: {len(dup_groups)}")
+    return batch_id, body.get("duplicateGroups", [])
+
+
+def step8_pending_duplicates(token):
+    section("STEP 8 — pending duplicates 조회")
+
+    status, body = request("GET", f"{BE}/api/v2/experiences/extract/duplicates/pending", cookie=token)
+    check("GET /duplicates/pending → 200", status == 200, f"status={status}")
+    if status != 200:
+        return None, None
+
+    batches = body.get("batches", [])
+    check("pending batch 목록 존재", len(batches) > 0, f"count={len(batches)}")
+    if batches:
+        first = batches[0]
+        info(f"첫 번째 batch ID: {first.get('duplicateBatchId')}")
+        info(f"groups 수: {len(first.get('duplicateGroups', []))}")
+        return first.get("duplicateBatchId"), first.get("duplicateGroups", [])
+    return None, None
+
+
+def step9_step3(token, batch_id, dup_groups):
+    section("STEP 9 — Step3 중복 선택 처리")
+
+    if not batch_id or not dup_groups:
+        info("batch_id 또는 dup_groups 없음 — Step3 스킵")
+        return
+
+    # 각 그룹에서 첫 번째 item 선택 (EXISTING 또는 EXTRACTED)
+    selections = []
+    for group in dup_groups:
+        group_id = group.get("groupId")
+        items    = group.get("items", [])
+        if items:
+            selected_id = items[0].get("itemId")
+            selections.append({"groupId": group_id, "selectedItemIds": [selected_id]})
+
+    status, body = request("POST", f"{BE}/api/v2/experiences/extract/step3", {
+        "duplicateBatchId": batch_id,
+        "groups": selections,
+    }, cookie=token)
+    check("POST /api/v2/experiences/extract/step3 → 200", status == 200, f"status={status}")
+    if status != 200:
+        info(f"응답: {json.dumps(body, ensure_ascii=False)[:300]}")
+        return
+
+    selected = body.get("selectedExperiences", [])
+    deleted  = body.get("deletedExperienceIds", [])
+    info(f"최종 선택 경험: {[e.get('title') for e in selected]}")
+    info(f"삭제된 경험 IDs: {deleted}")
+
+
+def step10_final_state(token):
+    section("STEP 10 — 최종 DB 상태 검증")
+
+    status, body = request("GET", f"{BE}/internal/experience-extraction-test/state", cookie=token)
+    check("최종 state 조회 → 200", status == 200, f"status={status}")
+    if status != 200:
+        return
+
+    exp_count  = len(body.get("experiences", []))
+    temp_count = len(body.get("temps", []))
+    batches    = body.get("batches", [])
+    completed  = [b for b in batches if b.get("status") == "COMPLETED"]
+
+    check("temp 0개 (모두 처리됨)", temp_count == 0, f"남은 temp={temp_count}")
+    check("완료된 batch 존재", len(completed) > 0, f"completed={len(completed)}")
+
+    print()
+    info(f"최종 상태 — experiences: {exp_count}  temps: {temp_count}  batches: {len(batches)} (완료: {len(completed)})")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 메인
+# ──────────────────────────────────────────────────────────────────────────────
+
+def main():
+    print(_color("=" * 50, "1;36"))
+    print(_color("  PICKD 로컬 E2E 테스트", "1;36"))
+    print(_color("=" * 50, "1;36"))
+    print(f"  BE: {BE}")
+    print(f"  AI: {AI}")
+    print(f"  테스트 유저: {TEST_EMAIL}")
+
+    step1_health()
+    token = step2_seed_user()
+    step3_seed_experiences(token)
+    temp_ids = step4_seed_temps(token)
+    step2_result = step5_extract_step2(token, temp_ids)
+    step6_verify_state(token, step2_result)
+    dup_result = step7_duplicate_batch(token)
+    if dup_result:
+        _batch_id, _groups = dup_result
+    else:
+        _batch_id, _groups = None, []
+    batch_id, dup_groups = step8_pending_duplicates(token)
+    step9_step3(token, batch_id or _batch_id, dup_groups or _groups)
+    step10_final_state(token)
+
+    summary()
+    sys.exit(1 if FAILED else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_h2.sql
+++ b/scripts/seed_h2.sql
@@ -1,0 +1,171 @@
+-- ============================================================
+-- PICKD 로컬 H2 수동 seed SQL
+-- ============================================================
+-- 용도: 프론트 화면 연결 테스트용 더미 데이터
+-- 실행: http://localhost:8080/h2-console
+--       JDBC URL: jdbc:h2:mem:pickd
+--       User: sa / Password: (비워둠)
+-- 주의: BE가 local 프로파일로 실행 중일 때만 유효.
+--       서버 재시작 시 H2 인메모리 DB가 초기화됩니다.
+--       E2E 스크립트(e2e_test.py)는 /internal/seed/* API를 사용하므로
+--       이 SQL과 별개입니다.
+-- ============================================================
+
+
+-- ──────────────────────────────────────────────────────────────
+-- 1. 테스트 유저
+-- ──────────────────────────────────────────────────────────────
+-- JWT는 BE 로그로 확인하거나 /internal/seed/user API로 발급
+
+INSERT INTO users (email, name, nickname, picture, phone, birth_date, is_verified, intro,
+                   provider, onboarding_step,
+                   service_agreed, privacy_agreed, marketing_agreed, push_agreed,
+                   last_login_date)
+VALUES (
+    'test@pickd.local',
+    '테스트유저',
+    '테스트닉네임',
+    NULL,
+    '010-0000-0000',
+    '19990101',
+    TRUE,
+    '프론트 연동 테스트용 계정입니다.',
+    'GOOGLE',
+    'COMPLETED',
+    TRUE, TRUE, FALSE, FALSE,
+    CURRENT_TIMESTAMP
+);
+
+
+-- ──────────────────────────────────────────────────────────────
+-- 2. 저장된 경험 (UserExperience) — 3개
+--    id: UUID 문자열, user_id: 위에서 생성된 ID (기본값 1)
+-- ──────────────────────────────────────────────────────────────
+
+-- 2-1. PROJECT / NARRATIVE
+INSERT INTO user_experiences (id, user_id, title, experience_type, experience_group,
+                              status, document_content, attributes, keywords,
+                              created_at, updated_at)
+VALUES (
+    'aaaaaaaa-0001-0001-0001-000000000001',
+    1,
+    '금융 AI Agent 프로젝트',
+    'PROJECT',
+    'NARRATIVE',
+    'COMPLETED',
+    '추천 모델 개선을 담당했습니다. 추천 정확도를 15% 향상시켰으며 Spring Boot 기반 REST API를 설계하였습니다.',
+    '{"project_name":"금융 AI Agent","role":"백엔드 개발","period":"2023.03 ~ 2023.08","organization":"부산대학교 캡스톤팀","achievements":"추천 정확도 15% 향상"}',
+    '["문제 해결","실행력","API 설계"]',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);
+
+-- 2-2. LANGUAGE / SPEC
+INSERT INTO user_experiences (id, user_id, title, experience_type, experience_group,
+                              status, document_content, attributes, keywords,
+                              created_at, updated_at)
+VALUES (
+    'aaaaaaaa-0002-0002-0002-000000000002',
+    1,
+    'TOEIC 930점',
+    'LANGUAGE',
+    'SPEC',
+    'COMPLETED',
+    NULL,
+    '{"score":"930","test_name":"TOEIC","acquired_date":"2023-06"}',
+    '["어학","영어"]',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);
+
+-- 2-3. INTERN / NARRATIVE
+INSERT INTO user_experiences (id, user_id, title, experience_type, experience_group,
+                              status, document_content, attributes, keywords,
+                              created_at, updated_at)
+VALUES (
+    'aaaaaaaa-0003-0003-0003-000000000003',
+    1,
+    '카카오 서버 인턴십',
+    'INTERN',
+    'NARRATIVE',
+    'COMPLETED',
+    'Spring Boot 기반 API 개발 및 유지보수를 담당했습니다. 코드 리뷰 문화에 적응하며 팀원과의 협업 역량을 키웠습니다.',
+    '{"company":"카카오","role":"서버 개발","period":"2023.07 ~ 2023.08"}',
+    '["Spring","Java","협업","코드리뷰"]',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);
+
+
+-- ──────────────────────────────────────────────────────────────
+-- 3. ExperienceTemp — Step1 완료 후 상태 흉내내기
+--    프론트가 "Step2 진입 직후" 화면을 테스트할 수 있도록
+-- ──────────────────────────────────────────────────────────────
+
+INSERT INTO experience_temps (user_id, experience_name, experience_group, experience_type, resume_url, created_at)
+VALUES (1, '공모전 수상 경험', 'NARRATIVE', 'CONTEST', 'https://example.com/dummy-resume.pdf', CURRENT_TIMESTAMP);
+
+INSERT INTO experience_temps (user_id, experience_name, experience_group, experience_type, resume_url, created_at)
+VALUES (1, '정보처리기사 취득', 'SPEC', 'LICENSE', 'https://example.com/dummy-resume.pdf', CURRENT_TIMESTAMP);
+
+
+-- ──────────────────────────────────────────────────────────────
+-- 4. 중복 처리 테스트용 PENDING batch + group + draft
+--    프론트가 "Step3 중복 선택 화면"을 바로 테스트할 수 있도록
+-- ──────────────────────────────────────────────────────────────
+
+-- 4-1. ExperienceExtractionBatch (PENDING)
+INSERT INTO experience_extraction_batches (id, user_id, status, created_at)
+VALUES ('bbbbbbbb-batch-0001-0001-000000000001', 1, 'PENDING', CURRENT_TIMESTAMP);
+
+-- 4-2. ExperienceDuplicateGroup
+--      existing_experience_id = 위에서 넣은 '금융 AI Agent 프로젝트' ID
+INSERT INTO experience_duplicate_groups (id, batch_id, existing_experience_id)
+VALUES (
+    'cccccccc-group-0001-0001-000000000001',
+    'bbbbbbbb-batch-0001-0001-000000000001',
+    'aaaaaaaa-0001-0001-0001-000000000001'
+);
+
+-- 4-3. ExperienceExtractionDraft (추출 후보)
+INSERT INTO experience_extraction_drafts (id, duplicate_group_id,
+    title, experience_type, experience_group, status,
+    document_content, attributes, keywords, resume_url, similarity)
+VALUES (
+    'dddddddd-draft-0001-0001-000000000001',
+    'cccccccc-group-0001-0001-000000000001',
+    '금융 AI Agent 프로젝트 (재추출)',
+    'PROJECT',
+    'NARRATIVE',
+    'COMPLETED',
+    '추천 시스템 개선을 통해 정확도를 15% 향상시킨 경험입니다.',
+    '{"project_name":"금융 AI Agent","role":"백엔드 개발"}',
+    '["문제 해결","실행력"]',
+    'https://example.com/dummy-resume.pdf',
+    0.92
+);
+
+
+-- ──────────────────────────────────────────────────────────────
+-- 5. COMPLETED batch 샘플 (Step3 완료 상태 확인용)
+-- ──────────────────────────────────────────────────────────────
+
+INSERT INTO experience_extraction_batches (id, user_id, status, created_at, processed_at)
+VALUES (
+    'eeeeeeee-batch-done-0001-000000000002',
+    1,
+    'COMPLETED',
+    DATEADD(DAY, -1, CURRENT_TIMESTAMP),
+    CURRENT_TIMESTAMP
+);
+
+
+-- ──────────────────────────────────────────────────────────────
+-- 확인 쿼리
+-- ──────────────────────────────────────────────────────────────
+-- SELECT * FROM users;
+-- SELECT id, title, experience_type, status FROM user_experiences;
+-- SELECT id, experience_name, experience_type FROM experience_temps;
+-- SELECT id, status FROM experience_extraction_batches;
+-- SELECT id, batch_id, existing_experience_id FROM experience_duplicate_groups;
+-- SELECT id, duplicate_group_id, title, similarity FROM experience_extraction_drafts;

--- a/src/main/java/back/pickd/application/controller/TodoController.java
+++ b/src/main/java/back/pickd/application/controller/TodoController.java
@@ -65,7 +65,21 @@ public class TodoController {
         return todoService.getTodosByApplication(applicationId, authentication);
     }
 
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
+    @Operation(summary = "할 일 수정", description = "할 일의 title, dueDateTime, memo를 부분 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = TodoResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public TodoResponse updateTodo(@PathVariable Long id,
+                                   @RequestBody TodoRequest dto,
+                                   @Parameter(hidden = true) Authentication authentication) {
+        return todoService.updateTodo(id, dto, authentication);
+    }
+
+    @PutMapping("/{id}/toggle")
     @Operation(summary = "할 일 완료 토글", description = "할 일의 완료 상태를 반전시킵니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "토글 성공"),

--- a/src/main/java/back/pickd/application/dto/request/ApplicationRequest.java
+++ b/src/main/java/back/pickd/application/dto/request/ApplicationRequest.java
@@ -1,6 +1,7 @@
 package back.pickd.application.dto.request;
 
 import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.notice.enums.JobCategory;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,12 +12,23 @@ import java.time.LocalDateTime;
 @Setter
 public class ApplicationRequest {
 
+    // 기존 공고 연결 (AI 분석된 공고)
     private Long noticeId;
 
+    // 수기 입력용 공고 정보 (noticeId 없을 때 Notice 자동 생성)
     private String company;
     private String jobTitle;
     private String position;
     private String industry;
+
+    /** 수기 입력 시 공고 카테고리 (미입력 시 FULL_TIME 기본값) */
+    private JobCategory category;
+
+    /** 수기 입력 시 공고 시작일 (미입력 시 오늘 날짜, 형식: yyyy-MM-dd) */
+    private String startedAt;
+
+    /** 수기 입력 시 공고 마감일 (선택) */
+    private String endedAt;
 
     @NotNull
     private ApplicationStatus status;

--- a/src/main/java/back/pickd/application/entity/Todo.java
+++ b/src/main/java/back/pickd/application/entity/Todo.java
@@ -64,6 +64,12 @@ public class Todo {
         this.completed = !this.completed;
     }
 
+    public void update(String title, LocalDateTime dueDateTime, String memo) {
+        if (title      != null) this.title       = title;
+        if (dueDateTime != null) this.dueDateTime = dueDateTime;
+        if (memo       != null) this.memo        = memo;
+    }
+
     public void assignCalendarEventId(String eventId) {
         this.calendarEventId = eventId;
     }

--- a/src/main/java/back/pickd/application/enums/ApplicationStatus.java
+++ b/src/main/java/back/pickd/application/enums/ApplicationStatus.java
@@ -22,7 +22,7 @@ public enum ApplicationStatus {
     @JsonCreator
     public static ApplicationStatus from(String label) {
         for (ApplicationStatus status : values()) {
-            if (status.label.equals(label)) {
+            if (status.label.equals(label) || status.name().equals(label)) {
                 return status;
             }
         }

--- a/src/main/java/back/pickd/application/service/ApplicationService.java
+++ b/src/main/java/back/pickd/application/service/ApplicationService.java
@@ -7,6 +7,7 @@ import back.pickd.application.enums.ApplicationStatus;
 import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.calendar.service.CalendarAsyncService;
 import back.pickd.notice.entity.Notice;
+import back.pickd.notice.enums.JobCategory;
 import back.pickd.notice.repository.NoticeRepository;
 import back.pickd.user.entity.User;
 import back.pickd.user.service.UserService;
@@ -42,10 +43,29 @@ public class ApplicationService {
         User user = userService.findByEmail(auth.getName());
         ApplicationStatus status = dto.getStatus();
 
-        Notice notice = null;
+        Notice notice;
         if (dto.getNoticeId() != null) {
+            // 기존 AI 분석 공고와 연결
             notice = noticeRepository.findByIdAndUser(dto.getNoticeId(), user)
                     .orElseThrow(() -> new IllegalArgumentException("공고를 찾을 수 없습니다."));
+        } else {
+            // 수기 입력: 최소 정보로 Notice 자동 생성
+            String companyName = dto.getCompany() != null ? dto.getCompany() : "미입력";
+            String noticeName  = dto.getJobTitle() != null ? dto.getJobTitle() : "미입력";
+            JobCategory category = dto.getCategory() != null ? dto.getCategory() : JobCategory.FULL_TIME;
+            String startedAt = dto.getStartedAt() != null ? dto.getStartedAt()
+                    : java.time.LocalDate.now().toString();
+
+            notice = noticeRepository.save(
+                    Notice.builder()
+                            .user(user)
+                            .companyName(companyName)
+                            .noticeName(noticeName)
+                            .category(category)
+                            .startedAt(startedAt)
+                            .endedAt(dto.getEndedAt())
+                            .build()
+            );
         }
 
         Application app = Application.builder()

--- a/src/main/java/back/pickd/application/service/TodoService.java
+++ b/src/main/java/back/pickd/application/service/TodoService.java
@@ -81,6 +81,14 @@ public class TodoService {
         todo.toggleCompleted();
     }
 
+    public TodoResponse updateTodo(Long id, TodoRequest dto, Authentication authentication) {
+        User user = userService.findByEmail(authentication.getName());
+        Todo todo = todoRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new IllegalArgumentException("할 일을 찾을 수 없습니다."));
+        todo.update(dto.getTitle(), parseDueDateTime(dto.getDueDateTime()), dto.getMemo());
+        return TodoResponse.from(todo);
+    }
+
     public void deleteTodo(Long id, Authentication authentication) {
         User user = userService.findByEmail(authentication.getName());
         Todo todo = todoRepository.findByIdAndUser(id, user)

--- a/src/main/java/back/pickd/auth/config/SecurityConfig.java
+++ b/src/main/java/back/pickd/auth/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                     "/onboarding-test.html",
                     "/experience-extraction-test",
                     "/api/experiences/extract/temp-token",
+                    "/internal/seed/**",
                     "/swagger-ui.html",
                     "/swagger-ui/**",
                     "/v3/api-docs/**"

--- a/src/main/java/back/pickd/auth/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/back/pickd/auth/oauth/OAuth2SuccessHandler.java
@@ -6,6 +6,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -41,25 +44,26 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     (String) attributes.get("picture")
             );
 
-            OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
-                    oauthToken.getAuthorizedClientRegistrationId(),
-                    oauthToken.getName()
-            );
-
-            if (client != null) {
-                Authentication newAuth =
-                        new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
-                                email, null, authentication.getAuthorities()
-                        );
-
-                authorizedClientService.saveAuthorizedClient(client, newAuth);
-            }
-
+            // JWT 발급 및 쿠키 설정 (핵심 로그인 흐름 — 먼저 처리)
             String token = jwtTokenProvider.createToken(email, authentication.getAuthorities());
             setTokenCookie(response, token);
 
-            // 테스트를 위해 백엔드 포트의 테스트 페이지로 이동
-            response.sendRedirect("http://localhost:8080/onboarding-test.html");
+            // Google Calendar/Drive 클라이언트 저장 (실패해도 로그인은 정상 처리)
+            try {
+                OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
+                        oauthToken.getAuthorizedClientRegistrationId(),
+                        oauthToken.getName()
+                );
+                if (client != null) {
+                    UsernamePasswordAuthenticationToken newAuth =
+                            new UsernamePasswordAuthenticationToken(email, null, authentication.getAuthorities());
+                    authorizedClientService.saveAuthorizedClient(client, newAuth);
+                }
+            } catch (Exception e) {
+                log.warn("OAuth2 authorized client 저장 실패 (캘린더/드라이브 연동 불가): {}", e.getMessage());
+            }
+
+            response.sendRedirect("http://localhost:5173/onboarding");
         }
     }
 

--- a/src/main/java/back/pickd/auth/security/JwtAuthFilter.java
+++ b/src/main/java/back/pickd/auth/security/JwtAuthFilter.java
@@ -34,13 +34,20 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
+        // 1. 쿠키 우선 (실제 서비스 흐름)
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
-            return Arrays.stream(cookies)
+            String fromCookie = Arrays.stream(cookies)
                     .filter(c -> "accessToken".equals(c.getName()))
                     .findFirst()
                     .map(Cookie::getValue)
                     .orElse(null);
+            if (fromCookie != null) return fromCookie;
+        }
+        // 2. Authorization 헤더 fallback (Swagger UI 테스트용)
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
         }
         return null;
     }

--- a/src/main/java/back/pickd/document/enums/DocumentStatus.java
+++ b/src/main/java/back/pickd/document/enums/DocumentStatus.java
@@ -18,7 +18,7 @@ public enum DocumentStatus {
     @JsonCreator
     public static DocumentStatus from(String label) {
         for (DocumentStatus s : values()) {
-            if (s.label.equals(label)) return s;
+            if (s.label.equals(label) || s.name().equals(label)) return s;
         }
         throw new IllegalArgumentException("지원하지 않는 서류 상태입니다: " + label);
     }

--- a/src/main/java/back/pickd/document/enums/DocumentType.java
+++ b/src/main/java/back/pickd/document/enums/DocumentType.java
@@ -19,7 +19,7 @@ public enum DocumentType {
     @JsonCreator
     public static DocumentType from(String label) {
         for (DocumentType t : values()) {
-            if (t.label.equals(label)) return t;
+            if (t.label.equals(label) || t.name().equals(label)) return t;
         }
         throw new IllegalArgumentException("지원하지 않는 서류 유형입니다: " + label);
     }

--- a/src/main/java/back/pickd/experience/controller/ExperienceExtractionController.java
+++ b/src/main/java/back/pickd/experience/controller/ExperienceExtractionController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -42,7 +43,7 @@ public class ExperienceExtractionController {
 
     private final ExperienceExtractionService extractionService;
 
-    @PostMapping("/step1")
+    @PostMapping(value = "/step1", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
             summary = "경험 후보 1차 추출",
             description = """
@@ -63,7 +64,9 @@ public class ExperienceExtractionController {
     })
     public ResponseEntity<List<TempResponse>> extractStep1(
             @Parameter(hidden = true) Authentication authentication,
-            @Parameter(description = "자소서 PDF/문서 파일", required = true)
+            @Parameter(description = "자소서 PDF/문서 파일", required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(type = "string", format = "binary")))
             @RequestParam("file") MultipartFile file) {
 
         List<TempResponse> result = extractionService.extractStep1(authentication.getName(), file)
@@ -76,6 +79,7 @@ public class ExperienceExtractionController {
     @PostMapping("/step2")
     @Operation(
             summary = "선택 경험 상세 추출 및 저장 (V1)",
+            deprecated = true,
             description = """
                     step1에서 선택한 임시 경험 ID를 받아 AI 2차 분석 후 영구 저장합니다.
 
@@ -111,6 +115,7 @@ public class ExperienceExtractionController {
     @PostMapping("/step3")
     @Operation(
             summary = "중복 경험 후처리 (V1)",
+            deprecated = true,
             description = """
                     step2에서 중복으로 분류된 경험을 CREATE_NEW 또는 SKIP 처리합니다.
 

--- a/src/main/java/back/pickd/experience/controller/LocalSeedController.java
+++ b/src/main/java/back/pickd/experience/controller/LocalSeedController.java
@@ -1,0 +1,201 @@
+package back.pickd.experience.controller;
+
+import back.pickd.auth.jwt.JwtTokenProvider;
+import back.pickd.experience.entity.ExperienceTemp;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.repository.ExperienceTempRepository;
+import back.pickd.user.entity.User;
+import back.pickd.user.entity.enums.AuthProvider;
+import back.pickd.user.entity.enums.OnboardingStep;
+import back.pickd.user.repository.UserRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 로컬 E2E 테스트 전용 시드 컨트롤러.
+ *
+ * <p><b>local 프로파일에서만 활성화됩니다. 절대 운영에 배포하지 마세요.</b>
+ *
+ * <ul>
+ *   <li>POST /internal/seed/user         — 테스트 유저 생성 + JWT 반환</li>
+ *   <li>POST /internal/seed/temp         — ExperienceTemp 주입 + ID 목록 반환</li>
+ *   <li>DELETE /internal/seed/temp       — 해당 유저의 temp 전체 삭제</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/internal/seed")
+@Profile("local")
+@RequiredArgsConstructor
+public class LocalSeedController {
+
+    private final UserRepository userRepository;
+    private final ExperienceTempRepository tempRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // POST /internal/seed/user
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @PostMapping("/user")
+    public UserSeedResponse seedUser(@RequestBody UserSeedRequest req) {
+        String email = req.getEmail() != null ? req.getEmail() : "test@pickd.local";
+        String name  = req.getName()  != null ? req.getName()  : "테스트유저";
+
+        User user = userRepository.findByEmail(email).orElseGet(() ->
+                userRepository.save(
+                        User.builder()
+                                .email(email)
+                                .name(name)
+                                .picture(null)
+                                .provider(AuthProvider.GOOGLE)
+                                .onboardingStep(OnboardingStep.COMPLETED)
+                                .serviceAgreed(true)
+                                .privacyAgreed(true)
+                                .marketingAgreed(false)
+                                .pushAgreed(false)
+                                .build()
+                )
+        );
+
+        var auth = new UsernamePasswordAuthenticationToken(
+                new org.springframework.security.core.userdetails.User(
+                        user.getEmail(), "", List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                ),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        String token = jwtTokenProvider.createToken(auth);
+        return new UserSeedResponse(user.getId(), user.getEmail(), user.getName(), token);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // POST /internal/seed/temp
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * ExperienceTemp 레코드를 주입합니다.
+     * Step1 S3 업로드 없이 Step2/Step3 E2E를 검증할 때 사용합니다.
+     *
+     * <p>요청 예시:
+     * <pre>
+     * {
+     *   "email": "test@pickd.local",
+     *   "resumeUrl": "https://example.com/resume.pdf",
+     *   "experiences": [
+     *     { "name": "금융 AI 프로젝트", "type": "PROJECT",  "group": "NARRATIVE" },
+     *     { "name": "TOEIC 930점",     "type": "LANGUAGE", "group": "SPEC"      }
+     *   ]
+     * }
+     * </pre>
+     */
+    @PostMapping("/temp")
+    public TempSeedResponse seedTemp(@RequestBody TempSeedRequest req) {
+        String email     = req.getEmail()     != null ? req.getEmail()     : "test@pickd.local";
+        String resumeUrl = req.getResumeUrl() != null ? req.getResumeUrl() : "https://example.com/dummy-resume.pdf";
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음: " + email + " — 먼저 /internal/seed/user 를 호출하세요."));
+
+        List<TempSeedRequest.TempEntry> entries = req.getExperiences() != null
+                ? req.getExperiences()
+                : defaultEntries();
+
+        List<Long> ids = entries.stream()
+                .map(e -> tempRepository.save(
+                        ExperienceTemp.builder()
+                                .user(user)
+                                .experienceName(e.getName())
+                                .experienceType(ExperienceType.valueOf(e.getType()))
+                                .experienceGroup(ExperienceGroup.valueOf(e.getGroup()))
+                                .resumeUrl(resumeUrl)
+                                .build()
+                ).getId())
+                .toList();
+
+        return new TempSeedResponse(email, ids, resumeUrl);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // DELETE /internal/seed/temp
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @DeleteMapping("/temp")
+    public Map<String, Object> deleteTemp(@RequestParam(defaultValue = "test@pickd.local") String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음: " + email));
+        List<ExperienceTemp> temps = tempRepository.findByUser(user);
+        tempRepository.deleteAll(temps);
+        return Map.of("deleted", temps.size(), "email", email);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // defaults
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private List<TempSeedRequest.TempEntry> defaultEntries() {
+        return List.of(
+                new TempSeedRequest.TempEntry("금융 AI Agent 프로젝트", "PROJECT", "NARRATIVE"),
+                new TempSeedRequest.TempEntry("TOEIC 930점", "LANGUAGE", "SPEC")
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // DTOs
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Getter
+    public static class UserSeedRequest {
+        private String email;
+        private String name;
+    }
+
+    @Getter
+    public static class UserSeedResponse {
+        private final Long   id;
+        private final String email;
+        private final String name;
+        private final String accessToken;
+
+        public UserSeedResponse(Long id, String email, String name, String accessToken) {
+            this.id = id; this.email = email; this.name = name; this.accessToken = accessToken;
+        }
+    }
+
+    @Getter
+    public static class TempSeedRequest {
+        private String email;
+        private String resumeUrl;
+        private List<TempEntry> experiences;
+
+        @Getter
+        public static class TempEntry {
+            private String name;
+            private String type;
+            private String group;
+
+            public TempEntry() {}
+            public TempEntry(String name, String type, String group) {
+                this.name = name; this.type = type; this.group = group;
+            }
+        }
+    }
+
+    @Getter
+    public static class TempSeedResponse {
+        private final String     email;
+        private final List<Long> tempIds;
+        private final String     resumeUrl;
+
+        public TempSeedResponse(String email, List<Long> tempIds, String resumeUrl) {
+            this.email = email; this.tempIds = tempIds; this.resumeUrl = resumeUrl;
+        }
+    }
+}

--- a/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceDuplicateGroup.java
@@ -1,6 +1,8 @@
 package back.pickd.experience.entity;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,6 +27,7 @@ public class ExperienceDuplicateGroup {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "existing_experience_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private UserExperience existingExperience;
 
     @OneToMany(mappedBy = "duplicateGroup", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
+++ b/src/main/java/back/pickd/experience/entity/ExperienceExtractionBatch.java
@@ -1,8 +1,10 @@
 package back.pickd.experience.entity;
 
 import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.global.error.ApiException;
 import back.pickd.user.entity.User;
 import jakarta.persistence.*;
+import org.springframework.http.HttpStatus;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -52,6 +54,9 @@ public class ExperienceExtractionBatch {
     }
 
     public void complete() {
+        if (this.status != ExtractionBatchStatus.PENDING) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "이미 처리된 배치입니다.");
+        }
         this.status = ExtractionBatchStatus.COMPLETED;
         this.processedAt = OffsetDateTime.now();
         this.groups.clear();

--- a/src/main/java/back/pickd/experience/entity/UserExperience.java
+++ b/src/main/java/back/pickd/experience/entity/UserExperience.java
@@ -6,6 +6,7 @@ import back.pickd.experience.enums.Status;
 import back.pickd.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -60,10 +61,12 @@ public class UserExperience {
     @Builder.Default
     private List<String> keywords = new ArrayList<>();
 
+    @BatchSize(size = 30)
     @OneToMany(mappedBy = "userExperience", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<ExperienceLink> links = new ArrayList<>();
 
+    @BatchSize(size = 30)
     @OneToMany(mappedBy = "userExperience", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<ExperienceFile> files = new ArrayList<>();

--- a/src/main/java/back/pickd/experience/enums/ExperienceType.java
+++ b/src/main/java/back/pickd/experience/enums/ExperienceType.java
@@ -28,8 +28,15 @@ public enum ExperienceType {
     }
 
     public static ExperienceType fromKoreanName(String koreanName) {
+        // 1. 정확히 일치
         for (ExperienceType type : values()) {
             if (type.getKoreanName().equals(koreanName)) {
+                return type;
+            }
+        }
+        // 2. 부분 일치 (예: "인턴" → "인턴/직무경험")
+        for (ExperienceType type : values()) {
+            if (type.getKoreanName().startsWith(koreanName) || koreanName.startsWith(type.getKoreanName())) {
                 return type;
             }
         }

--- a/src/main/java/back/pickd/global/admin/config/AdminSecurityConfig.java
+++ b/src/main/java/back/pickd/global/admin/config/AdminSecurityConfig.java
@@ -1,0 +1,46 @@
+package back.pickd.global.admin.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class AdminSecurityConfig {
+
+    @Value("${admin.username}")
+    private String adminUsername;
+
+    @Value("${admin.password}")
+    private String adminPassword;
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain adminFilterChain(HttpSecurity http, PasswordEncoder passwordEncoder) throws Exception {
+        http
+            .securityMatcher("/admin/**")
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().hasRole("ADMIN"))
+            .httpBasic(Customizer.withDefaults())
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService adminUserDetailsService(PasswordEncoder passwordEncoder) {
+        var adminUser = User.builder()
+                .username(adminUsername)
+                .password(passwordEncoder.encode(adminPassword))
+                .roles("ADMIN")
+                .build();
+        return new InMemoryUserDetailsManager(adminUser);
+    }
+}

--- a/src/main/java/back/pickd/global/admin/controller/AdminDashboardController.java
+++ b/src/main/java/back/pickd/global/admin/controller/AdminDashboardController.java
@@ -1,0 +1,41 @@
+package back.pickd.global.admin.controller;
+
+import back.pickd.global.admin.dto.EnumColumnResult;
+import back.pickd.global.admin.service.ValidationQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Controller
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminDashboardController {
+
+    private final ValidationQueryService validationQueryService;
+
+    @GetMapping
+    public String dashboard() {
+        return "redirect:/admin/validation";
+    }
+
+    @GetMapping("/validation")
+    public String validationDashboard(Model model) {
+        List<EnumColumnResult> results = validationQueryService.validateAll();
+
+        long passCount = results.stream().filter(EnumColumnResult::isPassed).count();
+        long failCount = results.size() - passCount;
+
+        model.addAttribute("results", results);
+        model.addAttribute("passCount", passCount);
+        model.addAttribute("failCount", failCount);
+        model.addAttribute("total", results.size());
+        model.addAttribute("checkedAt", LocalDateTime.now());
+
+        return "admin/dashboard";
+    }
+}

--- a/src/main/java/back/pickd/global/admin/dto/EnumColumnResult.java
+++ b/src/main/java/back/pickd/global/admin/dto/EnumColumnResult.java
@@ -1,0 +1,33 @@
+package back.pickd.global.admin.dto;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 특정 테이블 컬럼의 ENUM 검증 결과를 담는 DTO.
+ *
+ * @param tableName   DB 테이블명
+ * @param columnName  컬럼명
+ * @param enumClass   Java Enum 클래스명
+ * @param validValues Java Enum에 정의된 합법 값 목록
+ * @param dbValues    DB에 실제 저장된 distinct 값 목록
+ * @param invalidValues DB에만 존재하고 Java Enum에 없는 값 (비어있으면 PASS)
+ * @param totalRows   해당 컬럼의 전체 row 수
+ */
+public record EnumColumnResult(
+        String tableName,
+        String columnName,
+        String enumClass,
+        List<String> validValues,
+        List<String> dbValues,
+        List<String> invalidValues,
+        long totalRows
+) {
+    public boolean isPassed() {
+        return invalidValues.isEmpty();
+    }
+
+    public String statusBadge() {
+        return isPassed() ? "PASS" : "FAIL";
+    }
+}

--- a/src/main/java/back/pickd/global/admin/service/ValidationQueryService.java
+++ b/src/main/java/back/pickd/global/admin/service/ValidationQueryService.java
@@ -1,0 +1,120 @@
+package back.pickd.global.admin.service;
+
+import back.pickd.application.enums.ApplicationStatus;
+import back.pickd.document.enums.DocumentStatus;
+import back.pickd.document.enums.DocumentType;
+import back.pickd.experience.enums.ExperienceGroup;
+import back.pickd.experience.enums.ExperienceType;
+import back.pickd.experience.enums.ExtractionBatchStatus;
+import back.pickd.experience.enums.Status;
+import back.pickd.global.admin.dto.EnumColumnResult;
+import back.pickd.notice.enums.EmploymentType;
+import back.pickd.notice.enums.JobCategory;
+import back.pickd.user.entity.enums.AuthProvider;
+import back.pickd.user.entity.enums.DegreeType;
+import back.pickd.user.entity.enums.EnrollmentStatus;
+import back.pickd.user.entity.enums.OnboardingStep;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * DB에 저장된 ENUM 컬럼 값이 Java Enum 정의와 일치하는지 검증한다.
+ *
+ * 네이티브 쿼리로 raw 문자열을 직접 조회하므로,
+ * Hibernate 매핑 오류가 있는 잘못된 값도 탐지 가능하다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ValidationQueryService {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public List<EnumColumnResult> validateAll() {
+        return List.of(
+                // applications
+                validate("applications",  "status",          "ApplicationStatus",    ApplicationStatus.class),
+
+                // documents
+                validate("documents",     "type",            "DocumentType",         DocumentType.class),
+                validate("documents",     "status",          "DocumentStatus",       DocumentStatus.class),
+
+                // notices
+                validate("notices",       "category",        "JobCategory",          JobCategory.class),
+                validate("notices",       "employment_type", "EmploymentType",       EmploymentType.class),
+
+                // user_experiences
+                validate("user_experiences", "experience_type",  "ExperienceType",   ExperienceType.class),
+                validate("user_experiences", "experience_group", "ExperienceGroup",  ExperienceGroup.class),
+                validate("user_experiences", "status",           "Status",           Status.class),
+
+                // experience_temps
+                validate("experience_temps", "experience_type",  "ExperienceType",   ExperienceType.class),
+                validate("experience_temps", "experience_group", "ExperienceGroup",  ExperienceGroup.class),
+
+                // experience_extraction_drafts
+                validate("experience_extraction_drafts", "experience_type",  "ExperienceType",  ExperienceType.class),
+                validate("experience_extraction_drafts", "experience_group", "ExperienceGroup", ExperienceGroup.class),
+                validate("experience_extraction_drafts", "status",           "Status",          Status.class),
+
+                // experience_extraction_batches
+                validate("experience_extraction_batches", "status", "ExtractionBatchStatus", ExtractionBatchStatus.class),
+
+                // users
+                validate("users", "provider",        "AuthProvider",  AuthProvider.class),
+                validate("users", "onboarding_step", "OnboardingStep", OnboardingStep.class),
+
+                // user_educations
+                validate("user_educations", "degree_type",       "DegreeType",       DegreeType.class),
+                validate("user_educations", "enrollment_status", "EnrollmentStatus", EnrollmentStatus.class)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E extends Enum<E>> EnumColumnResult validate(
+            String table, String column, String enumClassName, Class<E> enumClass) {
+
+        // Java Enum에 정의된 합법 값 목록
+        List<String> validValues = Arrays.stream(enumClass.getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+        Set<String> validSet = Set.copyOf(validValues);
+
+        List<String> dbValues;
+        long totalRows;
+
+        try {
+            // raw 문자열로 조회 - 잘못된 값도 탐지 가능
+            dbValues = em.createNativeQuery(
+                            "SELECT DISTINCT " + column + " FROM " + table +
+                            " WHERE " + column + " IS NOT NULL ORDER BY " + column)
+                    .getResultList();
+
+            totalRows = ((Number) em.createNativeQuery(
+                            "SELECT COUNT(*) FROM " + table)
+                    .getSingleResult()).longValue();
+
+        } catch (Exception e) {
+            log.warn("검증 쿼리 실패: {}.{} — {}", table, column, e.getMessage());
+            dbValues = List.of("⚠ 쿼리 오류: " + e.getMessage());
+            totalRows = -1;
+        }
+
+        List<String> invalidValues = dbValues.stream()
+                .filter(v -> !validSet.contains(v))
+                .collect(Collectors.toList());
+
+        return new EnumColumnResult(table, column, enumClassName, validValues, dbValues, invalidValues, totalRows);
+    }
+}

--- a/src/main/java/back/pickd/global/aop/ServiceLoggingAspect.java
+++ b/src/main/java/back/pickd/global/aop/ServiceLoggingAspect.java
@@ -1,0 +1,59 @@
+package back.pickd.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+/**
+ * 모든 Service 클래스의 메서드 실행 로깅 Aspect.
+ * <ul>
+ *   <li>메서드 시작: 클래스명, 메서드명, 인자 출력</li>
+ *   <li>메서드 종료: 실행 시간(ms) 출력</li>
+ *   <li>예외 발생: 예외 타입과 메시지 ERROR 레벨로 출력</li>
+ * </ul>
+ */
+@Slf4j
+@Aspect
+@Component
+public class ServiceLoggingAspect {
+
+    @Around("execution(* back.pickd..*Service.*(..))")
+    public Object logServiceMethod(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String className  = joinPoint.getTarget().getClass().getSimpleName();
+        String methodName = signature.getName();
+        Object[] args     = joinPoint.getArgs();
+
+        log.info("[START] {}.{}() | args={}", className, methodName, formatArgs(args));
+        long start = System.currentTimeMillis();
+
+        try {
+            Object result = joinPoint.proceed();
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("[END]   {}.{}() | {}ms", className, methodName, elapsed);
+            return result;
+        } catch (Exception e) {
+            long elapsed = System.currentTimeMillis() - start;
+            log.error("[ERROR] {}.{}() | {}ms | {} : {}",
+                    className, methodName, elapsed,
+                    e.getClass().getSimpleName(), e.getMessage());
+            throw e;
+        }
+    }
+
+    private String formatArgs(Object[] args) {
+        if (args == null || args.length == 0) return "[]";
+        return Arrays.stream(args)
+                .map(arg -> arg == null ? "null" : arg.getClass().getSimpleName() + "(" + truncate(arg.toString()) + ")")
+                .reduce("[", (a, b) -> a + (a.equals("[") ? "" : ", ") + b) + "]";
+    }
+
+    private String truncate(String value) {
+        return value.length() > 100 ? value.substring(0, 100) + "..." : value;
+    }
+}

--- a/src/main/java/back/pickd/global/config/QueryDslConfig.java
+++ b/src/main/java/back/pickd/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package back.pickd.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/back/pickd/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/back/pickd/global/error/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import back.pickd.experience.dto.ExperienceMergeDto.Conflict;
 import back.pickd.experience.exception.ExperienceMergeConflictException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -46,6 +47,10 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({IOException.class, GeneralSecurityException.class})
     public ResponseEntity<ErrorResponse> handleGoogleApiException(Exception e, HttpServletRequest request) {
+        if (e instanceof ClientAbortException) {
+            log.debug("Client aborted connection (broken pipe): {}", request.getRequestURI());
+            return null;
+        }
         log.error("Google API Exception: {}", e.getMessage(), e);
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "구글 API 연동 중 오류가 발생했습니다.", request);
     }

--- a/src/main/java/back/pickd/global/infra/ai/AiClient.java
+++ b/src/main/java/back/pickd/global/infra/ai/AiClient.java
@@ -181,4 +181,18 @@ public class AiClient {
                 .retrieve()
                 .body(AiJobPostingResponse.class);
     }
+
+    public AiJobPostingResponse analyzeNoticeImages(List<MultipartFile> files) {
+        MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        for (MultipartFile file : files) {
+            bodyBuilder.part("files", file.getResource());
+        }
+
+        return restClient.post()
+                .uri("/api/v1/analyze/image")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(bodyBuilder.build())
+                .retrieve()
+                .body(AiJobPostingResponse.class);
+    }
 }

--- a/src/main/java/back/pickd/global/infra/ai/dto/AiJobPostingResponse.java
+++ b/src/main/java/back/pickd/global/infra/ai/dto/AiJobPostingResponse.java
@@ -19,7 +19,7 @@ public class AiJobPostingResponse {
     private String startedAt;
     private String endedAt;
     private String noticeUrl;
-    private Integer headcount;
+    private String headcount;
     private String region1depth;
     private String workplaceAddress;
     private List<AiNoticeSectionDto> sections;

--- a/src/main/java/back/pickd/global/infra/s3/FileController.java
+++ b/src/main/java/back/pickd/global/infra/s3/FileController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +28,7 @@ public class FileController {
 
     private final FileService fileService;
 
-    @PostMapping("/upload")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
             summary = "파일 업로드",
             description = "이력서, 자격증, 수료증 등을 S3에 업로드하고 CloudFront URL을 반환합니다."
@@ -42,7 +43,10 @@ public class FileController {
     })
     public ResponseEntity<UploadedFileResponse> uploadFile(
             @Parameter(hidden = true) Authentication authentication,
-            @Parameter(description = "업로드할 파일", required = true) @RequestParam("file") MultipartFile file,
+            @Parameter(description = "업로드할 파일", required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(type = "string", format = "binary")))
+            @RequestParam("file") MultipartFile file,
             @Parameter(description = "파일 유형", required = true) @RequestParam("type") FileUploadType type) {
         if (authentication == null) {
             return ResponseEntity.status(401).build();

--- a/src/main/java/back/pickd/notice/controller/NoticeController.java
+++ b/src/main/java/back/pickd/notice/controller/NoticeController.java
@@ -3,6 +3,8 @@ package back.pickd.notice.controller;
 import back.pickd.global.config.OpenApiConfig;
 import back.pickd.global.error.ErrorResponse;
 import back.pickd.notice.dto.UrlAnalysisRequestDto;
+import back.pickd.notice.dto.response.NoticeDetailResponse;
+import back.pickd.notice.dto.response.NoticeListResponse;
 import back.pickd.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,6 +22,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -30,6 +33,33 @@ import java.util.Map;
 public class NoticeController {
 
     private final NoticeService noticeService;
+
+    @GetMapping
+    @Operation(summary = "공고 목록 조회", description = "로그인 사용자의 전체 공고 목록을 최신순으로 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<NoticeListResponse>> getNotices(
+            @Parameter(hidden = true) Authentication authentication) {
+        return ResponseEntity.ok(noticeService.getNotices(authentication.getName()));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "공고 상세 조회", description = "noticeId로 공고 및 연결된 모집부문, 전형단계, 제출서류를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "공고를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<NoticeDetailResponse> getNoticeDetail(
+            @Parameter(hidden = true) Authentication authentication,
+            @PathVariable Long id) {
+        return ResponseEntity.ok(noticeService.getNoticeDetail(authentication.getName(), id));
+    }
 
     @PostMapping("/analyze/url")
     @Operation(
@@ -48,6 +78,29 @@ public class NoticeController {
             @Parameter(hidden = true) Authentication authentication,
             @RequestBody @Valid UrlAnalysisRequestDto request) {
         Long noticeId = noticeService.analyzeAndSaveNoticeUrl(authentication.getName(), request.getUrl());
+        return ResponseEntity.ok(Map.of("noticeId", noticeId));
+    }
+
+    @PostMapping(value = "/analyze/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "이미지 기반 채용공고 분석",
+            description = "채용공고 이미지(PNG, JPG 등) 1장 이상을 업로드하면 Gemini Flash로 분석하여 저장하고 noticeId를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "분석 및 저장 성공",
+                    content = @Content(schema = @Schema(example = "{\"noticeId\": 1}"))),
+            @ApiResponse(responseCode = "400", description = "파일 누락 또는 AI 분석 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Map<String, Long>> analyzeNoticeImages(
+            @Parameter(hidden = true) Authentication authentication,
+            @Parameter(description = "채용공고 이미지 파일 (여러 장 가능)", required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(type = "string", format = "binary")))
+            @RequestParam("files") List<MultipartFile> files) {
+        Long noticeId = noticeService.analyzeAndSaveNoticeImages(authentication.getName(), files);
         return ResponseEntity.ok(Map.of("noticeId", noticeId));
     }
 

--- a/src/main/java/back/pickd/notice/controller/NoticeController.java
+++ b/src/main/java/back/pickd/notice/controller/NoticeController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -50,7 +51,7 @@ public class NoticeController {
         return ResponseEntity.ok(Map.of("noticeId", noticeId));
     }
 
-    @PostMapping("/analyze/pdf")
+    @PostMapping(value = "/analyze/pdf", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
             summary = "PDF 기반 채용공고 분석",
             description = "채용공고 PDF 파일을 AI로 분석하여 저장하고 noticeId를 반환합니다."
@@ -65,7 +66,10 @@ public class NoticeController {
     })
     public ResponseEntity<Map<String, Long>> analyzeNoticePdf(
             @Parameter(hidden = true) Authentication authentication,
-            @Parameter(description = "채용공고 PDF 파일", required = true) @RequestParam("file") MultipartFile file) {
+            @Parameter(description = "채용공고 PDF 파일", required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(type = "string", format = "binary")))
+            @RequestParam("file") MultipartFile file) {
         Long noticeId = noticeService.analyzeAndSaveNoticePdf(authentication.getName(), file);
         return ResponseEntity.ok(Map.of("noticeId", noticeId));
     }

--- a/src/main/java/back/pickd/notice/dto/NoticeSectionRequestDto.java
+++ b/src/main/java/back/pickd/notice/dto/NoticeSectionRequestDto.java
@@ -1,0 +1,20 @@
+package back.pickd.notice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeSectionRequestDto {
+
+    @NotBlank(message = "섹션명은 필수입니다.")
+    private String sectionName;
+
+    @NotBlank(message = "직무명은 필수입니다.")
+    private String jobTitle;
+
+    private String responsibilities;
+    private String headcount;
+    private String workplace;
+}

--- a/src/main/java/back/pickd/notice/dto/response/ApplicationDocumentResponse.java
+++ b/src/main/java/back/pickd/notice/dto/response/ApplicationDocumentResponse.java
@@ -1,0 +1,24 @@
+package back.pickd.notice.dto.response;
+
+import back.pickd.notice.entity.ApplicationDocument;
+import lombok.Getter;
+
+@Getter
+public class ApplicationDocumentResponse {
+
+    private final Long id;
+    private final String mandatoryDocuments;
+    private final String proofDocuments;
+    private final String applyMethod;
+    private final String applyUrlOrEmail;
+    private final String submissionNotes;
+
+    public ApplicationDocumentResponse(ApplicationDocument d) {
+        this.id = d.getId();
+        this.mandatoryDocuments = d.getMandatoryDocuments();
+        this.proofDocuments = d.getProofDocuments();
+        this.applyMethod = d.getApplyMethod();
+        this.applyUrlOrEmail = d.getApplyUrlOrEmail();
+        this.submissionNotes = d.getSubmissionNotes();
+    }
+}

--- a/src/main/java/back/pickd/notice/dto/response/CoverLetterItemResponse.java
+++ b/src/main/java/back/pickd/notice/dto/response/CoverLetterItemResponse.java
@@ -1,0 +1,30 @@
+package back.pickd.notice.dto.response;
+
+import back.pickd.coverletter.entity.CoverLetterItem;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CoverLetterItemResponse {
+
+    private final Long id;
+    private final String question;
+    private final String answer;
+    private final Integer maxLength;
+    private final Integer orderIndex;
+    private final boolean aiGenerated;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public CoverLetterItemResponse(CoverLetterItem item) {
+        this.id = item.getId();
+        this.question = item.getQuestion();
+        this.answer = item.getAnswer();
+        this.maxLength = item.getMaxLength();
+        this.orderIndex = item.getOrderIndex();
+        this.aiGenerated = item.isAiGenerated();
+        this.createdAt = item.getCreatedAt();
+        this.updatedAt = item.getUpdatedAt();
+    }
+}

--- a/src/main/java/back/pickd/notice/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/back/pickd/notice/dto/response/NoticeDetailResponse.java
@@ -1,0 +1,50 @@
+package back.pickd.notice.dto.response;
+
+import back.pickd.notice.entity.Notice;
+import back.pickd.notice.enums.EmploymentType;
+import back.pickd.notice.enums.JobCategory;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class NoticeDetailResponse {
+
+    private final Long id;
+    private final String companyName;
+    private final String noticeName;
+    private final JobCategory category;
+    private final String startedAt;
+    private final String endedAt;
+    private final EmploymentType employmentType;
+    private final String headcount;
+    private final String region1depth;
+    private final String workplaceAddress;
+    private final String noticeUrl;
+    private final List<NoticeSectionResponse> sections;
+    private final List<NoticeProcessResponse> processes;
+    private final List<ApplicationDocumentResponse> documents;
+    private final List<CoverLetterItemResponse> coverLetterItems;
+
+    public NoticeDetailResponse(Notice notice,
+                                List<NoticeSectionResponse> sections,
+                                List<NoticeProcessResponse> processes,
+                                List<ApplicationDocumentResponse> documents,
+                                List<CoverLetterItemResponse> coverLetterItems) {
+        this.id = notice.getId();
+        this.companyName = notice.getCompanyName();
+        this.noticeName = notice.getNoticeName();
+        this.category = notice.getCategory();
+        this.startedAt = notice.getStartedAt();
+        this.endedAt = notice.getEndedAt();
+        this.employmentType = notice.getEmploymentType();
+        this.headcount = notice.getHeadcount();
+        this.region1depth = notice.getRegion1depth();
+        this.workplaceAddress = notice.getWorkplaceAddress();
+        this.noticeUrl = notice.getNoticeUrl();
+        this.sections = sections;
+        this.processes = processes;
+        this.documents = documents;
+        this.coverLetterItems = coverLetterItems;
+    }
+}

--- a/src/main/java/back/pickd/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/back/pickd/notice/dto/response/NoticeListResponse.java
@@ -1,0 +1,32 @@
+package back.pickd.notice.dto.response;
+
+import back.pickd.notice.entity.Notice;
+import back.pickd.notice.enums.EmploymentType;
+import back.pickd.notice.enums.JobCategory;
+import lombok.Getter;
+
+@Getter
+public class NoticeListResponse {
+
+    private final Long id;
+    private final String companyName;
+    private final String noticeName;
+    private final JobCategory category;
+    private final String startedAt;
+    private final String endedAt;
+    private final EmploymentType employmentType;
+    private final String region1depth;
+    private final String noticeUrl;
+
+    public NoticeListResponse(Notice notice) {
+        this.id = notice.getId();
+        this.companyName = notice.getCompanyName();
+        this.noticeName = notice.getNoticeName();
+        this.category = notice.getCategory();
+        this.startedAt = notice.getStartedAt();
+        this.endedAt = notice.getEndedAt();
+        this.employmentType = notice.getEmploymentType();
+        this.region1depth = notice.getRegion1depth();
+        this.noticeUrl = notice.getNoticeUrl();
+    }
+}

--- a/src/main/java/back/pickd/notice/dto/response/NoticeProcessResponse.java
+++ b/src/main/java/back/pickd/notice/dto/response/NoticeProcessResponse.java
@@ -1,0 +1,28 @@
+package back.pickd.notice.dto.response;
+
+import back.pickd.notice.entity.NoticeProcess;
+import lombok.Getter;
+
+@Getter
+public class NoticeProcessResponse {
+
+    private final Long id;
+    private final String processName;
+    private final String documentScreenSchedule;
+    private final String writtenExamSchedule;
+    private final String interviewSchedule;
+    private final String joinDate;
+    private final String applicationPeriod;
+    private final String scheduleNotes;
+
+    public NoticeProcessResponse(NoticeProcess p) {
+        this.id = p.getId();
+        this.processName = p.getProcessName();
+        this.documentScreenSchedule = p.getDocumentScreenSchedule();
+        this.writtenExamSchedule = p.getWrittenExamSchedule();
+        this.interviewSchedule = p.getInterviewSchedule();
+        this.joinDate = p.getJoinDate();
+        this.applicationPeriod = p.getApplicationPeriod();
+        this.scheduleNotes = p.getScheduleNotes();
+    }
+}

--- a/src/main/java/back/pickd/notice/dto/response/NoticeSectionResponse.java
+++ b/src/main/java/back/pickd/notice/dto/response/NoticeSectionResponse.java
@@ -1,0 +1,38 @@
+package back.pickd.notice.dto.response;
+
+import back.pickd.notice.entity.NoticeSection;
+import back.pickd.notice.entity.SectionPreference;
+import back.pickd.notice.entity.SectionQualification;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class NoticeSectionResponse {
+
+    private final Long id;
+    private final String sectionName;
+    private final String jobTitle;
+    private final String responsibilities;
+    private final String headcount;
+    private final String workplace;
+    private final List<SectionQualificationResponse> qualifications;
+    private final List<SectionPreferenceResponse> preferences;
+
+    public NoticeSectionResponse(NoticeSection section,
+                                 List<SectionQualification> qualifications,
+                                 List<SectionPreference> preferences) {
+        this.id = section.getId();
+        this.sectionName = section.getSectionName();
+        this.jobTitle = section.getJobTitle();
+        this.responsibilities = section.getResponsibilities();
+        this.headcount = section.getHeadcount();
+        this.workplace = section.getWorkplace();
+        this.qualifications = qualifications.stream()
+                .map(SectionQualificationResponse::new)
+                .toList();
+        this.preferences = preferences.stream()
+                .map(SectionPreferenceResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/back/pickd/notice/dto/response/SectionPreferenceResponse.java
+++ b/src/main/java/back/pickd/notice/dto/response/SectionPreferenceResponse.java
@@ -1,0 +1,24 @@
+package back.pickd.notice.dto.response;
+
+import back.pickd.notice.entity.SectionPreference;
+import lombok.Getter;
+
+@Getter
+public class SectionPreferenceResponse {
+
+    private final Long id;
+    private final String generalPreference;
+    private final String additionalPoints;
+    private final String veteranPreference;
+    private final String disabilityPreference;
+    private final String certificatePreference;
+
+    public SectionPreferenceResponse(SectionPreference p) {
+        this.id = p.getId();
+        this.generalPreference = p.getGeneralPreference();
+        this.additionalPoints = p.getAdditionalPoints();
+        this.veteranPreference = p.getVeteranPreference();
+        this.disabilityPreference = p.getDisabilityPreference();
+        this.certificatePreference = p.getCertificatePreference();
+    }
+}

--- a/src/main/java/back/pickd/notice/dto/response/SectionQualificationResponse.java
+++ b/src/main/java/back/pickd/notice/dto/response/SectionQualificationResponse.java
@@ -1,0 +1,18 @@
+package back.pickd.notice.dto.response;
+
+import back.pickd.notice.entity.SectionQualification;
+import lombok.Getter;
+
+@Getter
+public class SectionQualificationResponse {
+
+    private final Long id;
+    private final String generalQualification;
+    private final String mandatoryQualification;
+
+    public SectionQualificationResponse(SectionQualification q) {
+        this.id = q.getId();
+        this.generalQualification = q.getGeneralQualification();
+        this.mandatoryQualification = q.getMandatoryQualification();
+    }
+}

--- a/src/main/java/back/pickd/notice/entity/Notice.java
+++ b/src/main/java/back/pickd/notice/entity/Notice.java
@@ -79,6 +79,21 @@ public class Notice {
         this.noticeUrl = noticeUrl;
     }
 
+    public void update(String companyName, String noticeName, JobCategory category,
+                       String startedAt, String endedAt, EmploymentType employmentType,
+                       String headcount, String region1depth, String workplaceAddress, String noticeUrl) {
+        if (companyName  != null) this.companyName  = companyName;
+        if (noticeName   != null) this.noticeName   = noticeName;
+        if (category     != null) this.category     = category;
+        if (startedAt    != null) this.startedAt    = startedAt;
+        if (endedAt      != null) this.endedAt      = endedAt;
+        if (employmentType != null) this.employmentType = employmentType;
+        if (headcount    != null) this.headcount    = headcount;
+        if (region1depth != null) this.region1depth = region1depth;
+        if (workplaceAddress != null) this.workplaceAddress = workplaceAddress;
+        if (noticeUrl    != null) this.noticeUrl    = noticeUrl;
+    }
+
     public void addSection(NoticeSection section) {
         sections.add(section);
         section.assignToNotice(this);

--- a/src/main/java/back/pickd/notice/repository/ApplicationDocumentRepository.java
+++ b/src/main/java/back/pickd/notice/repository/ApplicationDocumentRepository.java
@@ -1,9 +1,13 @@
 package back.pickd.notice.repository;
 
 import back.pickd.notice.entity.ApplicationDocument;
+import back.pickd.notice.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ApplicationDocumentRepository extends JpaRepository<ApplicationDocument, Long> {
+    List<ApplicationDocument> findAllByNotice(Notice notice);
 }

--- a/src/main/java/back/pickd/notice/repository/NoticeProcessRepository.java
+++ b/src/main/java/back/pickd/notice/repository/NoticeProcessRepository.java
@@ -1,9 +1,13 @@
 package back.pickd.notice.repository;
 
+import back.pickd.notice.entity.Notice;
 import back.pickd.notice.entity.NoticeProcess;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NoticeProcessRepository extends JpaRepository<NoticeProcess, Long> {
+    List<NoticeProcess> findAllByNotice(Notice notice);
 }

--- a/src/main/java/back/pickd/notice/repository/SectionPreferenceRepository.java
+++ b/src/main/java/back/pickd/notice/repository/SectionPreferenceRepository.java
@@ -1,9 +1,13 @@
 package back.pickd.notice.repository;
 
+import back.pickd.notice.entity.NoticeSection;
 import back.pickd.notice.entity.SectionPreference;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SectionPreferenceRepository extends JpaRepository<SectionPreference, Long> {
+    List<SectionPreference> findAllBySection(NoticeSection section);
 }

--- a/src/main/java/back/pickd/notice/repository/SectionQualificationRepository.java
+++ b/src/main/java/back/pickd/notice/repository/SectionQualificationRepository.java
@@ -1,9 +1,13 @@
 package back.pickd.notice.repository;
 
+import back.pickd.notice.entity.NoticeSection;
 import back.pickd.notice.entity.SectionQualification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SectionQualificationRepository extends JpaRepository<SectionQualification, Long> {
+    List<SectionQualification> findAllBySection(NoticeSection section);
 }

--- a/src/main/java/back/pickd/notice/service/NoticeService.java
+++ b/src/main/java/back/pickd/notice/service/NoticeService.java
@@ -5,6 +5,10 @@ import back.pickd.application.enums.ApplicationStatus;
 import back.pickd.application.repository.ApplicationRepository;
 import back.pickd.global.infra.ai.AiClient;
 import back.pickd.global.infra.ai.dto.*;
+import back.pickd.notice.dto.NoticeSaveRequestDto;
+import back.pickd.notice.dto.NoticeSectionRequestDto;
+import back.pickd.notice.dto.response.*;
+import back.pickd.coverletter.repository.CoverLetterItemRepository;
 import back.pickd.notice.entity.*;
 import back.pickd.notice.enums.*;
 import back.pickd.notice.repository.*;
@@ -14,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 // 채용공고 AI 분석 결과를 DB에 저장하는 서비스 레이어
 @Service
@@ -30,6 +36,7 @@ public class NoticeService {
     private final ApplicationDocumentRepository applicationDocumentRepository;
     private final ApplicationRepository applicationRepository;
     private final UserRepository userRepository;
+    private final CoverLetterItemRepository coverLetterItemRepository;
 
     // URL 채용공고 분석 후 저장
     @Transactional
@@ -38,6 +45,18 @@ public class NoticeService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         AiJobPostingResponse aiResponse = aiClient.analyzeNoticeUrl(url);
         return saveNotice(user, aiResponse, url);
+    }
+
+    // 이미지 채용공고 분석 후 저장
+    @Transactional
+    public Long analyzeAndSaveNoticeImages(String email, List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            throw new IllegalArgumentException("이미지 파일은 최소 1개 이상 필요합니다.");
+        }
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        AiJobPostingResponse aiResponse = aiClient.analyzeNoticeImages(files);
+        return saveNotice(user, aiResponse, null);
     }
 
     // PDF 채용공고 분석 후 저장
@@ -152,6 +171,87 @@ public class NoticeService {
         applicationRepository.save(application);
 
         return savedNotice.getId();
+    }
+
+    // ── 공고 조회 API ──────────────────────────────────────────────────────────
+
+    /** 로그인 사용자의 전체 공고 목록 조회 (최신순) */
+    public List<NoticeListResponse> getNotices(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return noticeRepository.findAllByUserOrderByIdDesc(user).stream()
+                .map(NoticeListResponse::new)
+                .toList();
+    }
+
+    /** 공고 상세 조회 (sections + qualifications + preferences + processes + documents) */
+    public NoticeDetailResponse getNoticeDetail(String email, Long noticeId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Notice notice = noticeRepository.findByIdAndUser(noticeId, user)
+                .orElseThrow(() -> new IllegalArgumentException("공고를 찾을 수 없습니다."));
+
+        List<NoticeSectionResponse> sectionResponses = notice.getSections().stream()
+                .map(section -> {
+                    List<SectionQualification> quals = sectionQualificationRepository.findAllBySection(section);
+                    List<SectionPreference> prefs = sectionPreferenceRepository.findAllBySection(section);
+                    return new NoticeSectionResponse(section, quals, prefs);
+                })
+                .toList();
+
+        List<NoticeProcessResponse> processResponses = noticeProcessRepository.findAllByNotice(notice).stream()
+                .map(NoticeProcessResponse::new)
+                .toList();
+
+        List<ApplicationDocumentResponse> documentResponses = applicationDocumentRepository.findAllByNotice(notice).stream()
+                .map(ApplicationDocumentResponse::new)
+                .toList();
+
+        List<CoverLetterItemResponse> coverLetterResponses = coverLetterItemRepository
+                .findAllByNoticeIdAndUserOrderByOrderIndexAsc(notice.getId(), user).stream()
+                .map(CoverLetterItemResponse::new)
+                .toList();
+
+        return new NoticeDetailResponse(notice, sectionResponses, processResponses, documentResponses, coverLetterResponses);
+    }
+
+    // ── 수기 입력 Notice 수정 API ──────────────────────────────────────────────
+
+    /** 수기 입력으로 생성된 Notice의 기본 정보를 수정합니다. */
+    @Transactional
+    public void updateNotice(String email, Long noticeId, NoticeSaveRequestDto dto) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Notice notice = noticeRepository.findByIdAndUser(noticeId, user)
+                .orElseThrow(() -> new IllegalArgumentException("공고를 찾을 수 없습니다."));
+
+        notice.update(
+                dto.getCompanyName(), dto.getNoticeName(), dto.getCategory(),
+                dto.getStartedAt(), dto.getEndedAt(), dto.getEmploymentType(),
+                dto.getHeadcount(), dto.getRegion1depth(), dto.getWorkplaceAddress(), dto.getNoticeUrl()
+        );
+    }
+
+    /** Notice에 모집부문(Section)을 추가합니다. */
+    @Transactional
+    public Long addSectionToNotice(String email, Long noticeId, NoticeSectionRequestDto dto) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Notice notice = noticeRepository.findByIdAndUser(noticeId, user)
+                .orElseThrow(() -> new IllegalArgumentException("공고를 찾을 수 없습니다."));
+
+        NoticeSection section = NoticeSection.builder()
+                .notice(notice)
+                .sectionName(dto.getSectionName())
+                .jobTitle(dto.getJobTitle())
+                .responsibilities(dto.getResponsibilities())
+                .headcount(dto.getHeadcount())
+                .workplace(dto.getWorkplace())
+                .build();
+
+        NoticeSection saved = noticeSectionRepository.save(section);
+        notice.addSection(saved);
+        return saved.getId();
     }
 
     // 채용 구분 Enum 변환 및 방어 처리

--- a/src/main/java/back/pickd/notice/service/NoticeService.java
+++ b/src/main/java/back/pickd/notice/service/NoticeService.java
@@ -62,7 +62,7 @@ public class NoticeService {
                 .startedAt(aiResponse.getStartedAt())
                 .endedAt(aiResponse.getEndedAt())
                 .employmentType(convertEmploymentType(aiResponse.getEmploymentType()))
-                .headcount(aiResponse.getHeadcount() != null ? String.valueOf(aiResponse.getHeadcount()) : "0")
+                .headcount(aiResponse.getHeadcount())
                 .region1depth(aiResponse.getRegion1depth())
                 .workplaceAddress(aiResponse.getWorkplaceAddress())
                 .noticeUrl(url != null ? url : aiResponse.getNoticeUrl())

--- a/src/main/java/back/pickd/user/controller/UserController.java
+++ b/src/main/java/back/pickd/user/controller/UserController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -43,7 +44,7 @@ public class UserController {
         return ResponseEntity.ok(UserProfileDto.from(user));
     }
 
-    @PostMapping("/profile-image")
+    @PostMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "프로필 이미지 업로드", description = "프로필 이미지를 S3에 업로드하고 URL을 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "업로드 성공",
@@ -53,7 +54,10 @@ public class UserController {
     })
     public ResponseEntity<Map<String, String>> uploadProfileImage(
             @Parameter(hidden = true) Authentication authentication,
-            @Parameter(description = "업로드할 이미지 파일", required = true) @RequestParam("file") MultipartFile file) {
+            @Parameter(description = "업로드할 이미지 파일", required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(type = "string", format = "binary")))
+            @RequestParam("file") MultipartFile file) {
         String profileImageUrl = userService.updateProfileImage(authentication.getName(), file);
         return ResponseEntity.ok(Map.of("profileImageUrl", profileImageUrl));
     }

--- a/src/main/java/back/pickd/user/dto/onboarding/OnboardingRequest.java
+++ b/src/main/java/back/pickd/user/dto/onboarding/OnboardingRequest.java
@@ -5,6 +5,7 @@ import back.pickd.user.entity.enums.EnrollmentStatus;
 import back.pickd.user.entity.enums.OnboardingStep;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,7 @@ public class OnboardingRequest {
 
     // Step 1.5: Verification
     private String name;
+    @Pattern(regexp = "^\\d{8}$", message = "생년월일 형식은 YYYYMMDD여야 합니다.")
     private String birthDate;
     private String phone;
 
@@ -38,6 +40,7 @@ public class OnboardingRequest {
     private String minor;
     private DegreeType degreeType;
     private EnrollmentStatus enrollmentStatus;
+    @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "졸업년월 형식은 YYYY-MM이어야 합니다.")
     private String graduationDate;
     private Double gpa;
     private String campus;
@@ -87,6 +90,7 @@ public class OnboardingRequest {
     public static class CertificationDto {
         private String name;
         private String score;
+        @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "취득년월 형식은 YYYY-MM이어야 합니다.")
         private String acquisitionDate;
     }
 }

--- a/src/main/java/back/pickd/user/entity/UserInterest.java
+++ b/src/main/java/back/pickd/user/entity/UserInterest.java
@@ -23,12 +23,16 @@ public class UserInterest {
     private User user;
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_industries", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_industries",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_industries", columnList = "user_interest_id"))
     @Column(name = "industry")
     private List<String> industries = new ArrayList<>();
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_job_groups", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_job_groups",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_job_groups", columnList = "user_interest_id"))
     @Column(name = "job_group")
     private List<String> jobGroups = new ArrayList<>();
 
@@ -36,12 +40,16 @@ public class UserInterest {
     private String employmentType; // e.g., "FULL_TIME", "INTERN"
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_company_types", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_company_types",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_company_types", columnList = "user_interest_id"))
     @Column(name = "company_type")
     private List<String> companyTypes = new ArrayList<>();
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_keywords", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_keywords",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_keywords", columnList = "user_interest_id"))
     @Column(name = "keyword")
     private List<String> keywords = new ArrayList<>();
 
@@ -64,7 +72,9 @@ public class UserInterest {
     private String workType;
 
     @ElementCollection
-    @CollectionTable(name = "user_interest_apply_types", joinColumns = @JoinColumn(name = "user_interest_id"))
+    @CollectionTable(name = "user_interest_apply_types",
+            joinColumns = @JoinColumn(name = "user_interest_id"),
+            indexes = @Index(name = "idx_user_interest_apply_types", columnList = "user_interest_id"))
     @Column(name = "apply_type")
     private List<String> applyTypes = new ArrayList<>();
 

--- a/src/main/java/back/pickd/user/entity/UserLocation.java
+++ b/src/main/java/back/pickd/user/entity/UserLocation.java
@@ -26,7 +26,9 @@ public class UserLocation {
     private String currentResidence;
 
     @ElementCollection
-    @CollectionTable(name = "user_desired_locations", joinColumns = @JoinColumn(name = "user_location_id"))
+    @CollectionTable(name = "user_desired_locations",
+            joinColumns = @JoinColumn(name = "user_location_id"),
+            indexes = @Index(name = "idx_user_desired_locations", columnList = "user_location_id"))
     @Column(name = "location")
     private List<String> desiredLocations = new ArrayList<>();
 

--- a/src/main/java/back/pickd/user/entity/UserPrepStatus.java
+++ b/src/main/java/back/pickd/user/entity/UserPrepStatus.java
@@ -29,7 +29,9 @@ public class UserPrepStatus {
     private String currentStage;
 
     @ElementCollection
-    @CollectionTable(name = "user_focus_items", joinColumns = @JoinColumn(name = "user_prep_status_id"))
+    @CollectionTable(name = "user_focus_items",
+            joinColumns = @JoinColumn(name = "user_prep_status_id"),
+            indexes = @Index(name = "idx_user_focus_items", columnList = "user_prep_status_id"))
     @Column(name = "focus_item")
     private List<String> focusItems = new ArrayList<>();
 
@@ -43,7 +45,9 @@ public class UserPrepStatus {
     private boolean hasPortfolio;
 
     @ElementCollection
-    @CollectionTable(name = "user_preparing_exams", joinColumns = @JoinColumn(name = "user_prep_status_id"))
+    @CollectionTable(name = "user_preparing_exams",
+            joinColumns = @JoinColumn(name = "user_prep_status_id"),
+            indexes = @Index(name = "idx_user_preparing_exams", columnList = "user_prep_status_id"))
     @Column(name = "exam_name")
     private List<String> preparingExams = new ArrayList<>();
 

--- a/src/main/java/back/pickd/user/service/OnboardingService.java
+++ b/src/main/java/back/pickd/user/service/OnboardingService.java
@@ -87,7 +87,12 @@ public class OnboardingService {
             deleteExistingExperiences(user);
             List<UserExperience> experiences = new ArrayList<>();
             for (OnboardingRequest.ExperienceDto e : dto.getExperiences()) {
-                ExperienceType expType = ExperienceType.valueOf(e.getType());
+                ExperienceType expType;
+                try {
+                    expType = ExperienceType.valueOf(e.getType());  // 영문 enum (INTERN 등)
+                } catch (IllegalArgumentException ex) {
+                    expType = ExperienceType.fromKoreanName(e.getType());  // 한국어 (인턴 등)
+                }
                 experiences.add(
                     UserExperience.builder()
                         .user(user)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,4 +59,9 @@ aws:
   cloudfront:
     domain: ${AWS_CLOUDFRONT_DOMAIN:https://cdn.pickd.co.kr}
 
+# Admin 대시보드 Basic Auth (실제 값은 application-local.yml 또는 환경변수로 주입)
+admin:
+  username: ${ADMIN_USERNAME:admin}
+  password: ${ADMIN_PASSWORD:}
+
 

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PICKD Admin — ENUM 검증 대시보드</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #0f1117;
+            color: #e2e8f0;
+            min-height: 100vh;
+            padding: 32px 24px;
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 32px;
+        }
+
+        header h1 {
+            font-size: 22px;
+            font-weight: 700;
+            color: #f8fafc;
+            letter-spacing: -0.3px;
+        }
+
+        header h1 span {
+            color: #6366f1;
+        }
+
+        .meta {
+            font-size: 12px;
+            color: #64748b;
+        }
+
+        /* Summary cards */
+        .summary {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 16px;
+            margin-bottom: 36px;
+            max-width: 640px;
+        }
+
+        .card {
+            background: #1e2130;
+            border: 1px solid #2d3148;
+            border-radius: 12px;
+            padding: 20px 24px;
+        }
+
+        .card-label {
+            font-size: 12px;
+            color: #64748b;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            margin-bottom: 8px;
+        }
+
+        .card-value {
+            font-size: 32px;
+            font-weight: 700;
+        }
+
+        .card-value.pass { color: #22c55e; }
+        .card-value.fail { color: #ef4444; }
+        .card-value.total { color: #f8fafc; }
+
+        /* Table */
+        .table-wrap {
+            background: #1e2130;
+            border: 1px solid #2d3148;
+            border-radius: 12px;
+            overflow: hidden;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 13.5px;
+        }
+
+        thead {
+            background: #161824;
+        }
+
+        thead th {
+            padding: 14px 16px;
+            text-align: left;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: #64748b;
+            font-weight: 600;
+            border-bottom: 1px solid #2d3148;
+        }
+
+        tbody tr {
+            border-bottom: 1px solid #252840;
+            transition: background 0.1s;
+        }
+
+        tbody tr:last-child { border-bottom: none; }
+
+        tbody tr:hover { background: #252840; }
+
+        tbody td {
+            padding: 12px 16px;
+            vertical-align: top;
+        }
+
+        /* Status badge */
+        .badge {
+            display: inline-block;
+            padding: 3px 10px;
+            border-radius: 20px;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.4px;
+        }
+
+        .badge-pass {
+            background: #052e16;
+            color: #22c55e;
+            border: 1px solid #166534;
+        }
+
+        .badge-fail {
+            background: #2d0b0b;
+            color: #ef4444;
+            border: 1px solid #7f1d1d;
+        }
+
+        /* Enum chips */
+        .chip-wrap {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+        }
+
+        .chip {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 11px;
+            font-family: "SF Mono", "Fira Code", monospace;
+        }
+
+        .chip-ok {
+            background: #1a2e1a;
+            color: #86efac;
+            border: 1px solid #166534;
+        }
+
+        .chip-bad {
+            background: #2d0b0b;
+            color: #fca5a5;
+            border: 1px solid #7f1d1d;
+        }
+
+        .chip-db {
+            background: #1e1a2e;
+            color: #c4b5fd;
+            border: 1px solid #4c1d95;
+        }
+
+        .col-table { width: 160px; }
+        .col-column { width: 160px; }
+        .col-enum { width: 160px; }
+        .col-rows { width: 70px; text-align: right; color: #64748b; }
+        .col-status { width: 80px; }
+        .col-db { }
+        .col-invalid { }
+
+        .empty-state {
+            color: #4a5568;
+            font-style: italic;
+            font-size: 12px;
+        }
+
+        .table-name {
+            font-family: "SF Mono", "Fira Code", monospace;
+            color: #7dd3fc;
+        }
+
+        .column-name {
+            font-family: "SF Mono", "Fira Code", monospace;
+            color: #fbbf24;
+        }
+
+        .enum-name {
+            font-family: "SF Mono", "Fira Code", monospace;
+            color: #a78bfa;
+            font-size: 12px;
+        }
+
+        .refresh-btn {
+            background: #6366f1;
+            color: white;
+            border: none;
+            border-radius: 8px;
+            padding: 8px 18px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            text-decoration: none;
+            display: inline-block;
+        }
+
+        .refresh-btn:hover { background: #4f46e5; }
+
+        .section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 12px;
+        }
+
+        .section-title {
+            font-size: 14px;
+            font-weight: 600;
+            color: #94a3b8;
+        }
+    </style>
+</head>
+<body>
+
+<header>
+    <h1>PICKD <span>Admin</span> — ENUM 검증 대시보드</h1>
+    <div class="meta">
+        점검 시각: <span th:text="${#temporals.format(checkedAt, 'yyyy-MM-dd HH:mm:ss')}">2024-01-01 00:00:00</span>
+    </div>
+</header>
+
+<!-- Summary -->
+<div class="summary">
+    <div class="card">
+        <div class="card-label">전체</div>
+        <div class="card-value total" th:text="${total}">0</div>
+    </div>
+    <div class="card">
+        <div class="card-label">PASS</div>
+        <div class="card-value pass" th:text="${passCount}">0</div>
+    </div>
+    <div class="card">
+        <div class="card-label">FAIL</div>
+        <div class="card-value fail" th:text="${failCount}">0</div>
+    </div>
+</div>
+
+<!-- Table -->
+<div class="section-header">
+    <div class="section-title">테이블별 ENUM 컬럼 검증 결과</div>
+    <a class="refresh-btn" href="/admin/validation">↻ 새로고침</a>
+</div>
+
+<div class="table-wrap">
+    <table>
+        <thead>
+        <tr>
+            <th class="col-status">상태</th>
+            <th class="col-table">테이블</th>
+            <th class="col-column">컬럼</th>
+            <th class="col-enum">Enum 클래스</th>
+            <th class="col-rows">rows</th>
+            <th class="col-db">DB 저장값</th>
+            <th class="col-invalid">비정상 값</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="r : ${results}">
+            <td>
+                <span class="badge"
+                      th:classappend="${r.passed} ? 'badge-pass' : 'badge-fail'"
+                      th:text="${r.statusBadge()}">PASS</span>
+            </td>
+            <td><span class="table-name" th:text="${r.tableName()}">table</span></td>
+            <td><span class="column-name" th:text="${r.columnName()}">col</span></td>
+            <td><span class="enum-name" th:text="${r.enumClass()}">Enum</span></td>
+            <td class="col-rows" th:text="${r.totalRows() >= 0 ? r.totalRows() : '—'}">0</td>
+            <td>
+                <div class="chip-wrap">
+                    <span th:each="v : ${r.dbValues()}"
+                          class="chip"
+                          th:classappend="${r.invalidValues().contains(v)} ? 'chip-bad' : 'chip-db'"
+                          th:text="${v}">VAL</span>
+                    <span class="empty-state" th:if="${#lists.isEmpty(r.dbValues())}">데이터 없음</span>
+                </div>
+            </td>
+            <td>
+                <div class="chip-wrap">
+                    <span th:each="v : ${r.invalidValues()}"
+                          class="chip chip-bad"
+                          th:text="${v}">BAD</span>
+                    <span class="empty-state" th:if="${#lists.isEmpty(r.invalidValues())}">—</span>
+                </div>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
- Base: `main`

## 문제
- OAuth2 로그인 후 쿠키 발급이 불안정하여 프론트 리다이렉트 시 인증 토큰이 누락되는 경우가 있었음
- Swagger에서 Bearer 인증이 동작하지 않아 API 테스트가 불편했음
- Enum 값이 한국어로 저장된 경우 역직렬화 실패로 런타임 오류 발생 가능성 존재
- 채용공고 분석 후 목록/상세 조회 API가 없어 저장된 공고를 클라이언트에서 확인할 수 없었음
- DB에 저장된 Enum 값의 정합성을 운영 중 확인할 수단이 없었음

## 작업 내용

**Auth / Security**
- OAuth2 로그인 후 쿠키 발급 안정화 및 Swagger Bearer 인증 지원
- `/admin/**` 전용 HTTP Basic Auth Security 체인 추가 (`@Order(1)`)

**Enum / 예외 처리**
- Enum 한국어·영문 양방향 역직렬화 지원 (`@JsonCreator` 적용)
- Swagger multipart 파일 업로드 지원 및 BrokenPipe 예외 처리 추가

**API 추가**
- `GET /api/notices` — 로그인 사용자의 공고 목록 조회 (최신순)
- `GET /api/notices/{id}` — 공고 상세 조회 (sections / processes / documents / coverLetterItems 포함)
- `POST /api/notices/analyze/image` — 이미지 기반 채용공고 분석 (Gemini Flash)
- Experience extract step1 Swagger multipart 지원, step2/step3 deprecated 처리
- 수기 Application 입력 시 noticeId 없으면 Notice 자동 생성

**Admin 대시보드**
- `GET /admin/validation` — DB Enum 컬럼 18개 일괄 검증 대시보드 (Thymeleaf + Basic Auth)
- QueryDSL 5.0.0 의존성 추가 (`build.gradle`)

**기타**
- AOP 기반 Service 메서드 실행 로깅 추가
- Todo PATCH(부분수정) / PUT(toggle) 엔드포인트 분리
- 엔티티 컬렉션 인덱스 추가 및 DTO 필드 타입·검증 정비

## 테스트
```bash
./gradlew --stop
./gradlew clean cleanTest test
```
단위 테스트 33개 전체 PASS
(통합 테스트는 `./gradlew integrationTest` 별도 실행)